### PR TITLE
COMP: Avoid shadowed variables

### DIFF
--- a/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
+++ b/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
@@ -158,8 +158,8 @@ int main(int argc, char *argv[])
     if (first)
       {
       // Initialization of the output volume
-      InputImageType::SizeType    sizeInput = outImage->GetLargestPossibleRegion().GetSize();
-      sizeInput[2] = Nproj;
+      InputImageType::SizeType    sizeInput_local = outImage->GetLargestPossibleRegion().GetSize();
+      sizeInput_local[2] = Nproj;
       InputImageType::SpacingType spacingInput = outImage->GetSpacing();
       InputImageType::PointType   originInput = outImage->GetOrigin();
       InputImageType::DirectionType imageDirection;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
       constantSource->SetOrigin(originInput);
       constantSource->SetSpacing(spacingInput);
       constantSource->SetDirection(imageDirection);
-      constantSource->SetSize(sizeInput);
+      constantSource->SetSize(sizeInput_local);
       constantSource->SetConstant(0.);
       first = false;
       }

--- a/include/rtkFDKBackProjectionImageFilter.hxx
+++ b/include/rtkFDKBackProjectionImageFilter.hxx
@@ -130,17 +130,17 @@ FDKBackProjectionImageFilter<TInputImage,TOutputImage>
         }
 
       // Apply perspective
-      double perspFactor = matrix[Dimension-1][Dimension];
+      double perspFactor_local = matrix[Dimension-1][Dimension];
       for(unsigned int j=0; j<Dimension; j++)
-        perspFactor += matrix[Dimension-1][j] * itOut.GetIndex()[j];
-      perspFactor = 1/perspFactor;
+        perspFactor_local += matrix[Dimension-1][j] * itOut.GetIndex()[j];
+      perspFactor_local = 1/perspFactor_local;
       for(unsigned int i=0; i<Dimension-1; i++)
-        pointProj[i] = pointProj[i]*perspFactor;
+        pointProj[i] = pointProj[i]*perspFactor_local;
 
       // Interpolate if in projection
       if( interpolator->IsInsideBuffer(pointProj) )
         {
-        itOut.Set( itOut.Get() + perspFactor*perspFactor*interpolator->EvaluateAtContinuousIndex(pointProj) );
+        itOut.Set( itOut.Get() + perspFactor_local*perspFactor_local*interpolator->EvaluateAtContinuousIndex(pointProj) );
         }
 
       ++itOut;

--- a/include/rtkFDKWarpBackProjectionImageFilter.hxx
+++ b/include/rtkFDKWarpBackProjectionImageFilter.hxx
@@ -146,17 +146,17 @@ FDKWarpBackProjectionImageFilter<TInputImage,TOutputImage,TDeformation>
         }
 
       // Apply perspective
-      double perspFactor = matrix[Dimension-1][Dimension];
+      double perspFactor_local = matrix[Dimension-1][Dimension];
       for(unsigned int j=0; j<Dimension; j++)
-        perspFactor += matrix[Dimension-1][j] * point[j];
-      perspFactor = 1/perspFactor;
+        perspFactor_local += matrix[Dimension-1][j] * point[j];
+      perspFactor_local = 1/perspFactor_local;
       for(unsigned int i=0; i<Dimension-1; i++)
-        pointProj[i] = pointProj[i]*perspFactor;
+        pointProj[i] = pointProj[i]*perspFactor_local;
 
       // Interpolate if in projection
       if( interpolator->IsInsideBuffer(pointProj) )
         {
-        itOut.Set( itOut.Get() + perspFactor*perspFactor*interpolator->EvaluateAtContinuousIndex(pointProj) );
+        itOut.Set( itOut.Get() + perspFactor_local*perspFactor_local*interpolator->EvaluateAtContinuousIndex(pointProj) );
         }
 
       ++itOut;

--- a/include/rtkUpsampleImageFilter.hxx
+++ b/include/rtkUpsampleImageFilter.hxx
@@ -173,14 +173,14 @@ UpsampleImageFilter<TInputImage,TOutputImage>
       inputLine.SetSize(inputLineSize);
       inputLine.SetIndex(inputStartIndex + inputOffset);
 
-      OutputIterator outIt(outputPtr, outputLine);
+      OutputIterator outIt_local(outputPtr, outputLine);
       InputIterator inIt(inputPtr, inputLine);
 
       // Walk the line and copy the pixels
       while(!inIt.IsAtEnd())
         {
-        outIt.Set(inIt.Get());
-        for (unsigned int i=0; i<m_Factors[0]; i++) ++outIt;
+        outIt_local.Set(inIt.Get());
+        for (unsigned int i=0; i<m_Factors[0]; i++) ++outIt_local;
         ++inIt;
 
         progress.CompletedPixel();


### PR DESCRIPTION
Shadowed variables can make code very difficult to debug.

/RTK/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx:161:35: warning: declaration shadows a local variable [-Wshadow]
/RTK/code/rtkFDKBackProjectionImageFilter.hxx:131:14: warning: declaration shadows a local variable [-Wshadow]
/RTK/code/rtkFDKWarpBackProjectionImageFilter.hxx:147:14: warning: declaration shadows a local variable [-Wshadow]
/RTK/code/rtkUpsampleImageFilter.hxx:176:22: warning: declaration shadows a local variable [-Wshadow]