### PR TITLE
Free GPU mem after cudaPadding

### DIFF
--- a/code/rtkCudaFFTRampImageFilter.cxx
+++ b/code/rtkCudaFFTRampImageFilter.cxx
@@ -72,6 +72,7 @@ rtk::CudaFFTRampImageFilter::PadInputImageRegion(const RegionType &inputRegion)
                pout,
                m_TruncationMirrorWeights );
 
+  this->GetInput()->GetCudaDataManager()->ForceReleaseGPUBuffer();
   return paddedImage.GetPointer();
 }
 

--- a/utilities/ITKCudaCommon/include/itkCudaDataManager.h
+++ b/utilities/ITKCudaCommon/include/itkCudaDataManager.h
@@ -49,6 +49,14 @@ public:
     CUDA_CHECK(cudaMalloc(&m_GPUBuffer, bufferSize));
     }
 
+  void Release()
+    {
+    CUDA_CHECK(cuCtxSetCurrent(*(itk::CudaContextManager::GetInstance()->GetCurrentContext()))); // (peter) added this line
+    CUDA_CHECK(cudaFree(m_GPUBuffer));
+    m_BufferSize = 0;
+    m_GPUBuffer = 0;
+    }
+
   ~GPUMemPointer()
     {
     if(m_GPUBuffer)
@@ -153,6 +161,9 @@ public:
   virtual void UpdateGPUBuffer();
 
   void Allocate();
+
+  /** Release GPU Buffer without copying data to CPU and set CPU clean */
+  void ForceReleaseGPUBuffer();
 
   /** Synchronize CPU and Cuda buffers (using dirty flags) */
   bool Update();

--- a/utilities/ITKCudaCommon/src/itkCudaDataManager.cxx
+++ b/utilities/ITKCudaCommon/src/itkCudaDataManager.cxx
@@ -58,6 +58,19 @@ void CudaDataManager::Allocate()
     }
 }
 
+void CudaDataManager::ForceReleaseGPUBuffer()
+{
+  if (m_GPUBuffer)
+    {
+    #ifdef VERBOSE
+      std::cout << this << "::Release GPU buffer of size " << m_BufferSize << " Bytes" << " : " << m_GPUBuffer->GetPointer() << std::endl;
+    #endif
+    m_GPUBuffer->Release();
+    m_IsGPUBufferDirty = true;
+    m_IsCPUBufferDirty = false;
+    }
+}
+
 void CudaDataManager::SetCPUBufferPointer(void* ptr)
 {
   m_CPUBuffer = ptr;


### PR DESCRIPTION
Projections as input images are not needed in GPU after padding.

To discuss: 
GPU memory is scarce resource so it is recommended to release any unnecessary buffer immediately.
But this implementation needs to modify CudaDataManager. Please see if this scenario is acceptable or if you have better proposal.

Regards, Chao
