### PR TITLE
Reduce memory used by ProjectionsReader

### DIFF
--- a/code/rtkProjectionsReader.txx
+++ b/code/rtkProjectionsReader.txx
@@ -210,6 +210,10 @@ void ProjectionsReader<TOutputImage>
     m_ImageIO = imageIO;
     }
 
+  // Release output data of m_RawDataReader if conversion occurs
+  if ( m_RawDataReader != m_RawToProjectionsFilter )
+    m_RawDataReader->ReleaseDataFlagOn();
+
   // Set output information as provided by the pipe
   m_RawToProjectionsFilter->UpdateOutputInformation();
   TOutputImage * output = this->GetOutput();


### PR DESCRIPTION
After raw data are converted to attenuation, the raw data are not needed
anymore in the mini-pipeline and can be released. This can save memory
especially when --lowmem is not used in reconstruction.

Discussion: this may cause multiple unnecessary deallocation/allocation if
--lowmem is used. Maybe it is better to let SetProjectionsReaderFromGgo
determine whether to set the flag based on whether --lowmem exists?
