### PR TITLE
FIX: RTK did not build with ITK 4.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,10 +172,10 @@ endif()
 list(APPEND RTK_INCLUDE_DIRS "${PROJECT_BINARY_DIR}")
 include_directories(${RTK_INCLUDE_DIRS})
 
-if(ITK_VERSION LESS "4.4")
+if(ITK_VERSION VERSION_LESS "4.4")
   include_directories(BEFORE utilities/itkImageScanlineConstIterator)
 endif()
-if(ITK_VERSION LESS "4.5")
+if(ITK_VERSION VERSION_LESS "4.5")
   include_directories(BEFORE utilities/itkBinShrinkImageFilter)
 endif()
 


### PR DESCRIPTION
Build threw a couple of errors when using CMAKE 3.8.1 since utilities from ITK where included multiple times.

fixed: LESS --> VERSION_LESS