### PR TITLE
Change type for ITK version > 4.13rc02

### DIFF
--- a/code/rtkForwardWarpImageFilter.hxx
+++ b/code/rtkForwardWarpImageFilter.hxx
@@ -47,7 +47,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
 ::Protected_EvaluateDisplacementAtPhysicalPoint(const PointType & point, DisplacementType &output)
 {
 
-  DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
+  const DisplacementFieldType *fieldPtr = this->GetDisplacementField();
 
   itk::ContinuousIndex< double, TDVF::ImageDimension > index;
   fieldPtr->TransformPhysicalPointToContinuousIndex(point, index);
@@ -141,7 +141,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
 ::GenerateData()
 {
   Superclass::BeforeThreadedGenerateData();
-  DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
+  const DisplacementFieldType *fieldPtr = this->GetDisplacementField();
 
   // Connect input image to interpolator
   m_Protected_StartIndex = fieldPtr->GetBufferedRegion().GetIndex();
@@ -168,7 +168,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
   // iterator for the output image
   itk::ImageRegionConstIteratorWithIndex< TOutputImage > inputIt(
         inputPtr, inputPtr->GetBufferedRegion());
-  itk::ImageRegionIterator< DisplacementFieldType >  fieldIt(fieldPtr, fieldPtr->GetBufferedRegion());
+  itk::ImageRegionConstIterator< DisplacementFieldType >  fieldIt(fieldPtr, fieldPtr->GetBufferedRegion());
   typename TOutputImage::IndexType        index;
   typename TOutputImage::IndexType        baseIndex;
   typename TOutputImage::IndexType        neighIndex;


### PR DESCRIPTION
After the following commit in ITK:
https://github.com/InsightSoftwareConsortium/ITK/commit/0070848b91baf69f04893bc3ce85bcf110c3c63a#diff-e8fadb5e8b4526fd0833193b3d7ff4d3R153
The output type of GetDisplacementField is not correct anymore, it changed from DisplacementFieldPointer to const DisplacementFieldType*.