### PR TITLE
Fixed bug in rtkCudaRayCastBackProjectionImageFilter

### DIFF
--- a/code/rtkCudaRayCastBackProjectionImageFilter.cxx
+++ b/code/rtkCudaRayCastBackProjectionImageFilter.cxx
@@ -174,6 +174,9 @@ CudaRayCastBackProjectionImageFilter
                         boxMax,
                         spacing,
                         m_Normalize);
+
+    // Re-use the output as input
+    pin = pout;
     }
 
   delete[] translatedProjectionIndexTransformMatrices;


### PR DESCRIPTION
Fixed an unitialized global memory issue, which led to finding a real bug rtkCudaRayCastBackProjectionImageFilter. Might solve the few dashboard issues related to cudaraycast tests