### PR TITLE
Remove unnecessary New() and typedef of FDK recon filters

### DIFF
--- a/applications/rtkfdk/rtkfdk.cxx
+++ b/applications/rtkfdk/rtkfdk.cxx
@@ -125,19 +125,18 @@ int main(int argc, char * argv[])
 
   // FDK reconstruction filtering
   typedef rtk::FDKConeBeamReconstructionFilter< OutputImageType > FDKCPUType;
-  FDKCPUType::Pointer feldkamp = FDKCPUType::New();
+  FDKCPUType::Pointer feldkamp;
 #ifdef RTK_USE_OPENCL
   typedef rtk::OpenCLFDKConeBeamReconstructionFilter FDKOPENCLType;
-  FDKOPENCLType::Pointer feldkampOCL = FDKOPENCLType::New();
+  FDKOPENCLType::Pointer feldkampOCL;
 #endif
 #ifdef RTK_USE_CUDA
   typedef rtk::CudaFDKConeBeamReconstructionFilter FDKCUDAType;
-  FDKCUDAType::Pointer feldkampCUDA = FDKCUDAType::New();
+  FDKCUDAType::Pointer feldkampCUDA;
 #endif
   itk::Image< OutputPixelType, Dimension > *pfeldkamp = NULL;
   if(!strcmp(args_info.hardware_arg, "cpu") )
     {
-    typedef rtk::FDKConeBeamReconstructionFilter< OutputImageType > FDKCPUType;
     feldkamp = FDKCPUType::New();
     SET_FELDKAMP_OPTIONS( feldkamp );
 
@@ -153,6 +152,7 @@ int main(int argc, char * argv[])
   else if(!strcmp(args_info.hardware_arg, "cuda") )
     {
 #ifdef RTK_USE_CUDA
+    feldkampCUDA = FDKCUDAType::New();
     SET_FELDKAMP_OPTIONS( feldkampCUDA );
     pfeldkamp = feldkampCUDA->GetOutput();
 #else
@@ -163,6 +163,7 @@ int main(int argc, char * argv[])
   else if(!strcmp(args_info.hardware_arg, "opencl") )
     {
 #ifdef RTK_USE_OPENCL
+    feldkampOCL = FDKOPENCLType::New();
     SET_FELDKAMP_OPTIONS( feldkampOCL );
     pfeldkamp = feldkampOCL->GetOutput();
 #else


### PR DESCRIPTION
In the original code all three FDK reconstruction filters are constructed although only one will be used.
If 'cpu' is used, the CPU FDK filter is constructed twice and FDKCPUType are also defined twice.
