### PR TITLE
SimpleRTK with Cuda

### DIFF
--- a/utilities/ITKCudaCommon/include/itkCudaImageDataManager.h
+++ b/utilities/ITKCudaCommon/include/itkCudaImageDataManager.h
@@ -29,8 +29,6 @@
 
 namespace itk
 {
-template < class TPixel, unsigned int NDimension > class CudaImage;
-
 /**
  * \class CudaImageDataManager
  *
@@ -44,7 +42,6 @@ class ITK_EXPORT CudaImageDataManager : public CudaDataManager
 {
   // allow CudaKernelManager to access Cuda buffer pointer
   friend class CudaKernelManager;
-  friend class CudaImage< typename ImageType::PixelType, ImageType::ImageDimension >;
 
 public:
   typedef CudaImageDataManager      Self;
@@ -52,10 +49,12 @@ public:
   typedef SmartPointer<Self>        Pointer;
   typedef SmartPointer<const Self>  ConstPointer;
 
+  typedef typename ImageType::RegionType RegionType;
+  typedef typename ImageType::IndexType  IndexType;
+  typedef typename ImageType::SizeType   SizeType;
+
   itkNewMacro(Self);
   itkTypeMacro(CudaImageDataManager, CudaDataManager);
-
-  static const unsigned int ImageDimension = ImageType::ImageDimension;
 
   itkGetObjectMacro(GPUBufferedRegionIndex, CudaDataManager);
   itkGetObjectMacro(GPUBufferedRegionSize, CudaDataManager);
@@ -86,8 +85,8 @@ private:
   void operator=(const Self&);
 
   ImageType*                         m_Image;
-  int                                m_BufferedRegionIndex[ImageType::ImageDimension];
-  int                                m_BufferedRegionSize[ImageType::ImageDimension];
+  IndexType                          m_BufferedRegionIndex;
+  SizeType                           m_BufferedRegionSize;
   typename CudaDataManager::Pointer  m_GPUBufferedRegionIndex;
   typename CudaDataManager::Pointer  m_GPUBufferedRegionSize;
 

--- a/utilities/ITKCudaCommon/include/itkCudaImageDataManager.hxx
+++ b/utilities/ITKCudaCommon/include/itkCudaImageDataManager.hxx
@@ -30,28 +30,24 @@ void CudaImageDataManager< ImageType >::SetImagePointer(ImageType* img)
 {
   m_Image = img;
 
-  typedef typename ImageType::RegionType RegionType;
-  typedef typename ImageType::IndexType  IndexType;
-  typedef typename ImageType::SizeType   SizeType;
-
   RegionType region = m_Image->GetBufferedRegion();
   IndexType  index  = region.GetIndex();
   SizeType   size   = region.GetSize();
 
-  for (unsigned int d = 0; d < ImageDimension; d++)
+  for (unsigned int d = 0; d < ImageType::ImageDimension; d++)
     {
     m_BufferedRegionIndex[d] = index[d];
     m_BufferedRegionSize[d] = size[d];
     }
 
   m_GPUBufferedRegionIndex = CudaDataManager::New();
-  m_GPUBufferedRegionIndex->SetBufferSize(sizeof(int) * ImageDimension);
-  m_GPUBufferedRegionIndex->SetCPUBufferPointer(m_BufferedRegionIndex);
+  m_GPUBufferedRegionIndex->SetBufferSize(sizeof(int) * ImageType::ImageDimension);
+  m_GPUBufferedRegionIndex->SetCPUBufferPointer(&m_BufferedRegionIndex);
   m_GPUBufferedRegionIndex->SetGPUBufferDirty();
 
   m_GPUBufferedRegionSize = CudaDataManager::New();
-  m_GPUBufferedRegionSize->SetBufferSize(sizeof(int) * ImageDimension);
-  m_GPUBufferedRegionSize->SetCPUBufferPointer(m_BufferedRegionSize);
+  m_GPUBufferedRegionSize->SetBufferSize(sizeof(int) * ImageType::ImageDimension);
+  m_GPUBufferedRegionSize->SetCPUBufferPointer(&m_BufferedRegionSize);
   m_GPUBufferedRegionSize->SetGPUBufferDirty();
 }
 


### PR DESCRIPTION
When building SimpleRTK with Cuda using Visual Studio, the compiler
fails to interpret the value of ImageType::ImageDimension when used
to initialize an array length.
The fix uses itk's IndexType and SizeType to avoid declaration of
arrays.