### PR TITLE
Add missing include for ThreadIdType

### DIFF
--- a/include/rtkEdfRawToAttenuationImageFilter.h
+++ b/include/rtkEdfRawToAttenuationImageFilter.h
@@ -22,6 +22,8 @@
 #include <itkImageToImageFilter.h>
 #include <itkImageSeriesReader.h>
 
+#include "rtkConfiguration.h"
+
 namespace rtk
 {
 


### PR DESCRIPTION
include rtkConfiguration.h to fix recurrent errors on
RTKHeaderTest. Depending on the files order, the test can
fail with undefined type ThreadIdType. Including rtkConfiguration to define ThreadIdType.