### PR TITLE
Added Ram-Lak and SheppLogan window function in Ramp filter.

### DIFF
--- a/code/rtkFFTRampImageFilter.h
+++ b/code/rtkFFTRampImageFilter.h
@@ -130,11 +130,23 @@ public:
   itkGetConstMacro(HannCutFrequencyY, double);
   itkSetMacro(HannCutFrequencyY, double);
   
-  /** Set/Get the Ram-Lak window frequency (0...1). 0 (default) disable it */
+  /** Set/Get the Ram-Lak window frequency (0...1). 0 (default) disable it.
+   * Equation and further explanation about Ram-Lak filter could be found in:
+   * 1. Fundamentals of 2D and 3D reconstruction (by Dr. Günter Lauritsch). 
+   *    http://campar.in.tum.de/twiki/pub/Chair/TeachingWs04IOIV/08CTReconstruction.pdf
+   * 2. Reconstruction. 
+   *    http://oftankonyv.reak.bme.hu/tiki-index.php?page=Reconstruction
+   */
   itkGetConstMacro(RamLakCutFrequency, double);
   itkSetMacro(RamLakCutFrequency, double);
   
-  /** Set/Get the Shepp-Logan window frequency (0...1). 0 (default) disable it */
+  /** Set/Get the Shepp-Logan window frequency (0...1). 0 (default) disable it.
+   * Equation and further explanation about Shepp-Logan filter could be found in:
+   * 1. Fundamentals of 2D and 3D reconstruction (by Dr. Günter Lauritsch). 
+   *    http://campar.in.tum.de/twiki/pub/Chair/TeachingWs04IOIV/08CTReconstruction.pdf
+   * 2. Reconstruction. 
+   *    http://oftankonyv.reak.bme.hu/tiki-index.php?page=Reconstruction
+   */
   itkGetConstMacro(SheppLoganCutFrequency, double);
   itkSetMacro(SheppLoganCutFrequency, double);
   

--- a/code/rtkFFTRampImageFilter.h
+++ b/code/rtkFFTRampImageFilter.h
@@ -129,7 +129,15 @@ public:
   /** Set/Get the Hann window frequency in Y direction. 0 (default) disables it */
   itkGetConstMacro(HannCutFrequencyY, double);
   itkSetMacro(HannCutFrequencyY, double);
-
+  
+  /** Set/Get the Ram-Lak window frequency (0...1). 0 (default) disable it */
+  itkGetConstMacro(RamLakCutFrequency, double);
+  itkSetMacro(RamLakCutFrequency, double);
+  
+  /** Set/Get the Shepp-Logan window frequency (0...1). 0 (default) disable it */
+  itkGetConstMacro(SheppLoganCutFrequency, double);
+  itkSetMacro(SheppLoganCutFrequency, double);
+  
 protected:
   FFTRampImageFilter();
   ~FFTRampImageFilter(){}
@@ -190,6 +198,11 @@ private:
   double m_CosineCutFrequency;
   double m_HammingFrequency;
   double m_HannCutFrequencyY;
+  
+  /** Cut frequency of Ram-Lak and Shepp-Logan 
+    */
+  double m_RamLakCutFrequency;
+  double m_SheppLoganCutFrequency;
 
   int m_BackupNumberOfThreads;
 }; // end of class

--- a/code/rtkFFTRampImageFilter.txx
+++ b/code/rtkFFTRampImageFilter.txx
@@ -35,6 +35,7 @@ FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 ::FFTRampImageFilter() :
   m_TruncationCorrection(0.), m_GreatestPrimeFactor(2), m_HannCutFrequency(0.),
   m_CosineCutFrequency(0.),m_HammingFrequency(0.), m_HannCutFrequencyY(0.),
+  m_RamLakCutFrequency(0.),m_SheppLoganCutFrequency(0.),
   m_BackupNumberOfThreads(1)
 {
 #if defined(USE_FFTWD)
@@ -373,6 +374,22 @@ FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
     const unsigned int ncut = itk::Math::Round<double>(n * vnl_math_min(1.0, this->GetHammingFrequency() ) );
     for(unsigned int i=0; i<ncut; i++, ++itK)
       itK.Set( itK.Get() * TFFTPrecision(0.54+0.46*(vcl_cos(vnl_math::pi*i/ncut))));
+    }
+  else if (this->GetRamLakCutFrequency() > 0.)
+    {
+    const unsigned int ncut = itk::Math::Round<double>(n * vnl_math_min(1.0, this->GetRamLakCutFrequency() ) );
+    for(unsigned int i=0; i<ncut; i++, ++itK) {}
+    }
+  else if (this->GetSheppLoganCutFrequency() > 0.)
+    {
+    const unsigned int ncut = itk::Math::Round<double>(n * vnl_math_min(1.0, this->GetSheppLoganCutFrequency() ) );
+    //sinc(0) --> is 1
+    ++itK;
+    for(unsigned int i=1; i<ncut; i++, ++itK)
+      {
+      double x = 0.5*vnl_math::pi*i / ncut;
+      itK.Set( itK.Get() * TFFTPrecision(vcl_sin(x) / x));
+      }
     }
   else
     {


### PR DESCRIPTION
Dear Simon Rit,
I currently using RTK for reconstruction of industrial CT data. I add Ram-Lak and Shepp-Logan to the Ramp filter. I was considering to separate the ramp filter class and window function class (to easily add new/custom window function in the future), but it will affects the current API, so I end up with this solution. Please consider to merge these changes.

best regards,
P.S. I think I met you during ICCR 2013 in Melbourne.
