### PR TITLE
BugFix: changed AddProjections to AddProjectionsInRadians in rtkDigisensGeometryReader.cxx

### DIFF
--- a/code/rtkDigisensGeometryReader.cxx
+++ b/code/rtkDigisensGeometryReader.cxx
@@ -111,14 +111,14 @@ rtk::DigisensGeometryReader
     ThreeDTransformType::Pointer xfm3D = ThreeDTransformType::New();
     xfm3D->SetMatrix(xfm3DVersor.GetMatrix());
 
-    m_Geometry->AddProjection( sid,
-                               sdd,
-                               xfm3D->GetAngleY(),
-                               projectionOffsetX,
-                               projectionOffsetY,
-                               xfm3D->GetAngleX(),
-                               xfm3D->GetAngleZ(),
-                               rotationCenter[0],
-                               rotationCenter[1] );
+    m_Geometry->AddProjectionInRadians( sid,
+                                        sdd,
+                                        xfm3D->GetAngleY(),
+                                        projectionOffsetX,
+                                        projectionOffsetY,
+                                        xfm3D->GetAngleX(),
+                                        xfm3D->GetAngleZ(),
+                                        rotationCenter[0],
+                                        rotationCenter[1] );
     }
 }


### PR DESCRIPTION
AddProjection() expects all angles to be in degrees. The [code](https://github.com/SimonRit/RTK/pull/19/files#diff-3fd809ed536af9fbddb42d5b75126856R114) in rtkDigisensGeometryReader.cxx erroneously supplied angles in radians to this function.

@SimonRit If you think this fix is ok, i can modify the test file on MIDAS as well to make the test pass.
