### PR TITLE
BUG: Fix for rtkspectralonesteptest when FAST_TESTS_NO_CHECKS=TRUE

### DIFF
--- a/test/rtkspectralonesteptest.cxx
+++ b/test/rtkspectralonesteptest.cxx
@@ -77,7 +77,7 @@ int main(int, char** )
   materialAttenuationsReader->Update();
 
 #if FAST_TESTS_NO_CHECKS
-  const unsigned int NumberOfProjectionImages = 1;
+  const unsigned int NumberOfProjectionImages = 4;
 #else
   const unsigned int NumberOfProjectionImages = 64;
 #endif


### PR DESCRIPTION
The crash occurred only in the valgrind and coverage builds, and only when using subsets, so I'm guessing the fact that in this case, there is only one projection (which is not enough for 4 subsets) was the issue.