### PR TITLE
Made CudaCyclicDeformationImageFilter optional

### DIFF
--- a/applications/rtkfourdrooster/rtkfourdrooster.cxx
+++ b/applications/rtkfourdrooster/rtkfourdrooster.cxx
@@ -126,6 +126,7 @@ int main(int argc, char * argv[])
   rooster->SetMainLoop_iterations( args_info.niter_arg );
   rooster->SetPhaseShift(args_info.shift_arg);
   rooster->SetCudaConjugateGradient(args_info.cudacg_flag);
+  rooster->SetUseCudaCyclicDeformation(args_info.cudadvfinterpolation_flag);
   
   // Set the newly ordered arguments
   rooster->SetInputProjectionStack( reorder->GetOutput() );

--- a/applications/rtkfourdrooster/rtkfourdrooster.ggo
+++ b/applications/rtkfourdrooster/rtkfourdrooster.ggo
@@ -10,6 +10,7 @@ option "niter"       n "Number of main loop iterations"                        i
 option "cgiter"      - "Number of conjugate gradient nested iterations"        int    no   default="4"
 option "cudacg"      - "Perform conjugate gradient calculations on GPU"        flag   off
 option "time"        t "Records elapsed time during the process"               flag   off
+option "cudadvfinterpolation"   - "Perform DVF interpolation calculations on GPU"        flag   off
 
 section "Projectors"
 option "fp"    f "Forward projection method" values="Joseph","RayCastInterpolator","CudaRayCast" enum no default="Joseph"

--- a/applications/rtkmcrooster/rtkmcrooster.cxx
+++ b/applications/rtkmcrooster/rtkmcrooster.cxx
@@ -126,6 +126,7 @@ int main(int argc, char * argv[])
   mcrooster->SetCG_iterations( args_info.cgiter_arg );
   mcrooster->SetMainLoop_iterations( args_info.niter_arg );
   mcrooster->SetCudaConjugateGradient(args_info.cudacg_flag);
+  mcrooster->SetUseCudaCyclicDeformation(args_info.cudadvfinterpolation_flag);
 
   // Set the newly ordered arguments
   mcrooster->SetInputProjectionStack( reorder->GetOutput() );

--- a/applications/rtkmcrooster/rtkmcrooster.ggo
+++ b/applications/rtkmcrooster/rtkmcrooster.ggo
@@ -10,6 +10,7 @@ option "niter"       n "Number of main loop iterations"                        i
 option "cgiter"      - "Number of conjugate gradient nested iterations"        int    no   default="4"
 option "cudacg"      - "Perform conjugate gradient calculations on GPU"        flag   off
 option "time"        t "Records elapsed time during the process"               flag   off
+option "cudadvfinterpolation"   - "Perform DVF interpolation calculations on GPU"        flag   off
 
 section "Projectors"
 option "fp"    f "Forward projection method" values="Joseph","RayCastInterpolator","CudaRayCast" enum no default="Joseph"

--- a/code/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/code/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -279,7 +279,11 @@ public:
   itkGetMacro(UseNearestNeighborInterpolationInWarping, bool)
   itkGetMacro(CudaConjugateGradient, bool)
   itkSetMacro(CudaConjugateGradient, bool)
- 
+
+  /** Set and Get for the UseCudaCyclicDeformation variable */
+  itkSetMacro(UseCudaCyclicDeformation, bool)
+  itkGetMacro(UseCudaCyclicDeformation, bool)
+
   // Regularization parameters
   itkSetMacro(GammaTVSpace, float)
   itkGetMacro(GammaTVSpace, float)
@@ -361,6 +365,7 @@ protected:
   bool  m_ComputeInverseWarpingByConjugateGradient;
   bool  m_UseNearestNeighborInterpolationInWarping; //Default is false, linear interpolation is used instead
   bool  m_CudaConjugateGradient;
+  bool  m_UseCudaCyclicDeformation;
 
   // Regularization parameters
   float m_GammaTVSpace;

--- a/code/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/code/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -364,6 +364,7 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
     m_Warp->SetDisplacementField(this->GetDisplacementField());
     m_Warp->SetPhaseShift(m_PhaseShift);
     m_Warp->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
+    m_Warp->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
   
     currentDownstreamFilter = m_Warp;
     }
@@ -420,6 +421,7 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
       m_Unwarp->SetPhaseShift(m_PhaseShift);
       m_Unwarp->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
       m_Unwarp->SetCudaConjugateGradient(this->GetCudaConjugateGradient());
+      m_Unwarp->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 
       currentDownstreamFilter = m_Unwarp;
       }
@@ -436,6 +438,7 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
       m_InverseWarp->SetDisplacementField(this->GetInverseDisplacementField());
       m_InverseWarp->SetPhaseShift(m_PhaseShift);
       m_InverseWarp->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
+      m_InverseWarp->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 
       // Add the deformed correction to the spatially denoised image to get the output
       m_AddFilter->SetInput1(m_InverseWarp->GetOutput());

--- a/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -116,12 +116,18 @@ public:
   typedef rtk::WarpProjectionStackToFourDImageFilter< VolumeSeriesType, ProjectionStackType>                        MCProjStackToFourDType;
   typedef rtk::MotionCompensatedFourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType> MCCGOperatorType;
 
+  /** Set and Get for the UseCudaCyclicDeformation variable */
+  itkSetMacro(UseCudaCyclicDeformation, bool)
+  itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
   MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter();
   ~MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter(){}
 
   virtual void GenerateOutputInformation();
   virtual void GenerateInputRequestedRegion();
+
+  bool                                                m_UseCudaCyclicDeformation;
 
 private:
   //purposely not implemented

--- a/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.hxx
@@ -86,7 +86,9 @@ MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter< VolumeSerie
 #ifdef RTK_USE_CUDA
   dynamic_cast<MCCGOperatorType*>(this->m_CGOperator.GetPointer())->SetDisplacementField(this->GetDisplacementField());
   dynamic_cast<MCCGOperatorType*>(this->m_CGOperator.GetPointer())->SetInverseDisplacementField(this->GetInverseDisplacementField());
+  dynamic_cast<MCCGOperatorType*>(this->m_CGOperator.GetPointer())->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
   dynamic_cast<MCProjStackToFourDType*>(this->m_ProjStackToFourDFilter.GetPointer())->SetDisplacementField(this->GetDisplacementField());
+  dynamic_cast<MCProjStackToFourDType*>(this->m_ProjStackToFourDFilter.GetPointer())->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 #endif
 
   Superclass::GenerateOutputInformation();

--- a/code/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/code/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -69,6 +69,7 @@ MotionCompensatedFourDROOSTERConeBeamReconstructionFilter< VolumeSeriesType, Pro
   // Set the 4D conjugate gradient filter
   dynamic_cast<MotionCompensatedFourDCGFilterType*>(this->m_FourDCGFilter.GetPointer())->SetDisplacementField(this->GetDisplacementField());
   dynamic_cast<MotionCompensatedFourDCGFilterType*>(this->m_FourDCGFilter.GetPointer())->SetInverseDisplacementField(this->GetInverseDisplacementField());
+  dynamic_cast<MotionCompensatedFourDCGFilterType*>(this->m_FourDCGFilter.GetPointer())->SetUseCudaCyclicDeformation(this->m_UseCudaCyclicDeformation);
 
   // Call the superclass implementation
   Superclass::GenerateOutputInformation();

--- a/code/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/code/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -133,6 +133,10 @@ public:
     /** Set the vector containing the signal in the sub-filters */
     virtual void SetSignal(const std::vector<double> signal);
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
     MotionCompensatedFourDReconstructionConjugateGradientOperator();
     ~MotionCompensatedFourDReconstructionConjugateGradientOperator(){}
@@ -150,6 +154,7 @@ protected:
     typename DVFInterpolatorType::Pointer               m_DVFInterpolatorFilter;
     typename DVFInterpolatorType::Pointer               m_InverseDVFInterpolatorFilter;
     std::vector<double>                                 m_Signal;
+    bool                                                m_UseCudaCyclicDeformation;
 
 private:
     MotionCompensatedFourDReconstructionConjugateGradientOperator(const Self &); //purposely not implemented

--- a/code/rtkUnwarpSequenceConjugateGradientOperator.h
+++ b/code/rtkUnwarpSequenceConjugateGradientOperator.h
@@ -92,6 +92,10 @@ public:
     itkSetMacro(UseNearestNeighborInterpolationInWarping, bool)
     itkGetMacro(UseNearestNeighborInterpolationInWarping, bool)
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
     UnwarpSequenceConjugateGradientOperator();
     ~UnwarpSequenceConjugateGradientOperator(){}
@@ -115,6 +119,8 @@ protected:
     */
     void GenerateInputRequestedRegion();
     void GenerateOutputInformation();
+
+    bool m_UseCudaCyclicDeformation;
 
 private:
     UnwarpSequenceConjugateGradientOperator(const Self &); //purposely not implemented

--- a/code/rtkUnwarpSequenceConjugateGradientOperator.hxx
+++ b/code/rtkUnwarpSequenceConjugateGradientOperator.hxx
@@ -33,6 +33,7 @@ UnwarpSequenceConjugateGradientOperator< TImageSequence, TDVFImageSequence, TIma
   // Default member variables
   m_PhaseShift = 0;
   m_UseNearestNeighborInterpolationInWarping = false;
+  m_UseCudaCyclicDeformation = false;
 
   // Create filters
   m_WarpSequenceBackwardFilter = WarpSequenceFilterType::New();
@@ -96,8 +97,10 @@ UnwarpSequenceConjugateGradientOperator< TImageSequence, TDVFImageSequence, TIma
   // Set runtime parameters
   m_WarpSequenceBackwardFilter->SetPhaseShift(this->m_PhaseShift);
   m_WarpSequenceBackwardFilter->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
+  m_WarpSequenceBackwardFilter->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
   m_WarpSequenceForwardFilter->SetPhaseShift(this->m_PhaseShift);
   m_WarpSequenceForwardFilter->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
+  m_WarpSequenceForwardFilter->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 
   // Have the last filter calculate its output information
   m_WarpSequenceForwardFilter->UpdateOutputInformation();

--- a/code/rtkUnwarpSequenceImageFilter.h
+++ b/code/rtkUnwarpSequenceImageFilter.h
@@ -19,13 +19,10 @@
 #ifndef __rtkUnwarpSequenceImageFilter_h
 #define __rtkUnwarpSequenceImageFilter_h
 
-// #include <itkMultiplyImageFilter.h>
-
 #include "rtkConjugateGradientImageFilter.h"
 #include "rtkUnwarpSequenceConjugateGradientOperator.h"
 #include "rtkWarpSequenceImageFilter.h"
 #include "rtkConstantImageSource.h"
-// #include "rtkCyclicDeformationImageFilter.h"
 
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaConjugateGradientImageFilter_4f.h"
@@ -126,6 +123,10 @@ public:
     itkSetMacro(CudaConjugateGradient, bool)
     itkGetMacro(CudaConjugateGradient, bool)
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
     UnwarpSequenceImageFilter();
     ~UnwarpSequenceImageFilter(){}
@@ -137,7 +138,6 @@ protected:
     typename ConjugateGradientFilterType::Pointer                   m_ConjugateGradientFilter;
     typename CGOperatorFilterType::Pointer                          m_CGOperator;
     typename WarpForwardFilterType::Pointer                         m_WarpForwardFilter;
-//     typename DVFInterpolatorType::Pointer                           m_DVFInterpolator;
     typename ConstantSourceType::Pointer                            m_ConstantSource;
 
     /** Member variables */
@@ -155,6 +155,7 @@ protected:
 
     bool m_UseNearestNeighborInterpolationInWarping; //Default is false, linear interpolation is used instead
     bool m_CudaConjugateGradient;
+    bool m_UseCudaCyclicDeformation;
 
 private:
     UnwarpSequenceImageFilter(const Self &); //purposely not implemented

--- a/code/rtkUnwarpSequenceImageFilter.hxx
+++ b/code/rtkUnwarpSequenceImageFilter.hxx
@@ -35,6 +35,7 @@ UnwarpSequenceImageFilter< TImageSequence, TDVFImageSequence, TImage, TDVFImage>
   m_PhaseShift = 0;
   m_UseNearestNeighborInterpolationInWarping = false;
   m_CudaConjugateGradient = false;
+  m_UseCudaCyclicDeformation = false;
 
   // Create the filters
   m_ConjugateGradientFilter = ConjugateGradientFilterType::New();
@@ -84,8 +85,6 @@ void
 UnwarpSequenceImageFilter< TImageSequence, TDVFImageSequence, TImage, TDVFImage>
 ::GenerateInputRequestedRegion()
 {
-//   std::cout << "Running UnwarpSequenceImageFilter::GenerateInputRequestedRegion" << std::endl;
-  
   //Call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();
 
@@ -110,11 +109,13 @@ UnwarpSequenceImageFilter< TImageSequence, TDVFImageSequence, TImage, TDVFImage>
   m_WarpForwardFilter->SetInput(this->GetInput(0));
   m_WarpForwardFilter->SetDisplacementField(this->GetDisplacementField());
   m_WarpForwardFilter->SetUseNearestNeighborInterpolationInWarping(m_UseNearestNeighborInterpolationInWarping);
+  m_WarpForwardFilter->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 
   // Set runtime parameters
   m_ConjugateGradientFilter->SetNumberOfIterations(this->m_NumberOfIterations);
   m_WarpForwardFilter->SetPhaseShift(this->m_PhaseShift);
   m_CGOperator->SetPhaseShift(this->m_PhaseShift);
+  m_CGOperator->SetUseCudaCyclicDeformation(m_UseCudaCyclicDeformation);
 
   // Have the last filter calculate its output information
   m_ConjugateGradientFilter->UpdateOutputInformation();

--- a/code/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/code/rtkWarpFourDToProjectionStackImageFilter.h
@@ -122,6 +122,10 @@ public:
 
     virtual void SetSignal(const std::vector<double> signal);
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
     WarpFourDToProjectionStackImageFilter();
     ~WarpFourDToProjectionStackImageFilter(){}
@@ -140,6 +144,7 @@ protected:
     /** Member pointers to the filters used internally (for convenience)*/
     typename DVFInterpolatorType::Pointer               m_DVFInterpolatorFilter;
     std::vector<double>                                 m_Signal;
+    bool                                                m_UseCudaCyclicDeformation;
 
 private:
     WarpFourDToProjectionStackImageFilter(const Self &); //purposely not implemented

--- a/code/rtkWarpFourDToProjectionStackImageFilter.hxx
+++ b/code/rtkWarpFourDToProjectionStackImageFilter.hxx
@@ -29,10 +29,8 @@ WarpFourDToProjectionStackImageFilter< VolumeSeriesType, ProjectionStackType>::W
   this->SetNumberOfRequiredInputs(3);
 
 #ifdef RTK_USE_CUDA
-  m_DVFInterpolatorFilter = rtk::CudaCyclicDeformationImageFilter::New();
   this->m_ForwardProjectionFilter = rtk::CudaWarpForwardProjectionImageFilter::New();
 #else
-  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
   this->m_ForwardProjectionFilter = rtk::JosephForwardProjectionImageFilter<ProjectionStackType, ProjectionStackType>::New();
   itkWarningMacro("The warp Forward project image filter exists only in CUDA. Ignoring the displacement vector field and using CPU Joseph forward projection")
 #endif
@@ -67,6 +65,11 @@ void
 WarpFourDToProjectionStackImageFilter< VolumeSeriesType, ProjectionStackType>
 ::GenerateOutputInformation()
 {
+  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
+#ifdef RTK_USE_CUDA
+  if (m_UseCudaCyclicDeformation)
+    m_DVFInterpolatorFilter = rtk::CudaCyclicDeformationImageFilter::New();
+#endif
   m_DVFInterpolatorFilter->SetSignalVector(m_Signal);
   m_DVFInterpolatorFilter->SetInput(this->GetDisplacementField());
   m_DVFInterpolatorFilter->SetFrame(0);

--- a/code/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/code/rtkWarpProjectionStackToFourDImageFilter.h
@@ -120,6 +120,10 @@ public:
 
     virtual void SetSignal(const std::vector<double> signal);
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
 protected:
     WarpProjectionStackToFourDImageFilter();
     ~WarpProjectionStackToFourDImageFilter(){}
@@ -136,6 +140,7 @@ protected:
     /** Member pointers to the filters used internally (for convenience)*/
     typename DVFInterpolatorType::Pointer           m_DVFInterpolatorFilter;
     std::vector<double>                             m_Signal;
+    bool                                            m_UseCudaCyclicDeformation;
 
 private:
     WarpProjectionStackToFourDImageFilter(const Self &); //purposely not implemented

--- a/code/rtkWarpProjectionStackToFourDImageFilter.hxx
+++ b/code/rtkWarpProjectionStackToFourDImageFilter.hxx
@@ -34,12 +34,11 @@ WarpProjectionStackToFourDImageFilter< VolumeSeriesType, ProjectionStackType>::W
 
   this->m_UseCudaSplat = true;
   this->m_UseCudaSources = true;
+  m_UseCudaCyclicDeformation = false;
 
 #ifdef RTK_USE_CUDA
-  m_DVFInterpolatorFilter = rtk::CudaCyclicDeformationImageFilter::New();
   this->m_BackProjectionFilter = rtk::CudaWarpBackProjectionImageFilter::New();
 #else
-  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
   this->m_BackProjectionFilter = rtk::BackProjectionImageFilter<VolumeType, VolumeType>::New();
   itkWarningMacro("The warp back project image filter exists only in CUDA. Ignoring the displacement vector field and using CPU voxel-based back projection")
 #endif
@@ -74,6 +73,11 @@ void
 WarpProjectionStackToFourDImageFilter< VolumeSeriesType, ProjectionStackType>
 ::GenerateOutputInformation()
 {
+  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
+#ifdef RTK_USE_CUDA
+  if (m_UseCudaCyclicDeformation)
+    m_DVFInterpolatorFilter = rtk::CudaCyclicDeformationImageFilter::New();
+#endif
   m_DVFInterpolatorFilter->SetSignalVector(m_Signal);
   m_DVFInterpolatorFilter->SetInput(this->GetDisplacementField());
   m_DVFInterpolatorFilter->SetFrame(0);

--- a/code/rtkWarpSequenceImageFilter.h
+++ b/code/rtkWarpSequenceImageFilter.h
@@ -20,7 +20,6 @@
 #define __rtkWarpSequenceImageFilter_h
 
 #include "rtkConstantImageSource.h"
-#include "rtkCyclicDeformationImageFilter.h"
 
 #include <itkExtractImageFilter.h>
 #include <itkPasteImageFilter.h>
@@ -30,9 +29,11 @@
 #ifdef RTK_USE_CUDA
   #include "rtkCudaWarpImageFilter.h"
   #include "rtkCudaForwardWarpImageFilter.h"
+  #include "rtkCudaCyclicDeformationImageFilter.h"
 #else
   #include <itkWarpImageFilter.h>
   #include "rtkForwardWarpImageFilter.h"
+  #include "rtkCyclicDeformationImageFilter.h"
 #endif
 
 namespace rtk
@@ -125,6 +126,10 @@ public:
     itkSetMacro(UseNearestNeighborInterpolationInWarping, bool)
     itkGetMacro(UseNearestNeighborInterpolationInWarping, bool)
 
+    /** Set and Get for the UseCudaCyclicDeformation variable */
+    itkSetMacro(UseCudaCyclicDeformation, bool)
+    itkGetMacro(UseCudaCyclicDeformation, bool)
+
     /** Typedefs of internal filters */
 #ifdef RTK_USE_CUDA
     typedef rtk::CudaWarpImageFilter                                          CudaWarpFilterType;
@@ -174,6 +179,7 @@ protected:
     void GenerateInputRequestedRegion();
 
     bool m_UseNearestNeighborInterpolationInWarping; //Default is false, linear interpolation is used instead
+    bool m_UseCudaCyclicDeformation;
 
 private:
     WarpSequenceImageFilter(const Self &); //purposely not implemented

--- a/code/rtkWarpSequenceImageFilter.hxx
+++ b/code/rtkWarpSequenceImageFilter.hxx
@@ -38,10 +38,10 @@ WarpSequenceImageFilter< TImageSequence, TDVFImageSequence, TImage, TDVFImage>
   // Set default member values
   m_ForwardWarp = false;
   m_UseNearestNeighborInterpolationInWarping = false;
+  m_UseCudaCyclicDeformation = false;
 
   // Create the filters
   m_ExtractFilter = ExtractFilterType::New();
-  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
   m_PasteFilter = PasteFilterType::New();
   m_CastFilter = CastFilterType::New();
   m_ConstantSource = ConstantImageSourceType::New();
@@ -81,12 +81,15 @@ WarpSequenceImageFilter< TImageSequence, TDVFImageSequence, TImage, TDVFImage>
 {
   int Dimension = TImageSequence::ImageDimension;
 
+  m_DVFInterpolatorFilter = DVFInterpolatorType::New();
 #ifdef RTK_USE_CUDA
   // Create the right warp filter (regular or forward)
   if (m_ForwardWarp)
     m_WarpFilter = CudaForwardWarpFilterType::New();
   else
     m_WarpFilter = CudaWarpFilterType::New();
+  if (m_UseCudaCyclicDeformation)
+    m_DVFInterpolatorFilter = rtk::CudaCyclicDeformationImageFilter::New();
 #else
   if (m_ForwardWarp)
     m_WarpFilter = ForwardWarpFilterType::New();


### PR DESCRIPTION
in 4D ROOSTER and MC ROOSTER.
Default is the CPU version.
Did this because handling DVFs on the GPU typically requires too much GPU memory, except on the highest-end GPUs. 
