### PR TITLE
COMP: Prepare for C++11 features in ITKv5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ install:
       if ! test -d $HOME/cmake/bin; then
         CMAKE_URL="https://cmake.org/files/v${CMAKE_VERSION%.[0-9]}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
         travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C $HOME/cmake
-        export PATH=$HOME/cmake/bin:${PATH}
       fi
+      export PATH=$HOME/cmake/bin:${PATH}
     else
       brew upgrade cmake
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,19 @@
 # ITKv5 or C++11.
 cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 
-## Tell CMake to be quiet
-cmake_policy(SET CMP0003 NEW)
-if(POLICY CMP0054)
-  cmake_policy(SET CMP0054 NEW)
-endif()
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
-cmake_policy (SET CMP0022 NEW)
+## Only policies introduced after the cmake_minimum_required
+## version need to explicitly be set to NEW.
+## Refer to https://cmake.org/cmake/help/v3.11/manual/cmake-policies.7.html
+set(CMAKE_POLICIES
+  CMP0070
+  CMP0071
+  CMP0072)
+
+foreach(p ${CMAKE_POLICIES})
+  if(POLICY ${p})
+    cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
 
 project(RTK)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,9 @@
 #=========================================================
 # RTK : Reconstruction Toolkit
 #=========================================================
-cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
-if(WIN32 OR NOT EXISTS /dev/urandom)
-  cmake_minimum_required(VERSION 2.8.5)
-endif()
+# Respect the CMAKE_CXX_STANDARD flags when building for
+# ITKv5 or C++11.
+cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 
 ## Tell CMake to be quiet
 cmake_policy(SET CMP0003 NEW)


### PR DESCRIPTION
ITKv5 is going to require C++11 so require newer
versions of cmake features when the CMAKE_CXX_STANDARD
flag is present so that these standards are respected.