### PR TITLE
Prepare for itkv5

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -24,9 +24,10 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${RTK_INSTALL_LIB_DIR}")
 #-----------------------------------------------------------------------------
 # Find ITK.
 # Required to include ITK_USE_FILE in order to Register IO factories
+# Force requested modules to be RTK dependencies only, otherwise all
+# available factories will try to register themselves.
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED)
-  set(ITK_MODULES_REQUESTED ${ITK_MODULE_RTK_DEPENDS})
+  find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
   include(${ITK_USE_FILE})
 endif()
 #-----------------------------------------------------------------------------

--- a/include/rtkForwardWarpImageFilter.hxx
+++ b/include/rtkForwardWarpImageFilter.hxx
@@ -47,7 +47,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
 ::Protected_EvaluateDisplacementAtPhysicalPoint(const PointType & point, DisplacementType &output)
 {
 
-  DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
+  const DisplacementFieldType* fieldPtr = this->GetDisplacementField();
 
   itk::ContinuousIndex< double, TDVF::ImageDimension > index;
   fieldPtr->TransformPhysicalPointToContinuousIndex(point, index);
@@ -141,7 +141,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
 ::GenerateData()
 {
   Superclass::BeforeThreadedGenerateData();
-  DisplacementFieldPointer fieldPtr = this->GetDisplacementField();
+  const DisplacementFieldType* fieldPtr = this->GetDisplacementField();
 
   // Connect input image to interpolator
   m_Protected_StartIndex = fieldPtr->GetBufferedRegion().GetIndex();
@@ -168,7 +168,7 @@ ForwardWarpImageFilter<TInputImage, TOutputImage, TDVF>
   // iterator for the output image
   itk::ImageRegionConstIteratorWithIndex< TOutputImage > inputIt(
         inputPtr, inputPtr->GetBufferedRegion());
-  itk::ImageRegionIterator< DisplacementFieldType >  fieldIt(fieldPtr, fieldPtr->GetBufferedRegion());
+  itk::ImageRegionIterator< const DisplacementFieldType >  fieldIt(fieldPtr, fieldPtr->GetBufferedRegion());
   typename TOutputImage::IndexType        index;
   typename TOutputImage::IndexType        baseIndex;
   typename TOutputImage::IndexType        neighIndex;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,10 +12,10 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/rtkTestConfiguration.h.in
 #-----------------------------------------------------------------------------
 # Find ITK.
 # Required to include ITK_USE_FILE in order to Register IO factories
-# Force requested modules to be RTK dependencies only.
+# Force requested modules to be RTK dependencies only, otherwise all
+# available factories will try to register themselves.
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED)
-  set(ITK_MODULES_REQUESTED ${ITK_MODULE_RTK_DEPENDS})
+  find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
   include(${ITK_USE_FILE})
 endif()
 


### PR DESCRIPTION
Fix for recent changes in ITK.
The ITK Docker image "module-ci/latest" has been recently uptaded, resulting in RTK failing to build on CircleCI. This PR is fixing the build process with this new version of ITK, and is backward compatible.


