### PR TITLE
COMP: Add non-default missing types

### DIFF
--- a/wrapping/rtkConstantImageSource.wrap
+++ b/wrapping/rtkConstantImageSource.wrap
@@ -101,6 +101,11 @@ itk_wrap_class("itk::Image" POINTER)
     itk_wrap_template("US3" "${ITKT_US}, 3")
   endif()
 
+  # Wrap ITK short combination (required by : rtkLookupTableImageFilter)
+  if (NOT ITK_WRAP_signed_short)
+    itk_wrap_template("SS3" "${ITKT_SS}, 3")
+  endif()
+
   # Wrap ITK dimension 1 missing types
   list(FIND ITK_WRAP_IMAGE_DIMS "1" _index)
   if (${_index} EQUAL -1)
@@ -184,10 +189,17 @@ itk_wrap_class("itk::ImageToImageFilter" POINTER)
   endif()
 
   # Wrap ITK unsigned short combination (required by : rtkLookupTableImageFilter)
-  if (NOT ITK_WRAP_unsigned_short OR NOT ITK_WRAP_double)
-    itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
+  if (NOT ITK_WRAP_unsigned_short)
+    if (NOT ITK_WRAP_double)
+      itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
+    endif()
     itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
     itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
+  endif()
+
+  # Wrap ITK short combination (required by : rtkLookupTableImageFilter)
+  if (NOT ITK_WRAP_signed_short)
+    itk_wrap_template("ISS3IF3" "itk::Image<${ITKT_SS}, 3>, itk::Image<${ITKT_F}, 3>")
   endif()
 
   # Wrap ITK CovariantVector missing types
@@ -211,6 +223,7 @@ itk_wrap_class("itk::ImageToImageFilter" POINTER)
   list(FIND ITK_WRAP_IMAGE_DIMS "4" _index)
   if (${_index} EQUAL -1)
     itk_wrap_template("IF4IF3" "itk::Image<${ITKT_F}, 4>, itk::Image<${ITKT_F}, 3>")
+    itk_wrap_template("IF4IF4" "itk::Image<${ITKT_F}, 4>, itk::Image<${ITKT_F}, 4>")
   endif()
 
 itk_end_wrap_class()
@@ -241,10 +254,17 @@ itk_wrap_class("itk::InPlaceImageFilter" POINTER)
   endif()
 
   # Wrap ITK unsigned short combination (required by : rtkLookupTableImageFilter)
-  if (NOT ITK_WRAP_unsigned_short OR NOT ITK_WRAP_double)
-    itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
+  if (NOT ITK_WRAP_unsigned_short)
+    if (NOT ITK_WRAP_double)
+      itk_wrap_template("IUS3ID3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_D}, 3>")
+    endif()
     itk_wrap_template("IUS3IF3" "itk::Image<${ITKT_US}, 3>, itk::Image<${ITKT_F}, 3>")
     itk_wrap_template("IUS2IF2" "itk::Image<${ITKT_US}, 2>, itk::Image<${ITKT_F}, 2>")
+  endif()
+
+  # Wrap ITK short combination (required by : rtkLookupTableImageFilter)
+  if (NOT ITK_WRAP_signed_short)
+    itk_wrap_template("ISS3IF3" "itk::Image<${ITKT_SS}, 3>, itk::Image<${ITKT_F}, 3>")
   endif()
 
   # Wrap ITK real type combination
@@ -312,3 +332,17 @@ itk_wrap_simple_type("itk::VectorImage< float, 3 >::ConstPointer" "itkVectorImag
 
 itk_wrap_simple_type_swig_interface("itk::Image< itk::CovariantVector< float, 3 >, 4 >::ConstPointer" "itkImageCVF34_ConstPointer")
 itk_wrap_simple_type("itk::Image< itk::CovariantVector< float, 3 >, 4 >::ConstPointer" "itkImageCVF34_ConstPointer")
+
+if (ITK_WRAP_double)
+  itk_wrap_simple_type_swig_interface("itk::Image< double, 3 >::ConstPointer" "itkImageD3_ConstPointer")
+  itk_wrap_simple_type("itk::Image< double, 3 >::ConstPointer" "itkImageD3_ConstPointer")
+
+  itk_wrap_simple_type_swig_interface("itk::Image< double, 4 >::ConstPointer" "itkImageD4_ConstPointer")
+  itk_wrap_simple_type("itk::Image< double, 4 >::ConstPointer" "itkImageD4_ConstPointer")
+
+  itk_wrap_simple_type_swig_interface("itk::VectorImage< double, 3 >::ConstPointer" "itkVectorImageD3_ConstPointer")
+  itk_wrap_simple_type("itk::VectorImage< double, 3 >::ConstPointer" "itkVectorImageD3_ConstPointer")
+
+  itk_wrap_simple_type_swig_interface("itk::Image< itk::CovariantVector< double, 3 >, 4 >::ConstPointer" "itkImageCVD34_ConstPointer")
+  itk_wrap_simple_type("itk::Image< itk::CovariantVector< double, 3 >, 4 >::ConstPointer" "itkImageCVD34_ConstPointer")
+endif()

--- a/wrapping/rtkLookupTableImageFilter.wrap
+++ b/wrapping/rtkLookupTableImageFilter.wrap
@@ -28,6 +28,8 @@ itk_wrap_class("itk::UnaryFunctorImageFilter" POINTER)
     foreach(t ${WRAP_ITK_REAL})
     itk_wrap_template("I${ITKM_${i}}3I${ITKM_${t}}3LUT${ITKM_${i}}${ITKM_${t}}"
       "itk::Image<${ITKT_${i}}, 3>, itk::Image<${ITKT_${t}}, 3>, rtk::Functor::LUT< ${ITKT_${i}}, ${ITKT_${t}} >")
+    itk_wrap_template("I${ITKM_${i}}2I${ITKM_${t}}2LUT${ITKM_${i}}${ITKM_${t}}"
+      "itk::Image<${ITKT_${i}}, 2>, itk::Image<${ITKT_${t}}, 2>, rtk::Functor::LUT< ${ITKT_${i}}, ${ITKT_${t}} >")
     endforeach()
   endforeach()
 
@@ -46,7 +48,7 @@ itk_end_wrap_class()
 #-----------------------------------------------------------------------------
 itk_wrap_class("rtk::LookupTableImageFilter" POINTER)
 
-  itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${WRAP_ITK_REAL}" 3)
+  itk_wrap_image_filter_combinations("${WRAP_ITK_INT}" "${WRAP_ITK_REAL}" 2+)
   
   # Wrap ITK unsigned short missing types -- required by LUTbasedVariableI0RawToAttenuationImageFilter
   if (NOT ITK_WRAP_unsigned_short)


### PR DESCRIPTION
Enable wrapping against an ITK build tree that has less wrapped types than
its default state.
This commits fixes wrapping against an ITK build tree built with :
  - ITK_WRAP_IMAGES_DIMS/ITK_WRAP_VECTOR_COMPONENTS=1;2;3;4
  - ITK_WRAP_double
  - ITK_WRAP_float
  - ITK_WRAP_covariant_vector_float