### PR TITLE
COMP: Fixed logic to support ITKv5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,10 +172,10 @@ endif()
 list(APPEND RTK_INCLUDE_DIRS "${PROJECT_BINARY_DIR}")
 include_directories(${RTK_INCLUDE_DIRS})
 
-if(ITK_VERSION_MINOR LESS "4")
+if(ITK_VERSION LESS "4.4")
   include_directories(BEFORE utilities/itkImageScanlineConstIterator)
 endif()
-if(ITK_VERSION_MINOR LESS "5")
+if(ITK_VERSION LESS "4.5")
   include_directories(BEFORE utilities/itkBinShrinkImageFilter)
 endif()
 


### PR DESCRIPTION
With ITK version 5.0.0 the ITK_VERSION_MINOR was 0, thus
causing the logic to fail.