### PR TITLE
rtkdualenergyforwardmodel writes variances

### DIFF
--- a/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
+++ b/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
@@ -120,6 +120,7 @@ int main(int argc, char * argv[])
   forward->SetDetectorResponse(detectorImage);
   forward->SetMaterialAttenuations(materialAttenuationsReader->GetOutput());
   forward->SetIsSpectralCT(false);
+  forward->SetComputeVariances(args_info.variances_given);
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(forward->Update())
 
@@ -128,6 +129,14 @@ int main(int argc, char * argv[])
   writer->SetInput(forward->GetOutput());
   writer->SetFileName(args_info.output_arg);
   writer->Update();
+
+  // If requested, write the variances
+  if (args_info.variances_given)
+    {
+    writer->SetInput(forward->GetOutput(1));
+    writer->SetFileName(args_info.variances_arg);
+    writer->Update();
+    }
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.ggo
+++ b/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.ggo
@@ -9,3 +9,4 @@ option "high"       - "Incident spectrum image, high energy"                    
 option "low"        - "Incident spectrum image, low energy"                               string                       yes
 option "detector"   d "Detector response file"                                            string                       no
 option "attenuations" a "Material attenuations file"                                      string                       yes
+option "variances"  - "Output variances of measured energies, file name"                  string                       no

--- a/code/rtkProjectionsDecompositionNegativeLogLikelihood.h
+++ b/code/rtkProjectionsDecompositionNegativeLogLikelihood.h
@@ -182,6 +182,14 @@ public:
   return logTransforms;
   }
 
+  virtual vnl_vector<double>  GetVariances( const ParametersType & lineIntegrals ) const
+  {
+  vnl_vector<double> meaninglessResult;
+  meaninglessResult.set_size(m_NumberOfSpectralBins);
+  meaninglessResult.fill(0.);
+  return(meaninglessResult);
+  }
+
   itkSetMacro(MeasuredData, MeasuredDataType)
   itkGetMacro(MeasuredData, MeasuredDataType)
 

--- a/code/rtkSpectralForwardModelImageFilter.h
+++ b/code/rtkSpectralForwardModelImageFilter.h
@@ -107,9 +107,17 @@ public:
   itkSetMacro(IsSpectralCT, bool)
   itkGetMacro(IsSpectralCT, bool)
 
+  itkSetMacro(ComputeVariances, bool)
+  itkGetMacro(ComputeVariances, bool)
+
 protected:
   SpectralForwardModelImageFilter();
   ~SpectralForwardModelImageFilter() {}
+
+  /**  Create the Output */
+  typedef itk::ProcessObject::DataObjectPointerArraySizeType DataObjectPointerArraySizeType;
+  using Superclass::MakeOutput;
+  itk::DataObject::Pointer MakeOutput(DataObjectPointerArraySizeType idx) ITK_OVERRIDE;
 
   void GenerateOutputInformation() ITK_OVERRIDE;
 
@@ -134,6 +142,7 @@ protected:
   unsigned int m_NumberOfMaterials;
   bool         m_OptimizeWithRestarts;
   bool         m_IsSpectralCT; // If not, it is dual energy CT
+  bool         m_ComputeVariances; // Only implemented for dual energy CT
 
 private:
   //purposely not implemented


### PR DESCRIPTION
Added an option to write the variances of the distributions generated by rtkdualenergyforwardmodel (the means are the result written in the first output)