### PR TITLE
BUG: Requested BoundaryCondition was not respected

### DIFF
--- a/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
+++ b/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
@@ -156,8 +156,6 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
   typename TOutputImage::Pointer output = this->GetOutput();
   typename TInputImage::ConstPointer input = this->GetInput();
 
-  itk::ConstantBoundaryCondition<InputImageType> cbc;
-
   itk::ImageRegionIterator<TOutputImage> oit(output, outputRegionForThread);
   oit.GoToBegin();
 
@@ -166,7 +164,7 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
 
   itk::ConstNeighborhoodIterator<TInputImage> iit(radius, input, outputRegionForThread);
   iit.GoToBegin();
-  iit.OverrideBoundaryCondition(&cbc);
+  iit.OverrideBoundaryCondition(m_BoundaryCondition);
 
   itk::SizeValueType c = (itk::SizeValueType) (iit.Size() / 2); // get offset of center pixel
   itk::SizeValueType strides[TOutputImage::ImageDimension]; // get offsets to access neighboring pixels


### PR DESCRIPTION
When choosing an alternate boundary condition (i.e.
PeriodicBoundary), it was not being used.

This patch resolves #43.
