### PR TITLE
COMP: Prepare for C++11 features in ITKv5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,14 @@
 #=========================================================
 # RTK : Reconstruction Toolkit
 #=========================================================
-cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
-if(WIN32 OR NOT EXISTS /dev/urandom)
-  cmake_minimum_required(VERSION 2.8.5)
+if(CMAKE_CXX_STANDARD)
+  #If building for ITKv5 or C++11, then a newer version of cmake
+  #is needed to respect the CMAKE_CXX_STANDARD flags.
+  cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
+elseif(WIN32 OR NOT EXISTS /dev/urandom)
+  cmake_minimum_required(VERSION 2.8.5 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
 endif()
 
 ## Tell CMake to be quiet


### PR DESCRIPTION
ITKv5 is going to require C++11 so require newer
versions of cmake features when the CMAKE_CXX_STANDARD
flag is present so that these standards are respected.