### PR TITLE
Fix index type

### DIFF
--- a/code/rtkFFTRampImageFilter.txx
+++ b/code/rtkFFTRampImageFilter.txx
@@ -188,7 +188,7 @@ FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
   paddedImage->FillBuffer(0);
 
   const long next = vnl_math_min(inputRegion.GetIndex(0) - paddedRegion.GetIndex(0),
-                                 (long)this->GetTruncationCorrectionExtent() );
+                                 (FFTInputImageType::IndexValueType)this->GetTruncationCorrectionExtent() );
   if(next)
     {
     typename FFTInputImageType::IndexType idx;


### PR DESCRIPTION
Index could be 64-bit integers if ITK compiled with ITK_USE_64BITS_IDS
flag.
