### PR TITLE
Setup style hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+.git*            export-ignore
+
+*.c              whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
+*.h              whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
+*.cxx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
+*.hxx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
+*.txx            whitespace=tab-in-indent,no-lf-at-eof  hooks.style=KWStyle,uncrustify
+*.txt            whitespace=tab-in-indent,no-lf-at-eof
+*.cmake          whitespace=tab-in-indent,no-lf-at-eof
+
+# ExternalData content links must have LF newlines
+*.md5            crlf=input

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Do not add ExternalData module staging files
+.ExternalData*
+
+# back-up files
+*~
+*.bak
+# vim swp files
+*.swp
+## Ignore files that are used for auto_completion with clang
+*.clang_complete
+## YouCompleteMe vim plugin configuration file
+.ycm_extra_conf.py
+
+
+# KWStyle hook output
+*.kws
+
+# compiled python files
+*.pyc
+
+# Binary directory
+BUILD*
+build*
+
+# qtcreator
+CMakeLists.txt.user*
+
+# kdevelop
+*.kdev*
+.kdev*
+
+# back-up files when conflicts occur
+*.orig
+
+# Clion editor internal project information
+.idea
+
+# Mac System File
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,27 @@ if ((${_index} EQUAL -1) AND RTK_WRAP_PYTHON)
     turn off python wrapping by setting RTK_WRAP_PYTHON:BOOL=OFF")
 endif()
 
+# --------------------------------------------------------
+# Setup KWStyle from ITK
+if(ITK_USE_KWSTYLE)
+  set( KWStyle_DIR ${CMAKE_BINARY_DIR}/KWStyle-build )
+  set( KWSTYLE_EXECUTABLE ${KWStyle_DIR}/KWStyle)
+
+  set(WORKING_DIR "")
+  if(ITK_SOURCE_DIR)
+    set(WORKING_DIR "${ITK_SOURCE_DIR}")
+  else()
+    set(WORKING_DIR "${CMAKE_SOURCE_DIR}")
+  endif()
+
+  find_package( Git )
+  if(GIT_FOUND AND EXISTS "${WORKING_DIR}/.git/config")
+    execute_process( COMMAND ${GIT_EXECUTABLE} config hooks.KWStyle.path
+      "${KWSTYLE_EXECUTABLE}"
+      WORKING_DIRECTORY ${WORKING_DIR} )
+  endif()
+endif()
+
 #=========================================================
 # ITKCudaCommon
 #=========================================================

--- a/cmake/Hooks/SetupHooks.sh
+++ b/cmake/Hooks/SetupHooks.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+
+# Run this script to set up the git hooks for committing changes to ITK.
+# For more information, see:
+#   https://www.itk.org/Wiki/ITK/Git#Hooks
+#   https://www.itk.org/Wiki/Git/Hooks
+
+egrep-q() {
+  egrep "$@" >/dev/null 2>/dev/null
+}
+
+die() {
+  echo 'failure during hook setup' 1>&2
+  echo '-------------------------' 1>&2
+  echo '' 1>&2
+  echo "$@" 1>&2
+  exit 1
+}
+
+if test -z "$GIT_DIR"; then
+  export GIT_DIR=$(git rev-parse --git-dir)
+fi
+
+u=$(git rev-parse --git-dir)
+cd "$u/hooks"
+
+# We need to have a git repository to do a pull.
+if ! test -d ./.git; then
+  git init || die "Could not run git init."
+fi
+
+# Grab the hooks.
+# Use the local hooks if possible.
+echo "Pulling the hooks..."
+remote_hooks="https://github.com/SimonRit/RTK.git hooks"
+if GIT_DIR=.. git for-each-ref refs/remotes/origin/hooks 2>/dev/null | \
+  egrep-q 'refs/remotes/origin/hooks$'; then
+  git fetch .. remotes/origin/hooks ||  \
+  echo "Couldn't use local hooks. Using remote..."
+  git fetch $remote_hooks
+else
+  git fetch $remote_hooks
+fi &&
+
+git reset --hard FETCH_HEAD -- || die "Failed to install hooks"
+cd ../..
+
+# Disable the 'hooks' branch submodule check.
+# We have a check that blocks addition of submodules.
+#git config hooks.submodule false
+
+# Set up KWStyle hook.
+echo "Setting up the KWStyle hook..."
+git config hooks.KWStyle.conf "cmake/KWStyle/RTK.kws.xml"
+git config hooks.KWStyle.overwriteRulesConf "cmake/KWStyle/RTKOverwrite.txt"
+git config hooks.KWStyle true
+
+echo "Done."

--- a/cmake/Hooks/pre-commit-style.bash
+++ b/cmake/Hooks/pre-commit-style.bash
@@ -1,0 +1,162 @@
+#!/bin/bash
+#=============================================================================
+# Copyright 2010-2011 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Run KWStyle pre-commit hooks.
+#
+# 'git config' is used to enable the hooks and set their configuration files.
+# The repository .gitattributes must also enable the hooks on the targeted
+# files.
+
+die() {
+  echo 'failure during hook setup' 1>&2
+  echo '-------------------------' 1>&2
+  echo '' 1>&2
+  echo "$@" 1>&2
+  exit 1
+}
+
+do_KWStyle=$(git config --bool hooks.KWStyle) || do_KWStyle=false
+
+if [ "$(uname)" = "Darwin" ]; then
+    console="</dev/tty" # MacOSX
+elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
+    console="</dev/tty" # Linuxes
+else
+    echo "uname: "$(uname -a)
+    console="" # Windows (Msys, MinGW, Cygwin etc)
+fi
+
+#-----------------------------------------------------------------------------
+# Check if we want to run the style on a given file.  Uses git attributes.  If
+# the hook.style attribute is set, then all styles are executed.  If the
+# hook.style attribute is set to a value, only the values given are executed.
+# Also, do not run the style check if there are unstaged changes in the file.
+# The first positional parameter is the file to check.
+# The second positional parameter is the style to check.
+# Returns 0 for execute, 1 for don't execute.
+run_style_on_file() {
+  # Do not run on submodule changes.
+  if git diff-index --cached HEAD -- "$1" | grep -q '^:...... 160000'; then
+    return 1
+  fi
+  if ! git diff-files --quiet -- "$1"; then
+    # A way to always allow skipping.
+    skip_unstaged=$(git config --bool hooks.styleSkipUnstaged) ||
+    skip_unstaged=false
+    file_sha=$(git diff-index --cached --abbrev=7 HEAD -- "$1" | \
+    awk '{print substr($3,1,9) substr($4,1,7)}')
+    if file_skip_unstaged=$(git config "hooks.$1.styleSkipUnstaged"); then
+      if test ",$file_skip_unstaged," = ",$file_sha," -o \
+        ",$file_skip_unstaged," = ",true,"; then
+        skip_unstaged=true
+      fi
+    fi
+
+    if $skip_unstaged; then
+      echo "The file '$1' contains unstaged stages.  Skipping style \
+check '$2'."
+    else
+      die "Style check '$2' cannot run on '$1' with unstaged stages.
+
+Allow skipping the style check for this commit with
+
+  git config \"hooks.$1.styleSkipUnstaged\" $file_sha"
+    fi
+    return 1
+  fi
+  style=$(git check-attr hooks.style -- "$1" |
+      sed 's/^[^:]*: hooks.style: //')
+  case "$style" in
+    'unset')        return 1 ;;
+    'set')          return 0 ;;
+    'unspecified')  return 1 ;;
+    *)              echo ",$style," | grep -iq ",$2," && return 0 ;;
+  esac
+  return 1
+}
+
+#-----------------------------------------------------------------------------
+# KWStyle.
+check_for_KWStyle() {
+  KWStyle_path=$(git config hooks.KWStyle.path) ||
+  KWStyle_path=$(which KWStyle)
+  if [ $? != 0 ] ; then
+    echo "KWStyle executable was not found.
+
+  No style verification will be performed with KWStyle!
+
+Please install KWStyle or set the executable location with
+
+  git config hooks.KWStyle.path /path/to/KWStyle
+
+See https://kitware.github.io/KWStyle/
+" >&2
+    return 1
+  fi
+  KWStyle_conf=$(git config hooks.KWStyle.conf)
+  if ! test -f "$KWStyle_conf"; then
+    die "The file '$KWStyle_conf' does not exist.
+
+Please run
+
+  git config hooks.KWStyle.conf path/to/KWStyle.conf.xml"
+  fi
+  KWStyle_overWriteRulesConf=$(git config hooks.KWStyle.overwriteRulesConf)
+  if test $? -eq 0 && ! test -f "$KWStyle_overWriteRulesConf"; then
+    die "The hooks.KWStyle.overwriteRulesConf file '$KWStyle_overWriteRulesConf' does not exist."
+  fi
+}
+
+run_KWStyle_on_file() {
+  local_KWStyle_overWriteRulesConf="`pwd`/${1%/*}/../ITKKWStyleOverwrite.txt"
+  if test -f "$local_KWStyle_overWriteRulesConf"; then
+    "$KWStyle_path" -gcc -xml "$KWStyle_conf" -o "$local_KWStyle_overWriteRulesConf" "$1"
+  elif test -z "$KWStyle_overWriteRulesConf"; then
+    "$KWStyle_path" -gcc -xml "$KWStyle_conf" "$1"
+  else
+    echo "$KWStyle_overWriteRulesConf"
+    "$KWStyle_path" -gcc -xml "$KWStyle_conf" -o "$KWStyle_overWriteRulesConf" "$1"
+  fi
+
+  if test $? -ne 0; then
+    cp -- "$1" "$1".kws
+    die "KWStyle check failed.
+
+Line numbers in the errors shown refer to the file:
+${1}.kws"
+  fi
+}
+
+run_KWStyle() {
+  git diff-index --cached --diff-filter=ACMR --name-only HEAD -- |
+  while read f; do
+    if run_style_on_file "$f" KWStyle; then
+      run_KWStyle_on_file "$f"
+    fi || return
+  done
+}
+
+# Do not run during merge commits for now.
+if test -f "$GIT_DIR/MERGE_HEAD"; then
+  :
+elif $do_KWStyle; then
+  if check_for_KWStyle; then
+    run_KWStyle || exit 1
+  fi
+fi
+
+# vim: set filetype=sh tabstop=8 softtabstop=8 shiftwidth=8 noexpandtab :

--- a/cmake/KWStyle/RTK.kws.xml
+++ b/cmake/KWStyle/RTK.kws.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<Description>
+<LineLength>200</LineLength>
+<DeclarationOrder>0,1,2</DeclarationOrder>
+<Typedefs>[A-Z]</Typedefs>
+<InternalVariables>m_[A-Z]</InternalVariables>
+<SemicolonSpace>0</SemicolonSpace>
+<EndOfFileNewLine>1</EndOfFileNewLine>
+<Tabs>1</Tabs>
+<Spaces>3</Spaces>
+<Comments>/**, *, */,true</Comments>
+<Namespace>rtk</Namespace>
+<NameOfClass>[NameOfClass],rtk</NameOfClass>
+<IfNDefDefine>[NameOfClass]_[Extension]</IfNDefDefine>
+<EmptyLines>2</EmptyLines>
+<Template>[TNV]</Template>
+<Operator>1,1</Operator>
+<Header>cmake/KWStyle/RTKHeader.h,false,true</Header>
+</Description>

--- a/cmake/KWStyle/RTKOverwrite.txt
+++ b/cmake/KWStyle/RTKOverwrite.txt
@@ -1,0 +1,2 @@
+test/.*\.cxx Namespace Disable
+examples/.*\.cxx Namespace Disable


### PR DESCRIPTION
Add git hooks to check for basic style rules on every new commit.
This feature is disabled by default. To enable it run the SetupHooks.sh
script from any directory.
It will download the hooks scripts that are stored on the "hooks"
branch of the project. To add new hooks, just push the corresponding
executable hook script on that branch. (e.g. pre-push)
This commit only adds a pre-commit hook. It is run when "git commit" is
called and will run on every file specified in the .gitattributes file.
It internally calls pre-commit-style.bash to setup KWStyle checks.
RTK.kws.xml is added to specify KWStyle rules.
RTKOverwrite.txt is added to specify exception rules.
KWStyle generates temporary files for failing checks, thus we add a
.gitignore file to avoid commiting temporary files that are
in the source directory.