### PR TITLE
COMP: Fix Python wrapping with RTK_USE_CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,14 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   endif()
 endif()
 
+#=========================================================
+# Allow for multiple CL.EXE to write to the same .PDB file
+if(RTK_USE_CUDA)
+  if(WIN32)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /FS")
+  endif()
+endif()
+
 # --------------------------------------------------------
 # Shared libraries option
 set(RTK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})

--- a/wrapping/itkCudaImage.wrap
+++ b/wrapping/itkCudaImage.wrap
@@ -8,7 +8,6 @@ if(RTK_USE_CUDA)
       foreach(d ${ITK_WRAP_IMAGE_DIMS})
         itk_wrap_template("${ITKM_${t}}${d}" "${ITKT_${t}}, ${d}")
       endforeach()
-      itk_wrap_template("CV${ITKM_${t}}34" "itk::CovariantVector< ${ITKT_${t}}, 3 >, 4")
     endforeach()
   itk_end_wrap_class()
 

--- a/wrapping/itkCudaImageDataManager.wrap
+++ b/wrapping/itkCudaImageDataManager.wrap
@@ -3,12 +3,13 @@ if(RTK_USE_CUDA)
   itk_wrap_include(itkCudaImage.h)
 
   itk_wrap_class("itk::CudaImageDataManager" POINTER)
+
     foreach(t ${WRAP_ITK_REAL})
       foreach(d ${ITK_WRAP_IMAGE_DIMS})
         itk_wrap_template("CI${ITKM_${t}}${d}" "itk::CudaImage<${ITKT_${t}}, ${d}>")
       endforeach()
-      itk_wrap_template("CICV${ITKM_${t}}34" "itk::CudaImage<itk::CovariantVector<${ITKT_${t}}, 3>, 4>")
     endforeach()
+
   itk_end_wrap_class()
 
 endif()

--- a/wrapping/itkCudaImageToImageFilter.wrap
+++ b/wrapping/itkCudaImageToImageFilter.wrap
@@ -1,24 +1,6 @@
 if(RTK_USE_CUDA)
 
-  #-- itk::ImageSource templates --
-  itk_wrap_class("itk::ImageSource" POINTER)  
-    foreach(d ${ITK_WRAP_IMAGE_DIMS})
-      foreach(t ${WRAP_ITK_REAL})
-        itk_wrap_template("CI${ITKM_${t}}${d}"
-          "itk::CudaImage<${ITKT_${t}}, ${d}>")
-      endforeach()
-    endforeach()
-  itk_end_wrap_class()
 
-  #-- itk::ImageToImageFilter templates --
-  itk_wrap_class("itk::ImageToImageFilter" POINTER)  
-    foreach(d ${ITK_WRAP_IMAGE_DIMS})
-      foreach(t ${WRAP_ITK_REAL})
-        itk_wrap_template("CI${ITKM_${t}}${d}CI${ITKM_${t}}${d}"
-          "itk::CudaImage<${ITKT_${t}}, ${d}>, itk::CudaImage<${ITKT_${t}}, ${d}>")
-      endforeach()
-    endforeach()
-  itk_end_wrap_class()
 
   #-----------------------------------------------------------------------------
   # itk::CudaImageToImageFilter

--- a/wrapping/itkCudaInPlaceImageFilter.wrap
+++ b/wrapping/itkCudaInPlaceImageFilter.wrap
@@ -1,12 +1,14 @@
 if(RTK_USE_CUDA)
 
   #-- itk::InPlaceImageFilter templates --
-  itk_wrap_class("itk::InPlaceImageFilter" POINTER)  
+  itk_wrap_class("itk::InPlaceImageFilter" POINTER)
+
     foreach(d ${ITK_WRAP_IMAGE_DIMS})
       foreach(t ${WRAP_ITK_REAL})
         itk_wrap_template("CI${ITKM_${t}}${d}" "itk::CudaImage<${ITKT_${t}}, ${d}>")
       endforeach()
     endforeach()
+
   itk_end_wrap_class()
 
   #-- itk::CudaImageToImageFilter templates --

--- a/wrapping/rtkConstantImageSource.wrap
+++ b/wrapping/rtkConstantImageSource.wrap
@@ -123,6 +123,37 @@ itk_wrap_class("itk::Image" POINTER)
 
 itk_end_wrap_class()
 
+# ----------------------------------------------------------------------------
+# Wrap CUDA base classes. Required by the wrapped class following this block
+# ----------------------------------------------------------------------------
+if(RTK_USE_CUDA)
+
+  #----------------------------------------------------------
+  itk_wrap_class("itk::CudaImage" POINTER_WITH_CONST_POINTER)
+
+    list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+    if (${_index} EQUAL -1)
+      itk_wrap_template("F4" "${ITKT_F}, 4")
+    endif()
+
+    itk_wrap_template("${ITKM_CVF3}4" "${ITKT_CVF3}, 4")
+
+  itk_end_wrap_class()
+
+  #----------------------------------------------------------
+  itk_wrap_class("itk::CudaImageDataManager" POINTER)
+
+    list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+    if(${_index} EQUAL -1)
+        itk_wrap_template("CIF4" "itk::CudaImage<${ITKT_F}, 4>")
+    endif()
+
+    itk_wrap_template("CICVF34" "itk::CudaImage<itk::CovariantVector<${ITKT_F}, 3>, 4>")
+
+  itk_end_wrap_class()
+ 
+endif()
+
 # ---------------------------------------------------------------------------
 # Wrap itk::ImageSource missing types
 # ---------------------------------------------------------------------------
@@ -162,6 +193,18 @@ itk_wrap_class("itk::ImageSource" POINTER)
   list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
   if (${_index} EQUAL -1)
     itk_wrap_template("IF4" "itk::Image<${ITKT_F}, 4>")
+    if(RTK_USE_CUDA)
+      itk_wrap_template("CIF4" "itk::CudaImage<${ITKT_F}, 4>")
+    endif()
+  endif()
+
+  # Wrap CUDA types
+  if(RTK_USE_CUDA)
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+      foreach(t ${WRAP_ITK_REAL})
+        itk_wrap_template("CI${ITKM_${t}}${d}" "itk::CudaImage<${ITKT_${t}}, ${d}>")
+      endforeach()
+    endforeach()
   endif()
 
 itk_end_wrap_class()
@@ -213,6 +256,20 @@ itk_wrap_class("itk::ImageToImageFilter" POINTER)
     itk_wrap_template("IF4IF3" "itk::Image<${ITKT_F}, 4>, itk::Image<${ITKT_F}, 3>")
   endif()
 
+  if(RTK_USE_CUDA)
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+      foreach(t ${WRAP_ITK_REAL})
+        itk_wrap_template("CI${ITKM_${t}}${d}CI${ITKM_${t}}${d}"
+          "itk::CudaImage<${ITKT_${t}}, ${d}>, itk::CudaImage<${ITKT_${t}}, ${d}>")
+      endforeach()
+    endforeach()
+
+    # Wrap ITK dimension 4 missing types
+    list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+    if (${_index} EQUAL -1)
+      itk_wrap_template("CIF4CIF4" "itk::CudaImage<${ITKT_F}, 4>, itk::CudaImage<${ITKT_F}, 4>")
+    endif()
+  endif()
 itk_end_wrap_class()
 
 # ---------------------------------------------------------------------------
@@ -249,6 +306,14 @@ itk_wrap_class("itk::InPlaceImageFilter" POINTER)
 
   # Wrap ITK real type combination
   itk_wrap_template("IF3ID2" "itk::Image<${ITKT_F}, 3>, itk::Image<${ITKT_D}, 2>")
+
+  if(RTK_USE_CUDA)
+    # Wrap ITK dimension 4 CUDA missing types
+    list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
+    if (${_index} EQUAL -1)
+      itk_wrap_template("CIF4CIF4" "itk::CudaImage<${ITKT_F}, 4>, itk::CudaImage<${ITKT_F}, 4>")
+    endif()
+  endif()
 
 itk_end_wrap_class()
 

--- a/wrapping/rtkIterativeConeBeamReconstructionFilter.wrap
+++ b/wrapping/rtkIterativeConeBeamReconstructionFilter.wrap
@@ -1,7 +1,7 @@
 #-----------------------------------------------------------------------------
 # rtk::IterativeConeBeamReconstructionFilter
 #-----------------------------------------------------------------------------
-itk_wrap_class("rtk::IterativeConeBeamReconstructionFilter" POINTER_WITH_SUPERCLASS)
+itk_wrap_class("rtk::IterativeConeBeamReconstructionFilter" POINTER)
 
   #WARNING: Templates can not be defined for both itk::Image and itk::CudaImage.
   # The "=" operator for one subclass (rtk::FourDConjugateGradientConeBeamReconstructionFilter) 


### PR DESCRIPTION
Ensure that CUDA related classes are being wrapped before
itk::ImageFilter classes, but after itk::Image classes.