### PR TITLE
Allowing several warp_ggo in the same CMakeLists.txt

### DIFF
--- a/cmake/FindGengetopt.cmake
+++ b/cmake/FindGengetopt.cmake
@@ -26,21 +26,25 @@ ENDFOREACH()
 ")
 
 MACRO (WRAP_GGO GGO_SRCS)
+
+  # Set current list of files to zero for a new target
+  SET(GGO_FILES_ABS "")
+
   # Convert list of a file in a list with absolute file names
   FOREACH(GGO_FILE ${ARGN})
     GET_FILENAME_COMPONENT(GGO_FILE_ABS ${GGO_FILE} ABSOLUTE)
-    LIST(APPEND GGO_FILES_ABS ${GGO_FILE_ABS}) 
+    LIST(APPEND GGO_FILES_ABS ${GGO_FILE_ABS})
   ENDFOREACH()
 
   # Append to a new ggo file containing all files
   LIST(GET GGO_FILES_ABS 0 FIRST_GGO_FILE)
   GET_FILENAME_COMPONENT(FIRST_GGO_BASEFILENAME ${FIRST_GGO_FILE} NAME)
   ADD_CUSTOM_COMMAND(
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME}" 
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME}"
       COMMAND ${CMAKE_COMMAND} -D INPUTS="${GGO_FILES_ABS}"
                                -D OUTPUT=${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME}
                                -P ${CMAKE_BINARY_DIR}/cat.cmake
-      DEPENDS ${GGO_FILES_ABS} 
+      DEPENDS ${GGO_FILES_ABS}
   )
   SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME} PROPERTIES GENERATED TRUE)
 
@@ -51,7 +55,7 @@ MACRO (WRAP_GGO GGO_SRCS)
   SET(GGO_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${GGO_H} ${CMAKE_CURRENT_BINARY_DIR}/${GGO_C})
   ADD_CUSTOM_COMMAND(OUTPUT ${GGO_OUTPUT}
                      COMMAND gengetopt
-                     ARGS < ${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME} 
+                     ARGS < ${CMAKE_CURRENT_BINARY_DIR}/${FIRST_GGO_BASEFILENAME}
                             --output-dir=${CMAKE_CURRENT_BINARY_DIR}
                             --arg-struct-name=args_info_${GGO_BASEFILENAME}
                             --func-name=cmdline_parser_${GGO_BASEFILENAME}


### PR DESCRIPTION
Initialize the list of ggo files for a new warp_ggo command. 

It allows to put several warp_ggo in the same CMakeLists.txt. 
