### PR TITLE
Fix pre-commit-style.bash path for hooks

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -89,7 +89,7 @@ fi
 
 #-----------------------------------------------------------------------------
 # Style hooks.
-. "$GIT_DIR/../utilities/Hooks/pre-commit-style.bash"
+. "$GIT_DIR/../cmake/Hooks/pre-commit-style.bash"
 
 #-----------------------------------------------------------------------------
 # Builtin whitespace checks.


### PR DESCRIPTION
@SimonRit Fixing a typo in the pre-commit file
(I am still unable to open pull requests with my own hooks branch. This is why I went through this online editor )