### PR TITLE
BUG: Missing SetCPUBufferPointer in CudaImage<...>::SetPixelContainer(...)

### DIFF
--- a/utilities/ITKCudaCommon/include/itkCudaImage.hxx
+++ b/utilities/ITKCudaCommon/include/itkCudaImage.hxx
@@ -163,6 +163,7 @@ template <class TPixel, unsigned int VImageDimension>
 void CudaImage< TPixel, VImageDimension >::SetPixelContainer(PixelContainer *container)
 {
   Superclass::SetPixelContainer(container);
+  m_DataManager->SetCPUBufferPointer(Superclass::GetBufferPointer());
   m_DataManager->SetCPUDirtyFlag(false);
   m_DataManager->SetGPUDirtyFlag(true);
 }


### PR DESCRIPTION
In `CudaImage<...>::SetPixelContainer(...)`, after setting a new pixel container, the CPU buffer pointer of the CudaImage's CudaDataManager shall also be updated.

 This is likely a fix for #201.