### PR TITLE
PERF: Prefer multiplication to division

### DIFF
--- a/code/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/code/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -105,7 +105,7 @@ private:
     void operator=(const Self&); //purposely not implemented
 
     bool                              m_UseImageSpacing;
-    typename TInputImage::SpacingType m_SpacingCoeffs;
+    typename TInputImage::SpacingType m_InvSpacingCoeffs;
 
     // list of the dimensions along which the divergence has
     // to be computed. The components on other dimensions

--- a/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
+++ b/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
@@ -137,8 +137,18 @@ void
 BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
 ::BeforeThreadedGenerateData()
 {
-  m_SpacingCoeffs= this->GetInput()->GetSpacing();
-  if (m_UseImageSpacing == false) m_SpacingCoeffs.Fill(1);
+  if (m_UseImageSpacing == false)
+    {
+    m_InvSpacingCoeffs.Fill(1.0);
+    }
+  else
+    {
+    m_InvSpacingCoeffs= this->GetInput()->GetSpacing();
+    for (int dim = 0; dim < TInputImage::ImageDimension; dim++)
+      {
+      m_InvSpacingCoeffs[dim] = 1.0/m_InvSpacingCoeffs[dim];
+      }
+    }
 }
 
 template <class TInputImage, class TOutputImage>
@@ -148,6 +158,7 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
 {
   // Generate a list of indices of the dimensions to process
   std::vector<int> dimsToProcess;
+  dimsToProcess.reserve(TInputImage::ImageDimension);
   for (int dim = 0; dim < TInputImage::ImageDimension; dim++)
     {
     if(m_DimensionsProcessed[dim]) dimsToProcess.push_back(dim);
@@ -166,7 +177,7 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
   iit.GoToBegin();
   iit.OverrideBoundaryCondition(m_BoundaryCondition);
 
-  itk::SizeValueType c = (itk::SizeValueType) (iit.Size() / 2); // get offset of center pixel
+  const itk::SizeValueType c = (itk::SizeValueType) (iit.Size() / 2); // get offset of center pixel
   itk::SizeValueType strides[TOutputImage::ImageDimension]; // get offsets to access neighboring pixels
   for (int dim=0; dim<TOutputImage::ImageDimension; dim++)
     {
@@ -180,7 +191,7 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
     // Compute the local differences around the central pixel
     for (unsigned int k = 0; k < dimsToProcess.size(); k++)
       {
-      div += (iit.GetPixel(c)[k] - iit.GetPixel(c - strides[dimsToProcess[k]])[k]) / m_SpacingCoeffs[dimsToProcess[k]];
+      div += (iit.GetPixel(c)[k] - iit.GetPixel(c - strides[dimsToProcess[k]])[k]) * m_InvSpacingCoeffs[dimsToProcess[k]];
       }
     oit.Set(div);
     ++oit;
@@ -224,7 +235,7 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
       itk::ImageRegionIterator<TOutputImage> oit(this->GetOutput(), slice);
       itk::ImageRegionConstIterator<TInputImage> iit(this->GetInput(), slice);
 
-      oit.Set(oit.Get() - iit.Get()[k] / m_SpacingCoeffs[dimsToProcess[k]]);
+      oit.Set(oit.Get() - iit.Get()[k] * m_InvSpacingCoeffs[dimsToProcess[k]]);
       ++oit;
       ++iit;
       }


### PR DESCRIPTION
Multiplication is a faster operation than division, so
prefer to store 1/spacing values to be used repeatedly.
