### PR TITLE
Update rtkHisImageIO.cxx

### DIFF
--- a/code/rtkHisImageIO.cxx
+++ b/code/rtkHisImageIO.cxx
@@ -38,8 +38,8 @@ void rtk::HisImageIO::ReadImageInformation()
                              << m_FileName);
 
   // read header
-  char header[HEADER_INFO_SIZE];
-  file.read(header, HEADER_INFO_SIZE);
+  unsigned char header[HEADER_INFO_SIZE];
+  file.read((char*)header, HEADER_INFO_SIZE);
 
   if (header[0]!=0 || header[1]!=112 || header[2]!=68 || header[3]!=0) {
     itkExceptionMacro(<< "rtk::HisImageIO::ReadImageInformation: file "


### PR DESCRIPTION
Change header to `unsigned char` array.

When header bytes are read as `signed char`, a bounding rectangle size of, for example, 128 is cast to -128, and leads to errors when subsequently attempting to define an image with negative dimensions.

N.b. I think real .his format images from an Elekta XVI system would never have sizes of 128x128 pixels.
However, I discovered this problem when simulating Elekta XVI projection images and attempting to use rtkfdk to reconstruct projections that are not the standard size of 512x512.

The proposed change has no negative impact on the reconstruction of standard .his images produced by a real XVI system.
