### PR TITLE
COMP: Conform header include guard names to ITK style

### DIFF
--- a/cmake/KWStyle/RTK.kws.xml.in
+++ b/cmake/KWStyle/RTK.kws.xml.in
@@ -11,7 +11,7 @@
 <Comments>/**, *, */,true</Comments>
 <Namespace>rtk</Namespace>
 <NameOfClass>[NameOfClass],itk</NameOfClass>
-<IfNDefDefine>__[NameOfClass]_[Extension]</IfNDefDefine>
+<IfNDefDefine>[NameOfClass]_[Extension]</IfNDefDefine>
 <EmptyLines>2</EmptyLines>
 <Template>[TNV]</Template>
 <Operator>1,1</Operator>

--- a/code/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/code/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkADMMTotalVariationConeBeamReconstructionFilter_h
-#define __rtkADMMTotalVariationConeBeamReconstructionFilter_h
+#ifndef rtkADMMTotalVariationConeBeamReconstructionFilter_h
+#define rtkADMMTotalVariationConeBeamReconstructionFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/code/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkADMMTotalVariationConjugateGradientOperator_h
-#define __rtkADMMTotalVariationConjugateGradientOperator_h
+#ifndef rtkADMMTotalVariationConjugateGradientOperator_h
+#define rtkADMMTotalVariationConjugateGradientOperator_h
 
 #include <itkMultiplyImageFilter.h>
 #include <itkSubtractImageFilter.h>

--- a/code/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/code/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkADMMWaveletsConeBeamReconstructionFilter_h
-#define __rtkADMMWaveletsConeBeamReconstructionFilter_h
+#ifndef rtkADMMWaveletsConeBeamReconstructionFilter_h
+#define rtkADMMWaveletsConeBeamReconstructionFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkADMMWaveletsConjugateGradientOperator.h
+++ b/code/rtkADMMWaveletsConjugateGradientOperator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkADMMWaveletsConjugateGradientOperator_h
-#define __rtkADMMWaveletsConjugateGradientOperator_h
+#ifndef rtkADMMWaveletsConjugateGradientOperator_h
+#define rtkADMMWaveletsConjugateGradientOperator_h
 
 #include <itkMultiplyImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkAdditiveGaussianNoiseImageFilter.h
+++ b/code/rtkAdditiveGaussianNoiseImageFilter.h
@@ -31,8 +31,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __rtkAdditiveGaussianNoiseImageFilter_h
-#define __rtkAdditiveGaussianNoiseImageFilter_h
+#ifndef rtkAdditiveGaussianNoiseImageFilter_h
+#define rtkAdditiveGaussianNoiseImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkNormalVariateGenerator.h>
@@ -302,4 +302,4 @@ private:
 #include "rtkAdditiveGaussianNoiseImageFilter.hxx"
 #endif
 
-#endif /* __rtkAdditiveGaussianNoiseImageFilter_h */
+#endif /* rtkAdditiveGaussianNoiseImageFilter_h */

--- a/code/rtkAmsterdamShroudImageFilter.h
+++ b/code/rtkAmsterdamShroudImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkAmsterdamShroudImageFilter_h
-#define __rtkAmsterdamShroudImageFilter_h
+#ifndef rtkAmsterdamShroudImageFilter_h
+#define rtkAmsterdamShroudImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkRecursiveGaussianImageFilter.h>

--- a/code/rtkAverageOutOfROIImageFilter.h
+++ b/code/rtkAverageOutOfROIImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkAverageOutOfROIImageFilter_h
-#define __rtkAverageOutOfROIImageFilter_h
+#ifndef rtkAverageOutOfROIImageFilter_h
+#define rtkAverageOutOfROIImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
 

--- a/code/rtkBackProjectionImageFilter.h
+++ b/code/rtkBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkBackProjectionImageFilter_h
-#define __rtkBackProjectionImageFilter_h
+#ifndef rtkBackProjectionImageFilter_h
+#define rtkBackProjectionImageFilter_h
 
 #include "rtkConfiguration.h"
 

--- a/code/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/code/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkBackwardDifferenceDivergenceImageFilter_h
-#define __rtkBackwardDifferenceDivergenceImageFilter_h
+#ifndef rtkBackwardDifferenceDivergenceImageFilter_h
+#define rtkBackwardDifferenceDivergenceImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkCastImageFilter.h>

--- a/code/rtkBoellaardScatterCorrectionImageFilter.h
+++ b/code/rtkBoellaardScatterCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkBoellaardScatterCorrectionImageFilter_h
-#define __rtkBoellaardScatterCorrectionImageFilter_h
+#ifndef rtkBoellaardScatterCorrectionImageFilter_h
+#define rtkBoellaardScatterCorrectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkConfiguration.h"

--- a/code/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/code/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConjugateGradientConeBeamReconstructionFilter_h
-#define __rtkConjugateGradientConeBeamReconstructionFilter_h
+#ifndef rtkConjugateGradientConeBeamReconstructionFilter_h
+#define rtkConjugateGradientConeBeamReconstructionFilter_h
 
 #include <itkMultiplyImageFilter.h>
 #include <itkTimeProbe.h>

--- a/code/rtkConjugateGradientGetP_kPlusOneImageFilter.h
+++ b/code/rtkConjugateGradientGetP_kPlusOneImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConjugateGradientGetP_kPlusOneImageFilter_h
-#define __rtkConjugateGradientGetP_kPlusOneImageFilter_h
+#ifndef rtkConjugateGradientGetP_kPlusOneImageFilter_h
+#define rtkConjugateGradientGetP_kPlusOneImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkConjugateGradientGetR_kPlusOneImageFilter.h
+++ b/code/rtkConjugateGradientGetR_kPlusOneImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConjugateGradientGetR_kPlusOneImageFilter_h
-#define __rtkConjugateGradientGetR_kPlusOneImageFilter_h
+#ifndef rtkConjugateGradientGetR_kPlusOneImageFilter_h
+#define rtkConjugateGradientGetR_kPlusOneImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkBarrier.h>

--- a/code/rtkConjugateGradientGetX_kPlusOneImageFilter.h
+++ b/code/rtkConjugateGradientGetX_kPlusOneImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConjugateGradientGetX_kPlusOneImageFilter_h
-#define __rtkConjugateGradientGetX_kPlusOneImageFilter_h
+#ifndef rtkConjugateGradientGetX_kPlusOneImageFilter_h
+#define rtkConjugateGradientGetX_kPlusOneImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkConjugateGradientImageFilter.h
+++ b/code/rtkConjugateGradientImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConjugateGradientImageFilter_h
-#define __rtkConjugateGradientImageFilter_h
+#ifndef rtkConjugateGradientImageFilter_h
+#define rtkConjugateGradientImageFilter_h
 
 #include "itkImageToImageFilter.h"
 #include "itkSubtractImageFilter.h"

--- a/code/rtkConjugateGradientOperator.h
+++ b/code/rtkConjugateGradientOperator.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkConjugateGradientOperator_h
-#define __rtkConjugateGradientOperator_h
+#ifndef rtkConjugateGradientOperator_h
+#define rtkConjugateGradientOperator_h
 
 #include "itkImageToImageFilter.h"
 

--- a/code/rtkConstantImageSource.h
+++ b/code/rtkConstantImageSource.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConstantImageSource_h
-#define __rtkConstantImageSource_h
+#ifndef rtkConstantImageSource_h
+#define rtkConstantImageSource_h
 
 #include "rtkConfiguration.h"
 #include "rtkMacro.h"

--- a/code/rtkConvertEllipsoidToQuadricParametersFunction.h
+++ b/code/rtkConvertEllipsoidToQuadricParametersFunction.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkConvertEllipsoidToQuadricParametersFunction_h
-#define __rtkConvertEllipsoidToQuadricParametersFunction_h
+#ifndef rtkConvertEllipsoidToQuadricParametersFunction_h
+#define rtkConvertEllipsoidToQuadricParametersFunction_h
 
 #include <itkNumericTraits.h>
 #include <itkVector.h>

--- a/code/rtkCudaAverageOutOfROIImageFilter.h
+++ b/code/rtkCudaAverageOutOfROIImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaAverageOutOfROIImageFilter_h
-#define __rtkCudaAverageOutOfROIImageFilter_h
+#ifndef rtkCudaAverageOutOfROIImageFilter_h
+#define rtkCudaAverageOutOfROIImageFilter_h
 
 #include "rtkAverageOutOfROIImageFilter.h"
 #include "itkCudaImage.h"

--- a/code/rtkCudaBackProjectionImageFilter.h
+++ b/code/rtkCudaBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaBackProjectionImageFilter_h
-#define __rtkCudaBackProjectionImageFilter_h
+#ifndef rtkCudaBackProjectionImageFilter_h
+#define rtkCudaBackProjectionImageFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkWin32Header.h"

--- a/code/rtkCudaConjugateGradientImageFilter_3f.h
+++ b/code/rtkCudaConjugateGradientImageFilter_3f.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaConjugateGradientImageFilter_3f_h
-#define __rtkCudaConjugateGradientImageFilter_3f_h
+#ifndef rtkCudaConjugateGradientImageFilter_3f_h
+#define rtkCudaConjugateGradientImageFilter_3f_h
 
 #include "rtkConjugateGradientImageFilter.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaConjugateGradientImageFilter_4f.h
+++ b/code/rtkCudaConjugateGradientImageFilter_4f.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaConjugateGradientImageFilter_4f_h
-#define __rtkCudaConjugateGradientImageFilter_4f_h
+#ifndef rtkCudaConjugateGradientImageFilter_4f_h
+#define rtkCudaConjugateGradientImageFilter_4f_h
 
 #include "rtkConjugateGradientImageFilter.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaConstantVolumeSeriesSource.h
+++ b/code/rtkCudaConstantVolumeSeriesSource.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaConstantVolumeSeriesSource_h
-#define __rtkCudaConstantVolumeSeriesSource_h
+#ifndef rtkCudaConstantVolumeSeriesSource_h
+#define rtkCudaConstantVolumeSeriesSource_h
 
 #include "rtkConstantImageSource.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaConstantVolumeSource.h
+++ b/code/rtkCudaConstantVolumeSource.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaConstantVolumeSource_h
-#define __rtkCudaConstantVolumeSource_h
+#ifndef rtkCudaConstantVolumeSource_h
+#define rtkCudaConstantVolumeSource_h
 
 #include "rtkConstantImageSource.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaCropImageFilter.h
+++ b/code/rtkCudaCropImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkCudaCropImageFilter_h
-#define __rtkCudaCropImageFilter_h
+#ifndef rtkCudaCropImageFilter_h
+#define rtkCudaCropImageFilter_h
 
 #include <itkCropImageFilter.h>
 #include "rtkWin32Header.h"

--- a/code/rtkCudaCyclicDeformationImageFilter.h
+++ b/code/rtkCudaCyclicDeformationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaCyclicDeformationImageFilter_h
-#define __rtkCudaCyclicDeformationImageFilter_h
+#ifndef rtkCudaCyclicDeformationImageFilter_h
+#define rtkCudaCyclicDeformationImageFilter_h
 
 #include "rtkCyclicDeformationImageFilter.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaDisplacedDetectorImageFilter.h
+++ b/code/rtkCudaDisplacedDetectorImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaDisplacedDetectorImageFilter_h
-#define __rtkCudaDisplacedDetectorImageFilter_h
+#ifndef rtkCudaDisplacedDetectorImageFilter_h
+#define rtkCudaDisplacedDetectorImageFilter_h
 
 #include "rtkDisplacedDetectorImageFilter.h"
 #include "rtkWin32Header.h"
@@ -79,4 +79,4 @@ private:
 
 }
 
-#endif // __rtkCudaDisplacedDetectorImageFilter_h
+#endif // rtkCudaDisplacedDetectorImageFilter_h

--- a/code/rtkCudaFDKBackProjectionImageFilter.h
+++ b/code/rtkCudaFDKBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaFDKBackProjectionImageFilter_h
-#define __rtkCudaFDKBackProjectionImageFilter_h
+#ifndef rtkCudaFDKBackProjectionImageFilter_h
+#define rtkCudaFDKBackProjectionImageFilter_h
 
 #include "rtkFDKBackProjectionImageFilter.h"
 #include "rtkWin32Header.h"

--- a/code/rtkCudaFDKConeBeamReconstructionFilter.h
+++ b/code/rtkCudaFDKConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaFDKConeBeamReconstructionFilter_h
-#define __rtkCudaFDKConeBeamReconstructionFilter_h
+#ifndef rtkCudaFDKConeBeamReconstructionFilter_h
+#define rtkCudaFDKConeBeamReconstructionFilter_h
 
 #include "rtkFDKConeBeamReconstructionFilter.h"
 #include "rtkCudaFDKWeightProjectionFilter.h"

--- a/code/rtkCudaFDKWeightProjectionFilter.h
+++ b/code/rtkCudaFDKWeightProjectionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaFDKWeightProjectionFilter_h
-#define __rtkCudaFDKWeightProjectionFilter_h
+#ifndef rtkCudaFDKWeightProjectionFilter_h
+#define rtkCudaFDKWeightProjectionFilter_h
 
 #include "rtkFDKWeightProjectionFilter.h"
 #include "rtkWin32Header.h"
@@ -81,4 +81,4 @@ private:
 
 } // end namespace rtk
 
-#endif // __rtkCudaFDKWeightProjectionFilter_h
+#endif // rtkCudaFDKWeightProjectionFilter_h

--- a/code/rtkCudaFFTConvolutionImageFilter.h
+++ b/code/rtkCudaFFTConvolutionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaFFTConvolutionImageFilter_h
-#define __rtkCudaFFTConvolutionImageFilter_h
+#ifndef rtkCudaFFTConvolutionImageFilter_h
+#define rtkCudaFFTConvolutionImageFilter_h
 
 #include <itkCudaImage.h>
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaFFTRampImageFilter.h
+++ b/code/rtkCudaFFTRampImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaFFTRampImageFilter_h
-#define __rtkCudaFFTRampImageFilter_h
+#ifndef rtkCudaFFTRampImageFilter_h
+#define rtkCudaFFTRampImageFilter_h
 
 #include "rtkFFTRampImageFilter.h"
 #include "rtkCudaFFTConvolutionImageFilter.h"

--- a/code/rtkCudaForwardProjectionImageFilter.h
+++ b/code/rtkCudaForwardProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaForwardProjectionImageFilter_h
-#define __rtkCudaForwardProjectionImageFilter_h
+#ifndef rtkCudaForwardProjectionImageFilter_h
+#define rtkCudaForwardProjectionImageFilter_h
 
 #include "rtkForwardProjectionImageFilter.h"
 #include "itkCudaInPlaceImageFilter.h"

--- a/code/rtkCudaForwardWarpImageFilter.h
+++ b/code/rtkCudaForwardWarpImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaForwardWarpImageFilter_h
-#define __rtkCudaForwardWarpImageFilter_h
+#ifndef rtkCudaForwardWarpImageFilter_h
+#define rtkCudaForwardWarpImageFilter_h
 
 #include "rtkWin32Header.h"
 #include "rtkForwardWarpImageFilter.h"

--- a/code/rtkCudaInterpolateImageFilter.h
+++ b/code/rtkCudaInterpolateImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaInterpolateImageFilter_h
-#define __rtkCudaInterpolateImageFilter_h
+#ifndef rtkCudaInterpolateImageFilter_h
+#define rtkCudaInterpolateImageFilter_h
 
 #include "rtkInterpolatorWithKnownWeightsImageFilter.h"
 #include "itkCudaImage.h"

--- a/code/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
+++ b/code/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaIterativeFDKConeBeamReconstructionFilter_h
-#define __rtkCudaIterativeFDKConeBeamReconstructionFilter_h
+#ifndef rtkCudaIterativeFDKConeBeamReconstructionFilter_h
+#define rtkCudaIterativeFDKConeBeamReconstructionFilter_h
 
 #include "rtkIterativeFDKConeBeamReconstructionFilter.h"
 #include "rtkCudaFDKConeBeamReconstructionFilter.h"

--- a/code/rtkCudaLagCorrectionImageFilter.h
+++ b/code/rtkCudaLagCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaLagCorrectionImageFilter_h
-#define __rtkCudaLagCorrectionImageFilter_h
+#ifndef rtkCudaLagCorrectionImageFilter_h
+#define rtkCudaLagCorrectionImageFilter_h
 
 #include "rtkLagCorrectionImageFilter.h"
 #include "rtkWin32Header.h"
@@ -77,4 +77,4 @@ private:
 
 }
 
-#endif // __rtkCudaLagCorrectionImageFilter_h
+#endif // rtkCudaLagCorrectionImageFilter_h

--- a/code/rtkCudaLaplacianImageFilter.h
+++ b/code/rtkCudaLaplacianImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaLaplacianImageFilter_h
-#define __rtkCudaLaplacianImageFilter_h
+#ifndef rtkCudaLaplacianImageFilter_h
+#define rtkCudaLaplacianImageFilter_h
 
 #include "rtkLaplacianImageFilter.h"
 #include <itkCudaInPlaceImageFilter.h>

--- a/code/rtkCudaLastDimensionTVDenoisingImageFilter.h
+++ b/code/rtkCudaLastDimensionTVDenoisingImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaLastDimensionTVDenoisingImageFilter_h
-#define __rtkCudaLastDimensionTVDenoisingImageFilter_h
+#ifndef rtkCudaLastDimensionTVDenoisingImageFilter_h
+#define rtkCudaLastDimensionTVDenoisingImageFilter_h
 
 #include "rtkTotalVariationDenoisingBPDQImageFilter.h"
 #include <itkCudaInPlaceImageFilter.h>

--- a/code/rtkCudaParkerShortScanImageFilter.h
+++ b/code/rtkCudaParkerShortScanImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaParkerShortScanImageFilter_h
-#define __rtkCudaParkerShortScanImageFilter_h
+#ifndef rtkCudaParkerShortScanImageFilter_h
+#define rtkCudaParkerShortScanImageFilter_h
 
 #include "rtkParkerShortScanImageFilter.h"
 #include "rtkWin32Header.h"
@@ -79,4 +79,4 @@ private:
 
 }
 
-#endif // __rtkCudaParkerShortScanImageFilter_h
+#endif // rtkCudaParkerShortScanImageFilter_h

--- a/code/rtkCudaPolynomialGainCorrectionImageFilter.h
+++ b/code/rtkCudaPolynomialGainCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaPolynomialGainCorrectionImageFilter_h
-#define __rtkCudaPolynomialGainCorrectionImageFilter_h
+#ifndef rtkCudaPolynomialGainCorrectionImageFilter_h
+#define rtkCudaPolynomialGainCorrectionImageFilter_h
 
 #include "rtkPolynomialGainCorrectionImageFilter.h"
 #include "rtkWin32Header.h"
@@ -78,4 +78,4 @@ private:
 
 }
 
-#endif // __rtkCudaPolynomialGainCorrectionImageFilter_h
+#endif // rtkCudaPolynomialGainCorrectionImageFilter_h

--- a/code/rtkCudaRayCastBackProjectionImageFilter.h
+++ b/code/rtkCudaRayCastBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaRayCastBackProjectionImageFilter_h
-#define __rtkCudaRayCastBackProjectionImageFilter_h
+#ifndef rtkCudaRayCastBackProjectionImageFilter_h
+#define rtkCudaRayCastBackProjectionImageFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkWin32Header.h"

--- a/code/rtkCudaScatterGlareCorrectionImageFilter.h
+++ b/code/rtkCudaScatterGlareCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaScatterGlareCorrectionImageFilter_h
-#define __rtkCudaScatterGlareCorrectionImageFilter_h
+#ifndef rtkCudaScatterGlareCorrectionImageFilter_h
+#define rtkCudaScatterGlareCorrectionImageFilter_h
 
 #include "rtkScatterGlareCorrectionImageFilter.h"
 #include "rtkCudaFFTConvolutionImageFilter.h"

--- a/code/rtkCudaSplatImageFilter.h
+++ b/code/rtkCudaSplatImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaSplatImageFilter_h
-#define __rtkCudaSplatImageFilter_h
+#ifndef rtkCudaSplatImageFilter_h
+#define rtkCudaSplatImageFilter_h
 
 #include "rtkSplatWithKnownWeightsImageFilter.h"
 #include "itkCudaImage.h"

--- a/code/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
+++ b/code/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaTotalVariationDenoisingBPDQImageFilter_h
-#define __rtkCudaTotalVariationDenoisingBPDQImageFilter_h
+#ifndef rtkCudaTotalVariationDenoisingBPDQImageFilter_h
+#define rtkCudaTotalVariationDenoisingBPDQImageFilter_h
 
 #include "rtkTotalVariationDenoisingBPDQImageFilter.h"
 #include <itkCudaImageToImageFilter.h>

--- a/code/rtkCudaWarpBackProjectionImageFilter.h
+++ b/code/rtkCudaWarpBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaWarpBackProjectionImageFilter_h
-#define __rtkCudaWarpBackProjectionImageFilter_h
+#ifndef rtkCudaWarpBackProjectionImageFilter_h
+#define rtkCudaWarpBackProjectionImageFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkWin32Header.h"

--- a/code/rtkCudaWarpForwardProjectionImageFilter.h
+++ b/code/rtkCudaWarpForwardProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaWarpForwardProjectionImageFilter_h
-#define __rtkCudaWarpForwardProjectionImageFilter_h
+#ifndef rtkCudaWarpForwardProjectionImageFilter_h
+#define rtkCudaWarpForwardProjectionImageFilter_h
 
 #include "rtkForwardProjectionImageFilter.h"
 #include "itkCudaInPlaceImageFilter.h"

--- a/code/rtkCudaWarpImageFilter.h
+++ b/code/rtkCudaWarpImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCudaWarpImageFilter_h
-#define __rtkCudaWarpImageFilter_h
+#ifndef rtkCudaWarpImageFilter_h
+#define rtkCudaWarpImageFilter_h
 
 #include "rtkWin32Header.h"
 

--- a/code/rtkCyclicDeformationImageFilter.h
+++ b/code/rtkCyclicDeformationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkCyclicDeformationImageFilter_h
-#define __rtkCyclicDeformationImageFilter_h
+#ifndef rtkCyclicDeformationImageFilter_h
+#define rtkCyclicDeformationImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkDCMImagXImageIO.h
+++ b/code/rtkDCMImagXImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDCMImagXImageIO_h
-#define __rtkDCMImagXImageIO_h
+#ifndef rtkDCMImagXImageIO_h
+#define rtkDCMImagXImageIO_h
 
 #include <itkGDCMImageIO.h>
 

--- a/code/rtkDCMImagXImageIOFactory.h
+++ b/code/rtkDCMImagXImageIOFactory.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDCMImagXImageIOFactory_h
-#define __rtkDCMImagXImageIOFactory_h
+#ifndef rtkDCMImagXImageIOFactory_h
+#define rtkDCMImagXImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkDCMImagXImageIO.h"

--- a/code/rtkDPExtractShroudSignalImageFilter.h
+++ b/code/rtkDPExtractShroudSignalImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDPExtractShroudSignalImageFilter_h
-#define __rtkDPExtractShroudSignalImageFilter_h
+#ifndef rtkDPExtractShroudSignalImageFilter_h
+#define rtkDPExtractShroudSignalImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkDaubechiesWaveletsConvolutionImageFilter.h
+++ b/code/rtkDaubechiesWaveletsConvolutionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDaubechiesWaveletsConvolutionImageFilter_h
-#define __rtkDaubechiesWaveletsConvolutionImageFilter_h
+#ifndef rtkDaubechiesWaveletsConvolutionImageFilter_h
+#define rtkDaubechiesWaveletsConvolutionImageFilter_h
 
 //Includes
 #include <itkImageToImageFilter.h>

--- a/code/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
+++ b/code/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDaubechiesWaveletsDenoiseSequenceImageFilter_h
-#define __rtkDaubechiesWaveletsDenoiseSequenceImageFilter_h
+#ifndef rtkDaubechiesWaveletsDenoiseSequenceImageFilter_h
+#define rtkDaubechiesWaveletsDenoiseSequenceImageFilter_h
 
 #include "rtkConstantImageSource.h"
 

--- a/code/rtkDbf.h
+++ b/code/rtkDbf.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDbf_h
-#define __rtkDbf_h
+#ifndef rtkDbf_h
+#define rtkDbf_h
 
 #include <string>
 #include <fstream>

--- a/code/rtkDeconstructImageFilter.h
+++ b/code/rtkDeconstructImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDeconstructImageFilter_h
-#define __rtkDeconstructImageFilter_h
+#ifndef rtkDeconstructImageFilter_h
+#define rtkDeconstructImageFilter_h
 
 //Includes
 #include <itkImageToImageFilter.h>

--- a/code/rtkDeconstructSoftThresholdReconstructImageFilter.h
+++ b/code/rtkDeconstructSoftThresholdReconstructImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDeconstructSoftThresholdReconstructImageFilter_h
-#define __rtkDeconstructSoftThresholdReconstructImageFilter_h
+#ifndef rtkDeconstructSoftThresholdReconstructImageFilter_h
+#define rtkDeconstructSoftThresholdReconstructImageFilter_h
 
 //ITK includes
 #include "itkMacro.h"

--- a/code/rtkDigisensGeometryReader.h
+++ b/code/rtkDigisensGeometryReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDigisensGeometryReader_h
-#define __rtkDigisensGeometryReader_h
+#ifndef rtkDigisensGeometryReader_h
+#define rtkDigisensGeometryReader_h
 
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkDigisensGeometryXMLFileReader.h
+++ b/code/rtkDigisensGeometryXMLFileReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDigisensGeometryXMLFileReader_h
-#define __rtkDigisensGeometryXMLFileReader_h
+#ifndef rtkDigisensGeometryXMLFileReader_h
+#define rtkDigisensGeometryXMLFileReader_h
 
 #include <itkXMLFile.h>
 #include <itkMetaDataDictionary.h>

--- a/code/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
+++ b/code/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDisplacedDetectorForOffsetFieldOfViewImageFilter_h
-#define __rtkDisplacedDetectorForOffsetFieldOfViewImageFilter_h
+#ifndef rtkDisplacedDetectorForOffsetFieldOfViewImageFilter_h
+#define rtkDisplacedDetectorForOffsetFieldOfViewImageFilter_h
 
 #include "rtkDisplacedDetectorImageFilter.h"
 

--- a/code/rtkDisplacedDetectorImageFilter.h
+++ b/code/rtkDisplacedDetectorImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDisplacedDetectorImageFilter_h
-#define __rtkDisplacedDetectorImageFilter_h
+#ifndef rtkDisplacedDetectorImageFilter_h
+#define rtkDisplacedDetectorImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkDivergenceOfGradientConjugateGradientOperator.h
+++ b/code/rtkDivergenceOfGradientConjugateGradientOperator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDivergenceOfGradientConjugateGradientOperator_h
-#define __rtkDivergenceOfGradientConjugateGradientOperator_h
+#ifndef rtkDivergenceOfGradientConjugateGradientOperator_h
+#define rtkDivergenceOfGradientConjugateGradientOperator_h
 
 #include "rtkConjugateGradientOperator.h"
 

--- a/code/rtkDownsampleImageFilter.h
+++ b/code/rtkDownsampleImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDownsampleImageFilter_h
-#define __rtkDownsampleImageFilter_h
+#ifndef rtkDownsampleImageFilter_h
+#define rtkDownsampleImageFilter_h
 
 #include "itkImageToImageFilter.h"
 

--- a/code/rtkDrawConeImageFilter.h
+++ b/code/rtkDrawConeImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawConeImageFilter_h
-#define __rtkDrawConeImageFilter_h
+#ifndef rtkDrawConeImageFilter_h
+#define rtkDrawConeImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkDrawQuadricImageFilter.h"

--- a/code/rtkDrawCubeImageFilter.h
+++ b/code/rtkDrawCubeImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawCubeImageFilter_h
-#define __rtkDrawCubeImageFilter_h
+#ifndef rtkDrawCubeImageFilter_h
+#define rtkDrawCubeImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkVector.h>

--- a/code/rtkDrawCylinderImageFilter.h
+++ b/code/rtkDrawCylinderImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawCylinderImageFilter_h
-#define __rtkDrawCylinderImageFilter_h
+#ifndef rtkDrawCylinderImageFilter_h
+#define rtkDrawCylinderImageFilter_h
 
 
 #include <itkAddImageFilter.h>

--- a/code/rtkDrawEllipsoidImageFilter.h
+++ b/code/rtkDrawEllipsoidImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawEllipsoidImageFilter_h
-#define __rtkDrawEllipsoidImageFilter_h
+#ifndef rtkDrawEllipsoidImageFilter_h
+#define rtkDrawEllipsoidImageFilter_h
 
 #include "rtkDrawQuadricImageFilter.h"
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkDrawGeometricPhantomImageFilter.h
+++ b/code/rtkDrawGeometricPhantomImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawGeometricPhantomImageFilter_h
-#define __rtkDrawGeometricPhantomImageFilter_h
+#ifndef rtkDrawGeometricPhantomImageFilter_h
+#define rtkDrawGeometricPhantomImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 

--- a/code/rtkDrawImageFilter.h
+++ b/code/rtkDrawImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawImageFilter_h
-#define __rtkDrawImageFilter_h
+#ifndef rtkDrawImageFilter_h
+#define rtkDrawImageFilter_h
 
 
 #include <itkInPlaceImageFilter.h>

--- a/code/rtkDrawQuadricImageFilter.h
+++ b/code/rtkDrawQuadricImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawQuadricImageFilter_h
-#define __rtkDrawQuadricImageFilter_h
+#ifndef rtkDrawQuadricImageFilter_h
+#define rtkDrawQuadricImageFilter_h
 
 #include <itkAddImageFilter.h>
 

--- a/code/rtkDrawQuadricSpatialObject.h
+++ b/code/rtkDrawQuadricSpatialObject.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawQuadricSpatialObject_h
-#define __rtkDrawQuadricSpatialObject_h
+#ifndef rtkDrawQuadricSpatialObject_h
+#define rtkDrawQuadricSpatialObject_h
 
 #include "rtkWin32Header.h"
 

--- a/code/rtkDrawSheppLoganFilter.h
+++ b/code/rtkDrawSheppLoganFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawSheppLoganFilter_h
-#define __rtkDrawSheppLoganFilter_h
+#ifndef rtkDrawSheppLoganFilter_h
+#define rtkDrawSheppLoganFilter_h
 
 #include <itkInPlaceImageFilter.h>
 

--- a/code/rtkDrawSpatialObject.h
+++ b/code/rtkDrawSpatialObject.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkDrawSpatialObject_h
-#define __rtkDrawSpatialObject_h
+#ifndef rtkDrawSpatialObject_h
+#define rtkDrawSpatialObject_h
 
 #include <itkPoint.h>
 #include "rtkConvertEllipsoidToQuadricParametersFunction.h"

--- a/code/rtkEdfImageIO.h
+++ b/code/rtkEdfImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkEdfImageIO_h
-#define __rtkEdfImageIO_h
+#ifndef rtkEdfImageIO_h
+#define rtkEdfImageIO_h
 
 #include <itkImageIOBase.h>
 #include <fstream>

--- a/code/rtkEdfImageIOFactory.h
+++ b/code/rtkEdfImageIOFactory.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkEdfImageIOFactory_h
-#define __rtkEdfImageIOFactory_h
+#ifndef rtkEdfImageIOFactory_h
+#define rtkEdfImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkEdfImageIO.h"

--- a/code/rtkEdfRawToAttenuationImageFilter.h
+++ b/code/rtkEdfRawToAttenuationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkEdfRawToAttenuationImageFilter_h
-#define __rtkEdfRawToAttenuationImageFilter_h
+#ifndef rtkEdfRawToAttenuationImageFilter_h
+#define rtkEdfRawToAttenuationImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkImageSeriesReader.h>

--- a/code/rtkElektaSynergyGeometryReader.h
+++ b/code/rtkElektaSynergyGeometryReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkElektaSynergyGeometryReader_h
-#define __rtkElektaSynergyGeometryReader_h
+#ifndef rtkElektaSynergyGeometryReader_h
+#define rtkElektaSynergyGeometryReader_h
 
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkElektaSynergyLookupTableImageFilter.h
+++ b/code/rtkElektaSynergyLookupTableImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkElektaSynergyLookupTableImageFilter_h
-#define __rtkElektaSynergyLookupTableImageFilter_h
+#ifndef rtkElektaSynergyLookupTableImageFilter_h
+#define rtkElektaSynergyLookupTableImageFilter_h
 
 #include "rtkLookupTableImageFilter.h"
 #include <itkNumericTraits.h>

--- a/code/rtkElektaSynergyRawLookupTableImageFilter.h
+++ b/code/rtkElektaSynergyRawLookupTableImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkElektaSynergyRawLookupTableImageFilter_h
-#define __rtkElektaSynergyRawLookupTableImageFilter_h
+#ifndef rtkElektaSynergyRawLookupTableImageFilter_h
+#define rtkElektaSynergyRawLookupTableImageFilter_h
 
 #include "rtkLookupTableImageFilter.h"
 #include <itkNumericTraits.h>

--- a/code/rtkElektaXVI5GeometryXMLFile.h
+++ b/code/rtkElektaXVI5GeometryXMLFile.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkElektaXVI5GeometryXMLFile_h
-#define __rtkElektaXVI5GeometryXMLFile_h
+#ifndef rtkElektaXVI5GeometryXMLFile_h
+#define rtkElektaXVI5GeometryXMLFile_h
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )

--- a/code/rtkExtractPhaseImageFilter.h
+++ b/code/rtkExtractPhaseImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkExtractPhaseImageFilter_h
-#define __rtkExtractPhaseImageFilter_h
+#ifndef rtkExtractPhaseImageFilter_h
+#define rtkExtractPhaseImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 

--- a/code/rtkFDKBackProjectionImageFilter.h
+++ b/code/rtkFDKBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFDKBackProjectionImageFilter_h
-#define __rtkFDKBackProjectionImageFilter_h
+#ifndef rtkFDKBackProjectionImageFilter_h
+#define rtkFDKBackProjectionImageFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 

--- a/code/rtkFDKConeBeamReconstructionFilter.h
+++ b/code/rtkFDKConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFDKConeBeamReconstructionFilter_h
-#define __rtkFDKConeBeamReconstructionFilter_h
+#ifndef rtkFDKConeBeamReconstructionFilter_h
+#define rtkFDKConeBeamReconstructionFilter_h
 
 #include "rtkFDKWeightProjectionFilter.h"
 #include "rtkFFTRampImageFilter.h"

--- a/code/rtkFDKWarpBackProjectionImageFilter.h
+++ b/code/rtkFDKWarpBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFDKWarpBackProjectionImageFilter_h
-#define __rtkFDKWarpBackProjectionImageFilter_h
+#ifndef rtkFDKWarpBackProjectionImageFilter_h
+#define rtkFDKWarpBackProjectionImageFilter_h
 
 #include "rtkFDKBackProjectionImageFilter.h"
 

--- a/code/rtkFDKWeightProjectionFilter.h
+++ b/code/rtkFDKWeightProjectionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFDKWeightProjectionFilter_h
-#define __rtkFDKWeightProjectionFilter_h
+#ifndef rtkFDKWeightProjectionFilter_h
+#define rtkFDKWeightProjectionFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkFFTConvolutionImageFilter.h
+++ b/code/rtkFFTConvolutionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFFTConvolutionImageFilter_h
-#define __rtkFFTConvolutionImageFilter_h
+#ifndef rtkFFTConvolutionImageFilter_h
+#define rtkFFTConvolutionImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkConceptChecking.h>

--- a/code/rtkFFTRampImageFilter.h
+++ b/code/rtkFFTRampImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFFTRampImageFilter_h
-#define __rtkFFTRampImageFilter_h
+#ifndef rtkFFTRampImageFilter_h
+#define rtkFFTRampImageFilter_h
 
 #include <itkConceptChecking.h>
 #include "rtkConfiguration.h"

--- a/code/rtkFieldOfViewImageFilter.h
+++ b/code/rtkFieldOfViewImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFieldOfViewImageFilter_h
-#define __rtkFieldOfViewImageFilter_h
+#ifndef rtkFieldOfViewImageFilter_h
+#define rtkFieldOfViewImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 

--- a/code/rtkForwardProjectionImageFilter.h
+++ b/code/rtkForwardProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkForwardProjectionImageFilter_h
-#define __rtkForwardProjectionImageFilter_h
+#ifndef rtkForwardProjectionImageFilter_h
+#define rtkForwardProjectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkForwardWarpImageFilter.h
+++ b/code/rtkForwardWarpImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkForwardWarpImageFilter_h
-#define __rtkForwardWarpImageFilter_h
+#ifndef rtkForwardWarpImageFilter_h
+#define rtkForwardWarpImageFilter_h
 
 #include <itkWarpImageFilter.h>
 

--- a/code/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/code/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFourDConjugateGradientConeBeamReconstructionFilter_h
-#define __rtkFourDConjugateGradientConeBeamReconstructionFilter_h
+#ifndef rtkFourDConjugateGradientConeBeamReconstructionFilter_h
+#define rtkFourDConjugateGradientConeBeamReconstructionFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkForwardProjectionImageFilter.h"

--- a/code/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/code/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkFourDROOSTERConeBeamReconstructionFilter_h
-#define __rtkFourDROOSTERConeBeamReconstructionFilter_h
+#ifndef rtkFourDROOSTERConeBeamReconstructionFilter_h
+#define rtkFourDROOSTERConeBeamReconstructionFilter_h
 
 #include "rtkFourDConjugateGradientConeBeamReconstructionFilter.h"
 #include "rtkTotalVariationDenoiseSequenceImageFilter.h"

--- a/code/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/code/rtkFourDReconstructionConjugateGradientOperator.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkFourDReconstructionConjugateGradientOperator_h
-#define __rtkFourDReconstructionConjugateGradientOperator_h
+#ifndef rtkFourDReconstructionConjugateGradientOperator_h
+#define rtkFourDReconstructionConjugateGradientOperator_h
 
 #include "rtkConjugateGradientOperator.h"
 

--- a/code/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/code/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkFourDSARTConeBeamReconstructionFilter_h
-#define __rtkFourDSARTConeBeamReconstructionFilter_h
+#ifndef rtkFourDSARTConeBeamReconstructionFilter_h
+#define rtkFourDSARTConeBeamReconstructionFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkForwardProjectionImageFilter.h"

--- a/code/rtkFourDToProjectionStackImageFilter.h
+++ b/code/rtkFourDToProjectionStackImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkFourDToProjectionStackImageFilter_h
-#define __rtkFourDToProjectionStackImageFilter_h
+#ifndef rtkFourDToProjectionStackImageFilter_h
+#define rtkFourDToProjectionStackImageFilter_h
 
 #include <itkExtractImageFilter.h>
 #include <itkPasteImageFilter.h>

--- a/code/rtkGeneralPurposeFunctions.h
+++ b/code/rtkGeneralPurposeFunctions.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkGeneralPurposeFunctions_h
-#define __rtkGeneralPurposeFunctions_h
+#ifndef rtkGeneralPurposeFunctions_h
+#define rtkGeneralPurposeFunctions_h
 
 #include <vector>
 #include <itkMacro.h>
@@ -93,4 +93,4 @@ WriteImage(typename ImageType::Pointer input, std::string name)
 
 }
 
-#endif // __rtkGeneralPurposeFunctions_h
+#endif // rtkGeneralPurposeFunctions_h

--- a/code/rtkGeometricPhantomFileReader.h
+++ b/code/rtkGeometricPhantomFileReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkGeometricPhantomFileReader_h
-#define __rtkGeometricPhantomFileReader_h
+#ifndef rtkGeometricPhantomFileReader_h
+#define rtkGeometricPhantomFileReader_h
 
 #include <itkNumericTraits.h>
 #include <vector>

--- a/code/rtkGgoArgsInfoManager.h
+++ b/code/rtkGgoArgsInfoManager.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkGgoArgsInfoManager_h
-#define __rtkGgoArgsInfoManager_h
+#ifndef rtkGgoArgsInfoManager_h
+#define rtkGgoArgsInfoManager_h
 
 #include "rtkConfiguration.h"
 #ifdef RTK_TIME_EACH_FILTER

--- a/code/rtkGgoFunctions.h
+++ b/code/rtkGgoFunctions.h
@@ -19,8 +19,8 @@
 //#ifndef RTKGGOFUNCTIONS_H
 //#define RTKGGOFUNCTIONS_H
 
-#ifndef __rtkGgoFunctions_h
-#define __rtkGgoFunctions_h
+#ifndef rtkGgoFunctions_h
+#define rtkGgoFunctions_h
 
 #include "rtkMacro.h"
 #include "rtkConstantImageSource.h"
@@ -204,4 +204,4 @@ SetProjectionsReaderFromGgo(typename TProjectionsReaderType::Pointer reader, con
 
 }
 
-#endif // __rtkGgoFunctions_h
+#endif // rtkGgoFunctions_h

--- a/code/rtkGlobalTimer.h
+++ b/code/rtkGlobalTimer.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkGlobalTimer_h
-#define __rtkGlobalTimer_h
+#ifndef rtkGlobalTimer_h
+#define rtkGlobalTimer_h
 
 #include <itkProcessObject.h>
 #include "rtkGlobalTimerProbesCollector.h"

--- a/code/rtkGlobalTimerProbesCollector.h
+++ b/code/rtkGlobalTimerProbesCollector.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkGlobalTimerProbesCollector_h
-#define __rtkGlobalTimerProbesCollector_h
+#ifndef rtkGlobalTimerProbesCollector_h
+#define rtkGlobalTimerProbesCollector_h
 
 
 #include "itkTimeProbe.h"
@@ -71,4 +71,4 @@ protected:
 };
 } // end namespace itk
 
-#endif //__rtkGlobalTimerProbesCollector_h
+#endif //rtkGlobalTimerProbesCollector_h

--- a/code/rtkHilbertImageFilter.h
+++ b/code/rtkHilbertImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkHilbertImageFilter_h
-#define __rtkHilbertImageFilter_h
+#ifndef rtkHilbertImageFilter_h
+#define rtkHilbertImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkHisImageIO.h
+++ b/code/rtkHisImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkHisImageIO_h
-#define __rtkHisImageIO_h
+#ifndef rtkHisImageIO_h
+#define rtkHisImageIO_h
 
 // itk include
 #include <itkImageIOBase.h>
@@ -80,4 +80,4 @@ protected:
 }; // end class HisImageIO
 } // end namespace
 
-#endif /* end #define __rtkHisImageIO_h */
+#endif /* end #define rtkHisImageIO_h */

--- a/code/rtkHisImageIOFactory.h
+++ b/code/rtkHisImageIOFactory.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkHisImageIOFactory_h
-#define __rtkHisImageIOFactory_h
+#ifndef rtkHisImageIOFactory_h
+#define rtkHisImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkHisImageIO.h"
@@ -79,4 +79,4 @@ private:
 
 } // end namespace
 
-#endif /* end #define __rtkHisImageIOFactory_h */
+#endif /* end #define rtkHisImageIOFactory_h */

--- a/code/rtkHndImageIO.h
+++ b/code/rtkHndImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkHndImageIO_h
-#define __rtkHndImageIO_h
+#ifndef rtkHndImageIO_h
+#define rtkHndImageIO_h
 
 // itk include
 #include <itkImageIOBase.h>
@@ -142,4 +142,4 @@ public:
 
 } // end namespace
 
-#endif /* end #define __rtkHndImageIO_h */
+#endif /* end #define rtkHndImageIO_h */

--- a/code/rtkHndImageIOFactory.h
+++ b/code/rtkHndImageIOFactory.h
@@ -19,8 +19,8 @@
 //#ifndef ITKHNDIMAGEIOFACTORY_H
 //#define ITKHNDIMAGEIOFACTORY_H
 
-#ifndef __rtkHndImageIOFactory_h
-#define __rtkHndImageIOFactory_h
+#ifndef rtkHndImageIOFactory_h
+#define rtkHndImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkHndImageIO.h"
@@ -81,4 +81,4 @@ private:
 
 } // end namespace
 
-#endif // __rtkHndImageIOFactory_h
+#endif // rtkHndImageIOFactory_h

--- a/code/rtkHomogeneousMatrix.h
+++ b/code/rtkHomogeneousMatrix.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkHomogeneousMatrix_h
-#define __rtkHomogeneousMatrix_h
+#ifndef rtkHomogeneousMatrix_h
+#define rtkHomogeneousMatrix_h
 
 #include <itkMatrix.h>
 #include <itkImage.h>
@@ -82,4 +82,4 @@ GetPhysicalPointToIndexMatrix(const TImageType *image)
 
 } // end namespace
 
-#endif // __rtkHomogeneousMatrix_h
+#endif // rtkHomogeneousMatrix_h

--- a/code/rtkI0EstimationProjectionFilter.h
+++ b/code/rtkI0EstimationProjectionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkI0EstimationProjectionFilter_h
-#define __rtkI0EstimationProjectionFilter_h
+#ifndef rtkI0EstimationProjectionFilter_h
+#define rtkI0EstimationProjectionFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkMutexLock.h>

--- a/code/rtkIOFactories.h
+++ b/code/rtkIOFactories.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkIOFactories_h
-#define __rtkIOFactories_h
+#ifndef rtkIOFactories_h
+#define rtkIOFactories_h
 
 #include "rtkWin32Header.h"
 

--- a/code/rtkImagXGeometryReader.h
+++ b/code/rtkImagXGeometryReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkImagXGeometryReader_h
-#define __rtkImagXGeometryReader_h
+#ifndef rtkImagXGeometryReader_h
+#define rtkImagXGeometryReader_h
 
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"
@@ -121,4 +121,4 @@ private:
 #include "rtkImagXGeometryReader.hxx"
 #endif
 
-#endif // __rtkImagXGeometryReader_h
+#endif // rtkImagXGeometryReader_h

--- a/code/rtkImagXImageIO.h
+++ b/code/rtkImagXImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkImagXImageIO_h
-#define __rtkImagXImageIO_h
+#ifndef rtkImagXImageIO_h
+#define rtkImagXImageIO_h
 
 #include <itkImageIOBase.h>
 #include <fstream>

--- a/code/rtkImagXImageIOFactory.h
+++ b/code/rtkImagXImageIOFactory.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkImagXImageIOFactory_h
-#define __rtkImagXImageIOFactory_h
+#ifndef rtkImagXImageIOFactory_h
+#define rtkImagXImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkImagXImageIO.h"

--- a/code/rtkImagXXMLFileReader.h
+++ b/code/rtkImagXXMLFileReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkImagXXMLFileReader_h
-#define __rtkImagXXMLFileReader_h
+#ifndef rtkImagXXMLFileReader_h
+#define rtkImagXXMLFileReader_h
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )

--- a/code/rtkImportImageFilter.h
+++ b/code/rtkImportImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkImportImageFilter_h
-#define __rtkImportImageFilter_h
+#ifndef rtkImportImageFilter_h
+#define rtkImportImageFilter_h
 
 #include "itkImageSource.h"
 #include "rtkMacro.h"

--- a/code/rtkInterpolatorWithKnownWeightsImageFilter.h
+++ b/code/rtkInterpolatorWithKnownWeightsImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkInterpolatorWithKnownWeightsImageFilter_h
-#define __rtkInterpolatorWithKnownWeightsImageFilter_h
+#ifndef rtkInterpolatorWithKnownWeightsImageFilter_h
+#define rtkInterpolatorWithKnownWeightsImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
 #include "itkArray2D.h"

--- a/code/rtkIterativeConeBeamReconstructionFilter.h
+++ b/code/rtkIterativeConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkIterativeConeBeamReconstructionFilter_h
-#define __rtkIterativeConeBeamReconstructionFilter_h
+#ifndef rtkIterativeConeBeamReconstructionFilter_h
+#define rtkIterativeConeBeamReconstructionFilter_h
 
 // Forward projection filters
 #include "rtkConfiguration.h"

--- a/code/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/code/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkIterativeFDKConeBeamReconstructionFilter_h
-#define __rtkIterativeFDKConeBeamReconstructionFilter_h
+#ifndef rtkIterativeFDKConeBeamReconstructionFilter_h
+#define rtkIterativeFDKConeBeamReconstructionFilter_h
 
 #include <itkMultiplyImageFilter.h>
 #include <itkSubtractImageFilter.h>

--- a/code/rtkJosephBackProjectionImageFilter.h
+++ b/code/rtkJosephBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkJosephBackProjectionImageFilter_h
-#define __rtkJosephBackProjectionImageFilter_h
+#ifndef rtkJosephBackProjectionImageFilter_h
+#define rtkJosephBackProjectionImageFilter_h
 
 #include "rtkConfiguration.h"
 #include "rtkBackProjectionImageFilter.h"

--- a/code/rtkJosephForwardProjectionImageFilter.h
+++ b/code/rtkJosephForwardProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkJosephForwardProjectionImageFilter_h
-#define __rtkJosephForwardProjectionImageFilter_h
+#ifndef rtkJosephForwardProjectionImageFilter_h
+#define rtkJosephForwardProjectionImageFilter_h
 
 #include "rtkConfiguration.h"
 #include "rtkForwardProjectionImageFilter.h"

--- a/code/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
+++ b/code/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkLUTbasedVariableI0RawToAttenuationImageFilter_h
-#define __rtkLUTbasedVariableI0RawToAttenuationImageFilter_h
+#ifndef rtkLUTbasedVariableI0RawToAttenuationImageFilter_h
+#define rtkLUTbasedVariableI0RawToAttenuationImageFilter_h
 
 #include <itkNumericTraits.h>
 #include <itkSubtractImageFilter.h>

--- a/code/rtkLagCorrectionImageFilter.h
+++ b/code/rtkLagCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkLagCorrectionImageFilter_h
-#define __rtkLagCorrectionImageFilter_h
+#ifndef rtkLagCorrectionImageFilter_h
+#define rtkLagCorrectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkVector.h>

--- a/code/rtkLaplacianImageFilter.h
+++ b/code/rtkLaplacianImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkLaplacianImageFilter_h
-#define __rtkLaplacianImageFilter_h
+#ifndef rtkLaplacianImageFilter_h
+#define rtkLaplacianImageFilter_h
 
 #include "rtkForwardDifferenceGradientImageFilter.h"
 #include "rtkBackwardDifferenceDivergenceImageFilter.h"

--- a/code/rtkLastDimensionL0GradientDenoisingImageFilter.h
+++ b/code/rtkLastDimensionL0GradientDenoisingImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkLastDimensionL0GradientDenoisingImageFilter_h
-#define __rtkLastDimensionL0GradientDenoisingImageFilter_h
+#ifndef rtkLastDimensionL0GradientDenoisingImageFilter_h
+#define rtkLastDimensionL0GradientDenoisingImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
 

--- a/code/rtkLookupTableImageFilter.h
+++ b/code/rtkLookupTableImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkLookupTableImageFilter_h
-#define __rtkLookupTableImageFilter_h
+#ifndef rtkLookupTableImageFilter_h
+#define rtkLookupTableImageFilter_h
 
 #include <itkUnaryFunctorImageFilter.h>
 #include <itkLinearInterpolateImageFunction.h>

--- a/code/rtkMacro.h
+++ b/code/rtkMacro.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkMacro_h
-#define __rtkMacro_h
+#ifndef rtkMacro_h
+#define rtkMacro_h
 
 #include <iostream>
 #include <itkMacro.h>

--- a/code/rtkMagnitudeThresholdImageFilter.h
+++ b/code/rtkMagnitudeThresholdImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkMagnitudeThresholdImageFilter_h
-#define __rtkMagnitudeThresholdImageFilter_h
+#ifndef rtkMagnitudeThresholdImageFilter_h
+#define rtkMagnitudeThresholdImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkVector.h>

--- a/code/rtkMedianImageFilter.h
+++ b/code/rtkMedianImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkMedianImageFilter_h
-#define __rtkMedianImageFilter_h
+#ifndef rtkMedianImageFilter_h
+#define rtkMedianImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/code/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_h
-#define __rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_h
+#ifndef rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_h
+#define rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_h
 
 #include "rtkFourDConjugateGradientConeBeamReconstructionFilter.h"
 #include "rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h"

--- a/code/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
+++ b/code/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_h
-#define __rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_h
+#ifndef rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_h
+#define rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_h
 
 #include "rtkFourDROOSTERConeBeamReconstructionFilter.h"
 #include "rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h"

--- a/code/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/code/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_h
-#define __rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_h
+#ifndef rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_h
+#define rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_h
 
 #include "rtkFourDReconstructionConjugateGradientOperator.h"
 #include "rtkCyclicDeformationImageFilter.h"

--- a/code/rtkMultiplyByVectorImageFilter.h
+++ b/code/rtkMultiplyByVectorImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkMultiplyByVectorImageFilter_h
-#define __rtkMultiplyByVectorImageFilter_h
+#ifndef rtkMultiplyByVectorImageFilter_h
+#define rtkMultiplyByVectorImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkNormalizedJosephBackProjectionImageFilter.h
+++ b/code/rtkNormalizedJosephBackProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkNormalizedJosephBackProjectionImageFilter_h
-#define __rtkNormalizedJosephBackProjectionImageFilter_h
+#ifndef rtkNormalizedJosephBackProjectionImageFilter_h
+#define rtkNormalizedJosephBackProjectionImageFilter_h
 
 #include "rtkConfiguration.h"
 #include "rtkJosephBackProjectionImageFilter.h"

--- a/code/rtkParkerShortScanImageFilter.h
+++ b/code/rtkParkerShortScanImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkParkerShortScanImageFilter_h
-#define __rtkParkerShortScanImageFilter_h
+#ifndef rtkParkerShortScanImageFilter_h
+#define rtkParkerShortScanImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkSimpleFastMutexLock.h>

--- a/code/rtkPhaseGatingImageFilter.h
+++ b/code/rtkPhaseGatingImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkPhaseGatingImageFilter_h
-#define __rtkPhaseGatingImageFilter_h
+#ifndef rtkPhaseGatingImageFilter_h
+#define rtkPhaseGatingImageFilter_h
 
 #include "rtkSubSelectImageFilter.h"
 #include "rtkConstantImageSource.h"

--- a/code/rtkPhaseReader.h
+++ b/code/rtkPhaseReader.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkPhaseReader_h
-#define __rtkPhaseReader_h
+#ifndef rtkPhaseReader_h
+#define rtkPhaseReader_h
 
 #include <itkCSVFileReaderBase.h>
 

--- a/code/rtkPhasesToInterpolationWeights.h
+++ b/code/rtkPhasesToInterpolationWeights.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkPhasesToInterpolationWeights_h
-#define __rtkPhasesToInterpolationWeights_h
+#ifndef rtkPhasesToInterpolationWeights_h
+#define rtkPhasesToInterpolationWeights_h
 
 #include "itkCSVFileReaderBase.h"
 #include "itkArray2D.h"

--- a/code/rtkPolynomialGainCorrectionImageFilter.h
+++ b/code/rtkPolynomialGainCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkPolynomialGainCorrectionImageFilter_h
-#define __rtkPolynomialGainCorrectionImageFilter_h
+#ifndef rtkPolynomialGainCorrectionImageFilter_h
+#define rtkPolynomialGainCorrectionImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkSimpleFastMutexLock.h>

--- a/code/rtkProjectGeometricPhantomImageFilter.h
+++ b/code/rtkProjectGeometricPhantomImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkProjectGeometricPhantomImageFilter_h
-#define __rtkProjectGeometricPhantomImageFilter_h
+#ifndef rtkProjectGeometricPhantomImageFilter_h
+#define rtkProjectGeometricPhantomImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkProjectionGeometry.h
+++ b/code/rtkProjectionGeometry.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkProjectionGeometry_h
-#define __rtkProjectionGeometry_h
+#ifndef rtkProjectionGeometry_h
+#define rtkProjectionGeometry_h
 
 #include <itkImageBase.h>
 
@@ -95,4 +95,4 @@ private:
 
 #include "rtkProjectionGeometry.hxx"
 
-#endif // __rtkProjectionGeometry_h
+#endif // rtkProjectionGeometry_h

--- a/code/rtkProjectionStackToFourDImageFilter.h
+++ b/code/rtkProjectionStackToFourDImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkProjectionStackToFourDImageFilter_h
-#define __rtkProjectionStackToFourDImageFilter_h
+#ifndef rtkProjectionStackToFourDImageFilter_h
+#define rtkProjectionStackToFourDImageFilter_h
 
 #include <itkExtractImageFilter.h>
 #include <itkArray2D.h>

--- a/code/rtkProjectionsReader.h
+++ b/code/rtkProjectionsReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkProjectionsReader_h
-#define __rtkProjectionsReader_h
+#ifndef rtkProjectionsReader_h
+#define rtkProjectionsReader_h
 
 // ITK
 #include <itkImageSource.h>
@@ -301,4 +301,4 @@ private:
 #include "rtkProjectionsReader.hxx"
 #endif
 
-#endif // __rtkProjectionsReader_h
+#endif // rtkProjectionsReader_h

--- a/code/rtkRayBoxIntersectionFunction.h
+++ b/code/rtkRayBoxIntersectionFunction.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayBoxIntersectionFunction_h
-#define __rtkRayBoxIntersectionFunction_h
+#ifndef rtkRayBoxIntersectionFunction_h
+#define rtkRayBoxIntersectionFunction_h
 
 #include <itkNumericTraits.h>
 #include <vector>

--- a/code/rtkRayBoxIntersectionImageFilter.h
+++ b/code/rtkRayBoxIntersectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayBoxIntersectionImageFilter_h
-#define __rtkRayBoxIntersectionImageFilter_h
+#ifndef rtkRayBoxIntersectionImageFilter_h
+#define rtkRayBoxIntersectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkRayCastInterpolateImageFunction.h
+++ b/code/rtkRayCastInterpolateImageFunction.h
@@ -32,8 +32,8 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __rtkRayCastInterpolateImageFunction_h
-#define __rtkRayCastInterpolateImageFunction_h
+#ifndef rtkRayCastInterpolateImageFunction_h
+#define rtkRayCastInterpolateImageFunction_h
 
 #include <itkInterpolateImageFunction.h>
 #include <itkTransform.h>

--- a/code/rtkRayCastInterpolatorForwardProjectionImageFilter.h
+++ b/code/rtkRayCastInterpolatorForwardProjectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayCastInterpolatorForwardProjectionImageFilter_h
-#define __rtkRayCastInterpolatorForwardProjectionImageFilter_h
+#ifndef rtkRayCastInterpolatorForwardProjectionImageFilter_h
+#define rtkRayCastInterpolatorForwardProjectionImageFilter_h
 
 #include "rtkConfiguration.h"
 #include "rtkForwardProjectionImageFilter.h"

--- a/code/rtkRayEllipsoidIntersectionImageFilter.h
+++ b/code/rtkRayEllipsoidIntersectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayEllipsoidIntersectionImageFilter_h
-#define __rtkRayEllipsoidIntersectionImageFilter_h
+#ifndef rtkRayEllipsoidIntersectionImageFilter_h
+#define rtkRayEllipsoidIntersectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkRayQuadricIntersectionFunction.h
+++ b/code/rtkRayQuadricIntersectionFunction.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayQuadricIntersectionFunction_h
-#define __rtkRayQuadricIntersectionFunction_h
+#ifndef rtkRayQuadricIntersectionFunction_h
+#define rtkRayQuadricIntersectionFunction_h
 
 #include <itkNumericTraits.h>
 #include <vector>

--- a/code/rtkRayQuadricIntersectionImageFilter.h
+++ b/code/rtkRayQuadricIntersectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkRayQuadricIntersectionImageFilter_h
-#define __rtkRayQuadricIntersectionImageFilter_h
+#ifndef rtkRayQuadricIntersectionImageFilter_h
+#define rtkRayQuadricIntersectionImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkConfiguration.h"

--- a/code/rtkReconstructImageFilter.h
+++ b/code/rtkReconstructImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkReconstructImageFilter_h
-#define __rtkReconstructImageFilter_h
+#ifndef rtkReconstructImageFilter_h
+#define rtkReconstructImageFilter_h
 
 //Includes
 #include <itkImageToImageFilter.h>

--- a/code/rtkReconstructionConjugateGradientOperator.h
+++ b/code/rtkReconstructionConjugateGradientOperator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkReconstructionConjugateGradientOperator_h
-#define __rtkReconstructionConjugateGradientOperator_h
+#ifndef rtkReconstructionConjugateGradientOperator_h
+#define rtkReconstructionConjugateGradientOperator_h
 
 #include <itkMultiplyImageFilter.h>
 #include <itkAddImageFilter.h>

--- a/code/rtkReg1DExtractShroudSignalImageFilter.h
+++ b/code/rtkReg1DExtractShroudSignalImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkReg1DExtractShroudSignalImageFilter_h
-#define __rtkReg1DExtractShroudSignalImageFilter_h
+#ifndef rtkReg1DExtractShroudSignalImageFilter_h
+#define rtkReg1DExtractShroudSignalImageFilter_h
 
 #include <itkImageToImageFilter.h>
 

--- a/code/rtkReg23ProjectionGeometry.h
+++ b/code/rtkReg23ProjectionGeometry.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkReg23ProjectionGeometry_h
-#define __rtkReg23ProjectionGeometry_h
+#ifndef rtkReg23ProjectionGeometry_h
+#define rtkReg23ProjectionGeometry_h
 
 
 //RTK
@@ -147,4 +147,4 @@ private:
 
 }
 
-#endif // __rtkReg23ProjectionGeometry_h
+#endif // rtkReg23ProjectionGeometry_h

--- a/code/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/code/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkRegularizedConjugateGradientConeBeamReconstructionFilter_h
-#define __rtkRegularizedConjugateGradientConeBeamReconstructionFilter_h
+#ifndef rtkRegularizedConjugateGradientConeBeamReconstructionFilter_h
+#define rtkRegularizedConjugateGradientConeBeamReconstructionFilter_h
 
 #include "rtkConjugateGradientConeBeamReconstructionFilter.h"
 #ifdef RTK_USE_CUDA

--- a/code/rtkReorderProjectionsImageFilter.h
+++ b/code/rtkReorderProjectionsImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkReorderProjectionsImageFilter_h
-#define __rtkReorderProjectionsImageFilter_h
+#ifndef rtkReorderProjectionsImageFilter_h
+#define rtkReorderProjectionsImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkSARTConeBeamReconstructionFilter.h
+++ b/code/rtkSARTConeBeamReconstructionFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkSARTConeBeamReconstructionFilter_h
-#define __rtkSARTConeBeamReconstructionFilter_h
+#ifndef rtkSARTConeBeamReconstructionFilter_h
+#define rtkSARTConeBeamReconstructionFilter_h
 
 #include "rtkBackProjectionImageFilter.h"
 #include "rtkForwardProjectionImageFilter.h"

--- a/code/rtkScatterGlareCorrectionImageFilter.h
+++ b/code/rtkScatterGlareCorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkScatterGlareCorrectionImageFilter_h
-#define __rtkScatterGlareCorrectionImageFilter_h
+#ifndef rtkScatterGlareCorrectionImageFilter_h
+#define rtkScatterGlareCorrectionImageFilter_h
 
 #include "rtkConfiguration.h"
 #include "rtkFFTConvolutionImageFilter.h"

--- a/code/rtkSelectOneProjectionPerCycleImageFilter.h
+++ b/code/rtkSelectOneProjectionPerCycleImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkSelectOneProjectionPerCycleImageFilter_h
-#define __rtkSelectOneProjectionPerCycleImageFilter_h
+#ifndef rtkSelectOneProjectionPerCycleImageFilter_h
+#define rtkSelectOneProjectionPerCycleImageFilter_h
 
 #include "rtkSubSelectImageFilter.h"
 

--- a/code/rtkSheppLoganPhantomFilter.h
+++ b/code/rtkSheppLoganPhantomFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkSheppLoganPhantomFilter_h
-#define __rtkSheppLoganPhantomFilter_h
+#ifndef rtkSheppLoganPhantomFilter_h
+#define rtkSheppLoganPhantomFilter_h
 
 #include "rtkRayEllipsoidIntersectionImageFilter.h"
 

--- a/code/rtkSignalToInterpolationWeights.h
+++ b/code/rtkSignalToInterpolationWeights.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkSignalToInterpolationWeights_h
-#define __rtkSignalToInterpolationWeights_h
+#ifndef rtkSignalToInterpolationWeights_h
+#define rtkSignalToInterpolationWeights_h
 
 #include "itkCSVFileReaderBase.h"
 #include "itkArray2D.h"

--- a/code/rtkSoftThresholdImageFilter.h
+++ b/code/rtkSoftThresholdImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkSoftThresholdImageFilter_h
-#define __rtkSoftThresholdImageFilter_h
+#ifndef rtkSoftThresholdImageFilter_h
+#define rtkSoftThresholdImageFilter_h
 
 #include "itkUnaryFunctorImageFilter.h"
 #include "itkConceptChecking.h"

--- a/code/rtkSoftThresholdTVImageFilter.h
+++ b/code/rtkSoftThresholdTVImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkSoftThresholdTVImageFilter_h
-#define __rtkSoftThresholdTVImageFilter_h
+#ifndef rtkSoftThresholdTVImageFilter_h
+#define rtkSoftThresholdTVImageFilter_h
 
 #include <itkNeighborhoodIterator.h>
 #include <itkImageToImageFilter.h>

--- a/code/rtkSplatWithKnownWeightsImageFilter.h
+++ b/code/rtkSplatWithKnownWeightsImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkSplatWithKnownWeightsImageFilter_h
-#define __rtkSplatWithKnownWeightsImageFilter_h
+#ifndef rtkSplatWithKnownWeightsImageFilter_h
+#define rtkSplatWithKnownWeightsImageFilter_h
 
 #include <itkInPlaceImageFilter.h>
 #include <itkArray2D.h>

--- a/code/rtkSubSelectFromListImageFilter.h
+++ b/code/rtkSubSelectFromListImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkSubSelectFromListImageFilter_h
-#define __rtkSubSelectFromListImageFilter_h
+#ifndef rtkSubSelectFromListImageFilter_h
+#define rtkSubSelectFromListImageFilter_h
 
 #include "rtkSubSelectImageFilter.h"
 #include "rtkConstantImageSource.h"

--- a/code/rtkSubSelectImageFilter.h
+++ b/code/rtkSubSelectImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkSubSelectImageFilter_h
-#define __rtkSubSelectImageFilter_h
+#ifndef rtkSubSelectImageFilter_h
+#define rtkSubSelectImageFilter_h
 
 #include <itkPasteImageFilter.h>
 #include <itkExtractImageFilter.h>

--- a/code/rtkThreeDCircularProjectionGeometry.h
+++ b/code/rtkThreeDCircularProjectionGeometry.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkThreeDCircularProjectionGeometry_h
-#define __rtkThreeDCircularProjectionGeometry_h
+#ifndef rtkThreeDCircularProjectionGeometry_h
+#define rtkThreeDCircularProjectionGeometry_h
 
 #include "rtkWin32Header.h"
 #include "rtkProjectionGeometry.h"
@@ -240,4 +240,4 @@ private:
 };
 }
 
-#endif // __rtkThreeDCircularProjectionGeometry_h
+#endif // rtkThreeDCircularProjectionGeometry_h

--- a/code/rtkThreeDCircularProjectionGeometryXMLFile.h
+++ b/code/rtkThreeDCircularProjectionGeometryXMLFile.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkThreeDCircularProjectionGeometryXMLFile_h
-#define __rtkThreeDCircularProjectionGeometryXMLFile_h
+#ifndef rtkThreeDCircularProjectionGeometryXMLFile_h
+#define rtkThreeDCircularProjectionGeometryXMLFile_h
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )

--- a/code/rtkTimeProbesCollectorBase.h
+++ b/code/rtkTimeProbesCollectorBase.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkTimeProbesCollectorBase_h
-#define __rtkTimeProbesCollectorBase_h
+#ifndef rtkTimeProbesCollectorBase_h
+#define rtkTimeProbesCollectorBase_h
 
 #include "itkTimeProbesCollectorBase.h"
 

--- a/code/rtkTotalVariationDenoiseSequenceImageFilter.h
+++ b/code/rtkTotalVariationDenoiseSequenceImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkTotalVariationDenoiseSequenceImageFilter_h
-#define __rtkTotalVariationDenoiseSequenceImageFilter_h
+#ifndef rtkTotalVariationDenoiseSequenceImageFilter_h
+#define rtkTotalVariationDenoiseSequenceImageFilter_h
 
 #include "rtkConstantImageSource.h"
 

--- a/code/rtkTotalVariationDenoisingBPDQImageFilter.h
+++ b/code/rtkTotalVariationDenoisingBPDQImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkTotalVariationDenoisingBPDQImageFilter_h
-#define __rtkTotalVariationDenoisingBPDQImageFilter_h
+#ifndef rtkTotalVariationDenoisingBPDQImageFilter_h
+#define rtkTotalVariationDenoisingBPDQImageFilter_h
 
 #include "rtkForwardDifferenceGradientImageFilter.h"
 #include "rtkBackwardDifferenceDivergenceImageFilter.h"

--- a/code/rtkTotalVariationImageFilter.h
+++ b/code/rtkTotalVariationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkTotalVariationImageFilter_h
-#define __rtkTotalVariationImageFilter_h
+#ifndef rtkTotalVariationImageFilter_h
+#define rtkTotalVariationImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include <itkNumericTraits.h>

--- a/code/rtkUnwarpSequenceConjugateGradientOperator.h
+++ b/code/rtkUnwarpSequenceConjugateGradientOperator.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkUnwarpSequenceConjugateGradientOperator_h
-#define __rtkUnwarpSequenceConjugateGradientOperator_h
+#ifndef rtkUnwarpSequenceConjugateGradientOperator_h
+#define rtkUnwarpSequenceConjugateGradientOperator_h
 
 #include "rtkWarpSequenceImageFilter.h"
 #include "rtkConjugateGradientOperator.h"

--- a/code/rtkUnwarpSequenceImageFilter.h
+++ b/code/rtkUnwarpSequenceImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkUnwarpSequenceImageFilter_h
-#define __rtkUnwarpSequenceImageFilter_h
+#ifndef rtkUnwarpSequenceImageFilter_h
+#define rtkUnwarpSequenceImageFilter_h
 
 #include "rtkConjugateGradientImageFilter.h"
 #include "rtkUnwarpSequenceConjugateGradientOperator.h"

--- a/code/rtkUpsampleImageFilter.h
+++ b/code/rtkUpsampleImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkUpsampleImageFilter_h
-#define __rtkUpsampleImageFilter_h
+#ifndef rtkUpsampleImageFilter_h
+#define rtkUpsampleImageFilter_h
 
 #include "itkImageToImageFilter.h"
 

--- a/code/rtkVarianObiGeometryReader.h
+++ b/code/rtkVarianObiGeometryReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkVarianObiGeometryReader_h
-#define __rtkVarianObiGeometryReader_h
+#ifndef rtkVarianObiGeometryReader_h
+#define rtkVarianObiGeometryReader_h
 
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"

--- a/code/rtkVarianObiRawImageFilter.h
+++ b/code/rtkVarianObiRawImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkVarianObiRawImageFilter_h
-#define __rtkVarianObiRawImageFilter_h
+#ifndef rtkVarianObiRawImageFilter_h
+#define rtkVarianObiRawImageFilter_h
 
 #include <itkUnaryFunctorImageFilter.h>
 #include <itkConceptChecking.h>

--- a/code/rtkVarianObiXMLFileReader.h
+++ b/code/rtkVarianObiXMLFileReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkVarianObiXMLFileReader_h
-#define __rtkVarianObiXMLFileReader_h
+#ifndef rtkVarianObiXMLFileReader_h
+#define rtkVarianObiXMLFileReader_h
 
 #ifdef _MSC_VER
 #pragma warning ( disable : 4786 )

--- a/code/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/code/rtkWarpFourDToProjectionStackImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkWarpFourDToProjectionStackImageFilter_h
-#define __rtkWarpFourDToProjectionStackImageFilter_h
+#ifndef rtkWarpFourDToProjectionStackImageFilter_h
+#define rtkWarpFourDToProjectionStackImageFilter_h
 
 #include "rtkFourDToProjectionStackImageFilter.h"
 #include "rtkCyclicDeformationImageFilter.h"

--- a/code/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/code/rtkWarpProjectionStackToFourDImageFilter.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkWarpProjectionStackToFourDImageFilter_h
-#define __rtkWarpProjectionStackToFourDImageFilter_h
+#ifndef rtkWarpProjectionStackToFourDImageFilter_h
+#define rtkWarpProjectionStackToFourDImageFilter_h
 
 #include "rtkCyclicDeformationImageFilter.h"
 #include "rtkProjectionStackToFourDImageFilter.h"

--- a/code/rtkWarpSequenceImageFilter.h
+++ b/code/rtkWarpSequenceImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkWarpSequenceImageFilter_h
-#define __rtkWarpSequenceImageFilter_h
+#ifndef rtkWarpSequenceImageFilter_h
+#define rtkWarpSequenceImageFilter_h
 
 #include "rtkConstantImageSource.h"
 

--- a/code/rtkWatcherForTimer.h
+++ b/code/rtkWatcherForTimer.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkWatcherForTimer_h
-#define __rtkWatcherForTimer_h
+#ifndef rtkWatcherForTimer_h
+#define rtkWatcherForTimer_h
 
 #include "itkCommand.h"
 #include "itkProcessObject.h"

--- a/code/rtkWaterPrecorrectionImageFilter.h
+++ b/code/rtkWaterPrecorrectionImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkWaterPrecorrectionImageFilter_h
-#define __rtkWaterPrecorrectionImageFilter_h
+#ifndef rtkWaterPrecorrectionImageFilter_h
+#define rtkWaterPrecorrectionImageFilter_h
 
 #include <vector>
 #include <itkInPlaceImageFilter.h>

--- a/code/rtkWin32Header.h
+++ b/code/rtkWin32Header.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef __rtkWin32Header_h
-#define __rtkWin32Header_h
+#ifndef rtkWin32Header_h
+#define rtkWin32Header_h
 
 #include "rtkConfiguration.h"
 

--- a/code/rtkXRadGeometryReader.h
+++ b/code/rtkXRadGeometryReader.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkXRadGeometryReader_h
-#define __rtkXRadGeometryReader_h
+#ifndef rtkXRadGeometryReader_h
+#define rtkXRadGeometryReader_h
 
 #include <itkLightProcessObject.h>
 #include "rtkReg23ProjectionGeometry.h"

--- a/code/rtkXRadImageIO.h
+++ b/code/rtkXRadImageIO.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkXRadImageIO_h
-#define __rtkXRadImageIO_h
+#ifndef rtkXRadImageIO_h
+#define rtkXRadImageIO_h
 
 #include <itkImageIOBase.h>
 #include <fstream>

--- a/code/rtkXRadImageIOFactory.h
+++ b/code/rtkXRadImageIOFactory.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkXRadImageIOFactory_h
-#define __rtkXRadImageIOFactory_h
+#ifndef rtkXRadImageIOFactory_h
+#define rtkXRadImageIOFactory_h
 
 #include "rtkWin32Header.h"
 #include "rtkXRadImageIO.h"

--- a/code/rtkXRadRawToAttenuationImageFilter.h
+++ b/code/rtkXRadRawToAttenuationImageFilter.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkXRadRawToAttenuationImageFilter_h
-#define __rtkXRadRawToAttenuationImageFilter_h
+#ifndef rtkXRadRawToAttenuationImageFilter_h
+#define rtkXRadRawToAttenuationImageFilter_h
 
 #include <itkImageToImageFilter.h>
 #include "rtkConfiguration.h"

--- a/testing/rtkTest.h
+++ b/testing/rtkTest.h
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#ifndef __rtkTest_h
-#define __rtkTest_h
+#ifndef rtkTest_h
+#define rtkTest_h
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageFileWriter.h>
@@ -323,4 +323,4 @@ void CheckScalarProducts(typename TImage1::Pointer im1A,
 }
 #endif
 
-#endif //__rtkTest_h
+#endif //rtkTest_h


### PR DESCRIPTION
Instead of __rtkFoo_h now expect rtkFoo_h

Double underscore prefixes are reserved in C++ and so should not be used.
Fixes new clang warning -Wreserved-id-macro.

find . ( -iname _.h -and ! -path *utilities_ ) -exec perl -pi -w -e 's/__rtk(.*)_h/rtk$1_h/g;' {} \;

This brings RTK into compliance with ITK standards introduced Dec 15, 2014 by ITK.
This also conforms to best practices where double
underscores "__" are reserved for compiler reserved id macros.
