### PR TITLE
WIP: Add python wrapping missing types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,27 +120,6 @@ if(NOT ITK_SOURCE_DIR)
 endif()
 
 # --------------------------------------------------------
-# Check Image Dims required for Python wrapping
-set(WRAPPING_CONFIG_ERROR_LOG "
-  Python wrapping configuration is incorrect.
-
-  Please rebuild both ITK and RTK with the following options:
-    -ITK_WRAP_IMAGE_DIMS=\"2;3;4\"
-    -ITK_WRAP_unsigned_short:BOOL=ON
-
-  Or turn off python wrapping by setting RTK_WRAP_PYTHON:BOOL=OFF.
-  ")
-
-list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
-if ((${_index} EQUAL -1) AND RTK_WRAP_PYTHON)
-  message(FATAL_ERROR ${WRAPPING_CONFIG_ERROR_LOG})
-endif()
-
-if (NOT ITK_WRAP_unsigned_short AND RTK_WRAP_PYTHON)
-  message(FATAL_ERROR ${WRAPPING_CONFIG_ERROR_LOG})
-endif()
-
-# --------------------------------------------------------
 # Setup KWStyle from ITK
 if(ITK_USE_KWSTYLE)
   set( KWStyle_DIR ${CMAKE_BINARY_DIR}/KWStyle-build )

--- a/applications/rtkmedian/rtkmedian.cxx
+++ b/applications/rtkmedian/rtkmedian.cxx
@@ -30,7 +30,7 @@ int main(int argc, char * argv[])
 
   typedef unsigned short OutputPixelType;
   const unsigned int     Dimension = 2;
-  unsigned int           medianWindow[2];
+  int                    medianWindow[2];
 
   typedef itk::Image< OutputPixelType, Dimension > OutputImageType;
 

--- a/cmake/FindGengetopt.cmake
+++ b/cmake/FindGengetopt.cmake
@@ -77,6 +77,8 @@ macro (WRAP_GGO GGO_SRCS)
     endif()
   endif()
   if(MSVC)
-    set_source_files_properties(${${GGO_SRCS}} PROPERTIES COMPILE_FLAGS "/W0")
+    # Disable double to float truncation warning as gengetopt cannot append "f"
+    # to force default numeric float values in the .ggo config file
+    set_source_files_properties(${${GGO_SRCS}} PROPERTIES COMPILE_FLAGS "/wd4305")
   endif()
 endmacro ()

--- a/include/rtkMedianImageFilter.h
+++ b/include/rtkMedianImageFilter.h
@@ -59,7 +59,7 @@ public:
   typedef TImage::PixelType                 *InputImagePointer;
   typedef TImage::RegionType                OutputImageRegionType;
 
-  typedef itk::Vector<unsigned int, TImage::ImageDimension> VectorType;
+  typedef itk::Vector<int, TImage::ImageDimension> VectorType;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
+++ b/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
@@ -57,7 +57,7 @@ public:
   typedef vnl_matrix<double>                        MaterialAttenuationsType;
   typedef vnl_matrix<float>                         IncidentSpectrumType;
   typedef itk::VariableLengthVector<double>         MeasuredDataType;
-  typedef itk::VariableLengthVector<unsigned int>   ThresholdsType;
+  typedef itk::VariableLengthVector<int>            ThresholdsType;
   typedef itk::VariableSizeMatrix<double>           MeanAttenuationInBinType;
 
   // Constructor
@@ -160,7 +160,7 @@ public:
       {
       double accumulate = 0;
       double accumulateWeights = 0;
-      for (unsigned int energy=m_Thresholds[bin]-1; (energy<m_Thresholds[bin+1]) && (energy < this->m_MaterialAttenuations.rows()); energy++)
+      for (int energy=m_Thresholds[bin]-1; (energy<m_Thresholds[bin+1]) && (energy < (int)(this->m_MaterialAttenuations.rows())); energy++)
         {
         accumulate += this->m_MaterialAttenuations[energy][mat] * this->m_IncidentSpectrum[0][energy];
         accumulateWeights += this->m_IncidentSpectrum[0][energy];

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
@@ -57,7 +57,7 @@ public:
   typedef DecomposedProjectionsType       OutputImageType;
 
   /** Convenient information */
-  typedef itk::VariableLengthVector<unsigned int>           ThresholdsType;
+  typedef itk::VariableLengthVector<int>                    ThresholdsType;
   typedef itk::VariableSizeMatrix<double>                   MeanAttenuationInBinType;
   typedef vnl_matrix<double>                                DetectorResponseType;
   typedef vnl_matrix<double>                                MaterialAttenuationsType;

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
@@ -338,7 +338,7 @@ SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType, Me
       indexDet[0] = energy;
       for (unsigned int bin=0; bin<m_NumberOfSpectralBins; bin++)
         {
-        for (unsigned int pulseHeight=m_Thresholds[bin]-1; pulseHeight<m_Thresholds[bin+1]; pulseHeight++)
+        for (int pulseHeight=m_Thresholds[bin]-1; pulseHeight<m_Thresholds[bin+1]; pulseHeight++)
           {
           indexDet[1] = pulseHeight;
           // Linear interpolation on the pulse heights: half of the pulses that have "threshold"

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -60,7 +60,7 @@ public:
   typedef MeasuredProjectionsType       OutputImageType;
 
   /** Convenient information */
-  typedef itk::VariableLengthVector<unsigned int>           ThresholdsType;
+  typedef itk::VariableLengthVector<int>       ThresholdsType;
   typedef vnl_matrix<double>                   DetectorResponseType;
   typedef vnl_matrix<double>                   MaterialAttenuationsType;
 

--- a/include/rtkSpectralForwardModelImageFilter.hxx
+++ b/include/rtkSpectralForwardModelImageFilter.hxx
@@ -284,7 +284,7 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType, MeasuredProjectionsTy
       indexDet[0] = energy;
       for (unsigned int bin=0; bin<m_NumberOfSpectralBins; bin++)
         {
-        for (unsigned int pulseHeight=m_Thresholds[bin]-1; pulseHeight<m_Thresholds[bin+1]; pulseHeight++)
+        for (int pulseHeight=m_Thresholds[bin]-1; pulseHeight<m_Thresholds[bin+1]; pulseHeight++)
           {
           indexDet[1] = pulseHeight;
           // Linear interpolation on the pulse heights: half of the pulses that have "threshold"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from os import sys
+
+try:
+    from skbuild import setup
+except ImportError:
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
+
+setup(
+    name='itk-rtk',
+    version='0.0.1',
+    author='RTK Consortium',
+    author_email='rtk-users@openrtk.org',
+    packages=['itk'],
+    package_dir={'itk': 'itk'},
+    download_url=r'https://github.com/SimonRit/RTK.git',
+    description=r'The Reconstruction Toolkit (RTK) is an open-source and cross-platform software for fast circular cone-beam CT reconstruction.',
+    long_description='Based on the Insight Toolkit ITK, RTK provides: Basic operators for reconstruction (e.g. filtering, forward, projection and backprojection), Multithreaded CPU and GPU versions, Tools for respiratory motion correction, I/O for several scanners, Preprocessing of raw data for scatter correction.',
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: C++",
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Healthcare Industry",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Medical Science Apps.",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Software Development :: Libraries",
+        "Operating System :: Android",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Operating System :: MacOS"
+        ],
+    license='Apache',
+    keywords='RTK Reconstruction Toolkit',
+    url=r'https://www.openrtk.org/',
+    install_requires=[
+        r'itk'
+    ]
+    )

--- a/wrapping/rtkConstantImageSource.wrap
+++ b/wrapping/rtkConstantImageSource.wrap
@@ -187,6 +187,7 @@ itk_wrap_class("itk::ImageToImageFilter" POINTER)
   if (NOT ITK_WRAP_unsigned_short OR NOT ITK_WRAP_double)
     itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
     itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
+    itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
   endif()
 
   # Wrap ITK CovariantVector missing types
@@ -243,6 +244,7 @@ itk_wrap_class("itk::InPlaceImageFilter" POINTER)
   if (NOT ITK_WRAP_unsigned_short OR NOT ITK_WRAP_double)
     itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
     itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
+    itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
   endif()
 
   # Wrap ITK real type combination

--- a/wrapping/rtkConstantImageSource.wrap
+++ b/wrapping/rtkConstantImageSource.wrap
@@ -35,8 +35,6 @@ itk_wrap_class("itk::ContinuousIndex")
   # Wrap ITK double missing types
   if (NOT ITK_WRAP_double)
     itk_wrap_template("D1" "${ITKT_D}, 1")
-    itk_wrap_template("D2" "${ITKT_D}, 2")
-    itk_wrap_template("D3" "${ITKT_D}, 3")
   endif()
 
   # Wrap ITK dimension 1 missing types
@@ -57,8 +55,6 @@ itk_wrap_class("itk::Point")
   # Wrap ITK double missing types
   if (NOT ITK_WRAP_double)
     itk_wrap_template("D1" "${ITKT_D}, 1")
-    itk_wrap_template("D2" "${ITKT_D}, 2")
-    itk_wrap_template("D3" "${ITKT_D}, 3")
   endif()
 
   # Wrap ITK dimension 1 missing types
@@ -92,8 +88,6 @@ itk_wrap_class("itk::Image" POINTER)
   # Wrap ITK double missing types
   if (NOT ITK_WRAP_double)
     itk_wrap_template("D1" "${ITKT_D}, 1")
-    itk_wrap_template("D2" "${ITKT_D}, 2")
-    itk_wrap_template("D3" "${ITKT_D}, 3")
   endif()
 
   # Wrap ITK unsigned char missing types
@@ -117,6 +111,14 @@ itk_wrap_class("itk::Image" POINTER)
 	if (ITK_WRAP_unsigned_char)
       itk_wrap_template("UC1" "${ITKT_UC}, 1")
     endif()
+  endif()
+
+  # Wrap ITK dimension 4 missing types
+  list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+  if (${_index} EQUAL -1)
+    itk_wrap_template("F4" "${ITKT_F}, 4")
+    itk_wrap_template("${ITKM_VF3}4" "${ITKT_VF3}, 4") #rtkCyclicDeformationImageFilter
+    itk_wrap_template("${ITKM_CVF3}4" "${ITKT_CVF3}, 4") #rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter
   endif()
 
 itk_end_wrap_class()
@@ -154,6 +156,12 @@ itk_wrap_class("itk::ImageSource" POINTER)
 	if (ITK_WRAP_unsigned_char)
       itk_wrap_template("IUC1" "itk::Image<${ITKT_UC}, 1>")
     endif()
+  endif()
+
+  # Wrap ITK dimension 4 missing types
+  list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+  if (${_index} EQUAL -1)
+    itk_wrap_template("IF4" "itk::Image<${ITKT_F}, 4>")
   endif()
 
 itk_end_wrap_class()
@@ -198,6 +206,12 @@ itk_wrap_class("itk::ImageToImageFilter" POINTER)
     endif()
   endif()
 
+  # Wrap ITK dimension 4 missing types
+  list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+  if (${_index} EQUAL -1)
+    itk_wrap_template("IF4IF3" "itk::Image<${ITKT_F}, 4>, itk::Image<${ITKT_F}, 3>")
+  endif()
+
 itk_end_wrap_class()
 
 # ---------------------------------------------------------------------------
@@ -235,3 +249,64 @@ itk_wrap_class("itk::InPlaceImageFilter" POINTER)
   itk_wrap_template("IF3ID2" "itk::Image<${ITKT_F}, 3>, itk::Image<${ITKT_D}, 2>")
 
 itk_end_wrap_class()
+
+# ---------------------------------------------------------------------------
+# Wrap itk::Matrix missing types
+# ---------------------------------------------------------------------------
+itk_wrap_class("itk::Matrix")
+
+  # Wrap ITK double missing types --
+  if (NOT ITK_WRAP_double)
+    itk_wrap_template("D11" "${ITKT_D}, 1, 1")
+  endif()
+
+  # Wrap ITK dimension 1 missing types
+  list(FIND ITK_WRAP_IMAGE_DIMS "1" _index)
+  if (${_index} EQUAL -1)
+	if (ITK_WRAP_double)
+      itk_wrap_template("D11" "${ITKT_D}, 1, 1")
+    endif()
+  endif()
+
+itk_end_wrap_class()
+
+# ---------------------------------------------------------------------------
+# Wrap itk::CovariantVector missing types
+# ---------------------------------------------------------------------------
+itk_wrap_class("itk::CovariantVector")
+
+  # Wrap ITK double missing types
+  if (NOT ITK_WRAP_double)
+    itk_wrap_template("D1" "${ITKT_D}, 1")
+  endif()
+
+  # Wrap ITK dimension 1 missing types
+  list(FIND ITK_WRAP_IMAGE_DIMS "1" _index)
+  if (${_index} EQUAL -1)
+    if (ITK_WRAP_double)
+      itk_wrap_template("D1" "double, 1")
+    endif()
+  endif()
+
+itk_end_wrap_class()
+
+# ---------------------------------------------------------------------------
+# Wrap const missing types
+# ---------------------------------------------------------------------------
+itk_wrap_simple_type_swig_interface("itk::Image< float, 2 >::ConstPointer" "itkImageF2_ConstPointer")
+itk_wrap_simple_type("itk::Image< float, 2 >::ConstPointer" "itkImageF2_ConstPointer")
+
+itk_wrap_simple_type_swig_interface("itk::Image< float, 3 >::ConstPointer" "itkImageF3_ConstPointer")
+itk_wrap_simple_type("itk::Image< float, 3 >::ConstPointer" "itkImageF3_ConstPointer")
+
+itk_wrap_simple_type_swig_interface("itk::Image< float, 4 >::ConstPointer" "itkImageF4_ConstPointer")
+itk_wrap_simple_type("itk::Image< float, 4 >::ConstPointer" "itkImageF4_ConstPointer")
+
+itk_wrap_simple_type_swig_interface("itk::VectorImage< float, 2 >::ConstPointer" "itkVectorImageF2_ConstPointer")
+itk_wrap_simple_type("itk::VectorImage< float, 2 >::ConstPointer" "itkVectorImageF2_ConstPointer")
+
+itk_wrap_simple_type_swig_interface("itk::VectorImage< float, 3 >::ConstPointer" "itkVectorImageF3_ConstPointer")
+itk_wrap_simple_type("itk::VectorImage< float, 3 >::ConstPointer" "itkVectorImageF3_ConstPointer")
+
+itk_wrap_simple_type_swig_interface("itk::Image< itk::CovariantVector< float, 3 >, 4 >::ConstPointer" "itkImageCVF34_ConstPointer")
+itk_wrap_simple_type("itk::Image< itk::CovariantVector< float, 3 >, 4 >::ConstPointer" "itkImageCVF34_ConstPointer")

--- a/wrapping/rtkLUTbasedVariableI0RawToAttenuationImageFilter.wrap
+++ b/wrapping/rtkLUTbasedVariableI0RawToAttenuationImageFilter.wrap
@@ -1,4 +1,9 @@
+#-----------------------------------------------------------------------------
+# rtk::LUTbasedVariableI0RawToAttenuationImageFilter
+#-----------------------------------------------------------------------------
 itk_wrap_class("rtk::LUTbasedVariableI0RawToAttenuationImageFilter" POINTER)
-  #TODO: Wrap integer types
-  itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${WRAP_ITK_REAL}" 3)
+
+  itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
+  itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
+
 itk_end_wrap_class()

--- a/wrapping/rtkLookupTableImageFilter.wrap
+++ b/wrapping/rtkLookupTableImageFilter.wrap
@@ -3,11 +3,18 @@
 #-----------------------------------------------------------------------------
 set(WRAPPER_AUTO_INCLUDE_HEADERS OFF)
 itk_wrap_named_class("rtk::Functor::LUT" "rtkFunctorLUT")
+
   foreach(i ${WRAP_ITK_INT})
     foreach(t ${WRAP_ITK_REAL})
       itk_wrap_template("${ITKM_${i}}${ITKM_${t}}" "${ITKT_${i}}, ${ITKT_${t}}")
     endforeach()
   endforeach()
+
+  # Wrap ITK unsigned short missing types -- required by LUTbasedVariableI0RawToAttenuationImageFilter
+  if (NOT ITK_WRAP_unsigned_short)
+    itk_wrap_template("${ITKM_US}${ITKM_F}" "${ITKT_US}, ${ITKT_F}")
+  endif()
+
 itk_end_wrap_class()
 set(WRAPPER_AUTO_INCLUDE_HEADERS ON)
 
@@ -16,17 +23,35 @@ set(WRAPPER_AUTO_INCLUDE_HEADERS ON)
 #   rtk::Functor::LUT< int, float > >
 #-----------------------------------------------------------------------------
 itk_wrap_class("itk::UnaryFunctorImageFilter" POINTER)
+
   foreach(i ${WRAP_ITK_INT})
     foreach(t ${WRAP_ITK_REAL})
     itk_wrap_template("I${ITKM_${i}}3I${ITKM_${t}}3LUT${ITKM_${i}}${ITKM_${t}}"
       "itk::Image<${ITKT_${i}}, 3>, itk::Image<${ITKT_${t}}, 3>, rtk::Functor::LUT< ${ITKT_${i}}, ${ITKT_${t}} >")
     endforeach()
   endforeach()
+
+  # Wrap ITK unsigned short missing types -- required by LUTbasedVariableI0RawToAttenuationImageFilter
+  if (NOT ITK_WRAP_unsigned_short)
+    itk_wrap_template("I${ITKM_US}2I${ITKM_F}2LUT${ITKM_US}${ITKM_F}"
+      "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>, rtk::Functor::LUT< ${ITKT_US}, ${ITKT_F} >")
+    itk_wrap_template("I${ITKM_US}3I${ITKM_F}3LUT${ITKM_US}${ITKM_F}"
+      "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>, rtk::Functor::LUT< ${ITKT_US}, ${ITKT_F} >")
+  endif()
+
 itk_end_wrap_class()
 
 #-----------------------------------------------------------------------------
 # rtk::LookupTableImageFilter
 #-----------------------------------------------------------------------------
 itk_wrap_class("rtk::LookupTableImageFilter" POINTER)
+
   itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${WRAP_ITK_REAL}" 3)
+  
+  # Wrap ITK unsigned short missing types -- required by LUTbasedVariableI0RawToAttenuationImageFilter
+  if (NOT ITK_WRAP_unsigned_short)
+    itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
+    itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
+  endif()
+
 itk_end_wrap_class()

--- a/wrapping/rtkMedianImageFilter.wrap
+++ b/wrapping/rtkMedianImageFilter.wrap
@@ -1,1 +1,0 @@
-itk_wrap_simple_class("rtk::MedianImageFilter" POINTER)

--- a/wrapping/rtkSpectralForwardModelImageFilter.wrap
+++ b/wrapping/rtkSpectralForwardModelImageFilter.wrap
@@ -6,9 +6,9 @@ itk_wrap_class("itk::InPlaceImageFilter" POINTER)
   endforeach()
 itk_end_wrap_class()
 
-#itk::VariableLengthVector<unsigned int>
+#itk::VariableLengthVector<int>
 itk_wrap_class("itk::VariableLengthVector")
-  itk_wrap_template("UI" "unsigned int")
+  itk_wrap_template("I" "int")
 itk_end_wrap_class()
 
 itk_wrap_class("rtk::SpectralForwardModelImageFilter" POINTER)


### PR DESCRIPTION
Depending on the value that was set for ITK_WRAP_* options, we could have
missing types that were not required by ITK but that are necessary for building RTK.
This commit ensures that RTK-required types are always defined.