### PR TITLE
Cuda FFT convolution: avoid recreating kernel FFT each time

### DIFF
--- a/code/rtkCudaFFTConvolutionImageFilter.h
+++ b/code/rtkCudaFFTConvolutionImageFilter.h
@@ -76,9 +76,7 @@ private:
   CudaFFTConvolutionImageFilter(const Self&); // purposely not implemented
   void operator=(const Self&);                // purposely not implemented
 
-  CudaFFTOutputImagePointer m_FftKCUDA;
-  typename Superclass::FFTOutputImageType::SizeType m_currentPaddedSize;
-
+  CudaFFTOutputImagePointer m_KernelFFTCUDA;
 }; // end of class
 
 } // end namespace rtk

--- a/code/rtkCudaFFTConvolutionImageFilter.h
+++ b/code/rtkCudaFFTConvolutionImageFilter.h
@@ -76,7 +76,8 @@ private:
   CudaFFTConvolutionImageFilter(const Self&); // purposely not implemented
   void operator=(const Self&);                // purposely not implemented
 
-  CudaFFTOutputImagePointer m_fftKCUDA;
+  CudaFFTOutputImagePointer m_FftKCUDA;
+  typename Superclass::FFTOutputImageType::SizeType m_currentPaddedSize;
 
 }; // end of class
 

--- a/code/rtkCudaFFTConvolutionImageFilter.h
+++ b/code/rtkCudaFFTConvolutionImageFilter.h
@@ -76,6 +76,8 @@ private:
   CudaFFTConvolutionImageFilter(const Self&); // purposely not implemented
   void operator=(const Self&);                // purposely not implemented
 
+  CudaFFTOutputImagePointer m_fftKCUDA;
+
 }; // end of class
 
 } // end namespace rtk

--- a/code/rtkCudaFFTConvolutionImageFilter.hxx
+++ b/code/rtkCudaFFTConvolutionImageFilter.hxx
@@ -98,24 +98,28 @@ CudaFFTConvolutionImageFilter<TParentImageFilter>
   if(inputDimension.y==1 && inputDimension.z>1) // Troubles cuda 3.2 and 4.0
     std::swap(inputDimension.y, inputDimension.z);
 
-  if(!m_fftKCUDA)
+  // Get FFT ramp kernel. Must be itk::Image because GetFFTConvolutionKernel is not
+  // compatible with itk::CudaImage + ITK 3.20.
+  typename Superclass::FFTOutputImageType::SizeType s = paddedImage->GetLargestPossibleRegion().GetSize();
+
+  if(!m_FftKCUDA || (s[0] != m_currentPaddedSize[0]) || (s[1] != m_currentPaddedSize[1]))
     {
-     // Get FFT ramp kernel. Must be itk::Image because GetFFTConvolutionKernel is not
-     // compatible with itk::CudaImage + ITK 3.20.
-     typename Superclass::FFTOutputImageType::SizeType s = paddedImage->GetLargestPossibleRegion().GetSize();
+
+	 m_currentPaddedSize = s; // Save padded image size
+
      this->UpdateFFTConvolutionKernel(s);
 
      // Create the itk::CudaImage holding the kernel
      typename Superclass::FFTOutputImageType::RegionType kreg = this->m_KernelFFT->GetLargestPossibleRegion();
 
-     m_fftKCUDA = CudaFFTOutputImageType::New();
-     m_fftKCUDA->SetRegions(kreg);
-     m_fftKCUDA->Allocate();
+     m_FftKCUDA = CudaFFTOutputImageType::New();
+     m_FftKCUDA->SetRegions(kreg);
+     m_FftKCUDA->Allocate();
 
      // CUFFT scales by the number of element, correct for it in kernel.
      // Also transfer the kernel from the itk::Image to the itk::CudaImage.
      itk::ImageRegionIterator<typename TParentImageFilter::FFTOutputImageType> itKI(this->m_KernelFFT, kreg);
-     itk::ImageRegionIterator<CudaFFTOutputImageType> itKO(m_fftKCUDA, kreg);
+     itk::ImageRegionIterator<CudaFFTOutputImageType> itKO(m_FftKCUDA, kreg);
      typename TParentImageFilter::FFTPrecisionType invNPixels;
      invNPixels = 1 / double(paddedImage->GetBufferedRegion().GetNumberOfPixels() );
      while(!itKO.IsAtEnd() )
@@ -134,7 +138,7 @@ CudaFFTConvolutionImageFilter<TParentImageFilter>
   CUDA_fft_convolution(inputDimension,
                        kernelDimension,
                        *(float**)(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
-                       *(float2**)(m_fftKCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
+                       *(float2**)(m_FftKCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
 
   // CUDA Cropping and Graft Output
   typedef CudaCropImageFilter CropFilter;

--- a/code/rtkFFTConvolutionImageFilter.h
+++ b/code/rtkFFTConvolutionImageFilter.h
@@ -117,7 +117,7 @@ protected:
   FFTConvolutionImageFilter();
   ~FFTConvolutionImageFilter() ITK_OVERRIDE {}
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
 
   void BeforeThreadedGenerateData() ITK_OVERRIDE;
 

--- a/code/rtkFFTRampImageFilter.h
+++ b/code/rtkFFTRampImageFilter.h
@@ -22,6 +22,7 @@
 #include <itkConceptChecking.h>
 #include "rtkConfiguration.h"
 #include "rtkFFTConvolutionImageFilter.h"
+#include "rtkMacro.h"
 
 // The Set macro is redefined to clear the current FFT kernel when a parameter
 // is modified.

--- a/code/rtkFFTRampImageFilter.h
+++ b/code/rtkFFTRampImageFilter.h
@@ -23,6 +23,24 @@
 #include "rtkConfiguration.h"
 #include "rtkFFTConvolutionImageFilter.h"
 
+// The Set macro is redefined to clear the current FFT kernel when a parameter
+// is modified.
+#undef itkSetMacro
+#define itkSetMacro(name, type)                     \
+  virtual void Set##name (const type _arg)          \
+    {                                               \
+    itkDebugMacro("setting " #name " to " << _arg); \
+CLANG_PRAGMA_PUSH                                   \
+CLANG_SUPPRESS_Wfloat_equal                         \
+    if ( this->m_##name != _arg )                   \
+      {                                             \
+      this->m_##name = _arg;                        \
+      this->Modified();                             \
+      this->m_KernelFFT = ITK_NULLPTR;              \
+      }                                             \
+CLANG_PRAGMA_POP                                    \
+    }
+
 namespace rtk
 {
 
@@ -84,16 +102,7 @@ public:
 
   /** Set/Get the Hann window frequency in Y direction. 0 (default) disables it */
   itkGetConstMacro(HannCutFrequencyY, double);
-  virtual void SetHannCutFrequencyY(const double _arg)
-    {
-    itkDebugMacro("setting HannCutFrequencyY to " << _arg);
-    if ( this->m_HannCutFrequencyY != _arg )
-      {
-      this->m_HannCutFrequencyY = _arg;
-      this->Modified();
-      this->m_KernelDimension = (_arg == 0.)?1:2;
-      }
-    }
+  itkSetMacro(HannCutFrequencyY, double);
 
   /** Set/Get the Ram-Lak window frequency (0...1). 0 (default) disable it.
    * Equation and further explanation about Ram-Lak filter could be found in:
@@ -119,6 +128,8 @@ protected:
   FFTRampImageFilter();
   ~FFTRampImageFilter() ITK_OVERRIDE {}
 
+  virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
+
   /** Creates and return a pointer to one line of the ramp kernel in Fourier space.
    *  Used in generate data functions.  */
   void UpdateFFTConvolutionKernel(const SizeType size) ITK_OVERRIDE;
@@ -140,6 +151,8 @@ private:
     */
   double m_RamLakCutFrequency;
   double m_SheppLoganCutFrequency;
+
+  SizeType m_PreviousKernelUpdateSize;
 }; // end of class
 
 } // end namespace rtk
@@ -147,5 +160,21 @@ private:
 #ifndef ITK_MANUAL_INSTANTIATION
 #include "rtkFFTRampImageFilter.hxx"
 #endif
+
+// Rollback to the original definition of the Set macro
+#undef itkSetMacro
+#define itkSetMacro(name, type)                     \
+  virtual void Set##name (const type _arg)          \
+    {                                               \
+    itkDebugMacro("setting " #name " to " << _arg); \
+CLANG_PRAGMA_PUSH                                   \
+CLANG_SUPPRESS_Wfloat_equal                         \
+    if ( this->m_##name != _arg )                   \
+      {                                             \
+      this->m_##name = _arg;                        \
+      this->Modified();                             \
+      }                                             \
+CLANG_PRAGMA_POP                                    \
+    }
 
 #endif

--- a/code/rtkFFTRampImageFilter.hxx
+++ b/code/rtkFFTRampImageFilter.hxx
@@ -42,11 +42,26 @@ FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 }
 
+template <class TInputImage, class TOutputImage, class TFFTPrecision>
+void
+FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
+::GenerateInputRequestedRegion()
+{
+  this->m_KernelDimension = (m_HannCutFrequencyY == 0.)?1:2;
+  Superclass::GenerateInputRequestedRegion();
+}
+
 template<class TInputImage, class TOutputImage, class TFFTPrecision>
 void
 FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 ::UpdateFFTConvolutionKernel(const SizeType s)
 {
+  if(this->m_KernelFFT.GetPointer() != ITK_NULLPTR && s == this->m_PreviousKernelUpdateSize)
+    {
+    return;
+    }
+  m_PreviousKernelUpdateSize = s;
+
   const int width = s[0];
   const int height = s[1];
 

--- a/code/rtkMacro.h
+++ b/code/rtkMacro.h
@@ -25,6 +25,23 @@
 #include "rtkGgoArgsInfoManager.h"
 
 //--------------------------------------------------------------------
+#ifndef CLANG_PRAGMA_PUSH
+#define ITK_PRAGMA(x) _Pragma (#x)
+#if defined(__clang__) && defined(__has_warning)
+#define CLANG_PRAGMA_PUSH ITK_PRAGMA(clang diagnostic push)
+#define CLANG_PRAGMA_POP  ITK_PRAGMA(clang diagnostic pop)
+# if __has_warning("-Wfloat-equal")
+#define CLANG_SUPPRESS_Wfloat_equal ITK_PRAGMA( clang diagnostic ignored "-Wfloat-equal" )
+# endif
+#else
+#define CLANG_PRAGMA_PUSH
+#define CLANG_PRAGMA_POP
+#define CLANG_SUPPRESS_Wfloat_equal
+#endif
+#endif
+//--------------------------------------------------------------------
+
+//--------------------------------------------------------------------
 #ifndef ITK_NULLPTR
 # define ITK_NULLPTR NULL
 #endif


### PR DESCRIPTION
First implementation. 

We need to check that the image size has not changed