### PR TITLE
BUG: Pixel accumulator type should match image pixel type

### DIFF
--- a/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
+++ b/code/rtkBackwardDifferenceDivergenceImageFilter.hxx
@@ -173,10 +173,9 @@ BackwardDifferenceDivergenceImageFilter< TInputImage, TOutputImage>
     strides[dim] = iit.GetStride(dim);
     }
 
-  float div;
   while(!oit.IsAtEnd())
     {
-    div = 0;
+    typename TOutputImage::PixelType div = 0.0F;
     // Compute the local differences around the central pixel
     for (unsigned int k = 0; k < dimsToProcess.size(); k++)
       {


### PR DESCRIPTION
Prefer initialization to assignment, and make types match
to avoid typecasting.
