### PR TITLE
Add checks to make sure filename list is not longer than geometry

### DIFF
--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -170,7 +170,7 @@ template<typename T> struct HasGeometryArg {
 * If larger, remove the last file from the container until equal */
 template<class TArgsInfo>
 void
-CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo args_info, std::true_type)
+CheckGeomAgainstFiles(std::vector<std::string> &fileNames, typename TArgsInfo args_info, std::true_type)
 {
 	rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
 	geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
@@ -179,7 +179,9 @@ CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo arg
 	while (geometryReader->GetGeometry()->GetGantryAngles().size() < fileNames.size())
 	  {
       std::cout << "WARNING: Geometry has less entries than the number of files:\n"
-        << "Assuming the last file is empty..."
+        << "Assuming the last file, "
+		<< fileNames.at(fileNames.size()-1)
+		<< ", is empty..."
         << std::endl;
       fileNames.pop_back();
 	  }
@@ -187,7 +189,7 @@ CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo arg
 
 template<class TArgsInfo>
 void
-CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo args_info, std::false_type)
+CheckGeomAgainstFiles(std::vector<std::string> &fileNames, typename TArgsInfo args_info, std::false_type)
 {
 // Intentionally empty
 }
@@ -195,7 +197,7 @@ CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo arg
 /** Check if TArgsInfo in template instantiation has geometry_arg. */
 template<class TArgsInfo>
 void
-CheckGeomAgainstFiles(std::vector<std::string> fileNames, typename TArgsInfo args_info){
+CheckGeomAgainstFiles(std::vector<std::string> &fileNames, typename TArgsInfo args_info){
 	CheckGeomAgainstFiles(fileNames, args_info, std::integral_constant<bool, HasGeometryArg<TArgsInfo>::Has>());
 }
 
@@ -290,8 +292,7 @@ SetProjectionsReaderFromGgo(typename TProjectionsReaderType::Pointer reader,
     coeffs.assign(args_info.wpc_arg, args_info.wpc_arg+args_info.wpc_given);
     reader->SetWaterPrecorrectionCoefficients(coeffs);
     }
-  if (HasGeometryArg<TArgsInfo>::Has)
-	  std::cout << "Has geometry arg" << std::endl;
+  
   CheckGeomAgainstFiles<TArgsInfo>(fileNames, args_info);
 
   // Pass list to projections reader

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -245,6 +245,18 @@ SetProjectionsReaderFromGgo(typename TProjectionsReaderType::Pointer reader,
     reader->SetWaterPrecorrectionCoefficients(coeffs);
     }
 
+
+  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
+  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
+  geometryReader->SetFilename(args_info.geometry_arg);
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation());
+  while (geometryReader->GetGeometry()->GetAngularGaps().size() < fileNames.size()) {
+	  std::cout << "WARNING: Geometry has less entries than the number of files:\n"
+		  << "Assuming the last file is empty..."
+		  << std::endl;
+	  fileNames.pop_back();
+  }
+
   // Pass list to projections reader
   reader->SetFileNames( fileNames );
   TRY_AND_EXIT_ON_ITK_EXCEPTION( reader->UpdateOutputInformation() );

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -25,6 +25,7 @@
 #include "rtkMacro.h"
 #include "rtkConstantImageSource.h"
 #include "rtkProjectionsReader.h"
+#include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 #include <itkRegularExpressionSeriesFileNames.h>
 #include <itksys/RegularExpression.hxx>
 

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -163,10 +163,9 @@ struct HasGeometryArg
 	static const bool Has = sizeof(Test<T>(0)) == sizeof(char);
 };
 
-
 template<class TArgsInfo>
 void
-check_geom_against_files(std::vector<std::string> fileNames, typename TArgsInfo args_info) {
+check_geom_against_files(std::vector<std::string> fileNames, typename TArgsInfo args_info, std::true_type) {
 	rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
 	geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
 	geometryReader->SetFilename(args_info.geometry_arg);
@@ -177,6 +176,16 @@ check_geom_against_files(std::vector<std::string> fileNames, typename TArgsInfo 
 			<< std::endl;
 		fileNames.pop_back();
 	}
+}
+
+template<class TArgsInfo>
+void
+check_geom_against_files(std::vector<std::string> fileNames, typename TArgsInfo args_info, std::false_type) {}
+
+template<class TArgsInfo>
+void
+check_geom_against_files(std::vector<std::string> fileNames, typename TArgsInfo args_info){
+	check_geom_against_files(fileNames, args_info, std::integral_constant<bool, HasGeometryArg<TArgsInfo>::Has>());
 }
 
 template< class TProjectionsReaderType, class TArgsInfo >

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -250,7 +250,7 @@ SetProjectionsReaderFromGgo(typename TProjectionsReaderType::Pointer reader,
   geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
   geometryReader->SetFilename(args_info.geometry_arg);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation());
-  while (geometryReader->GetGeometry()->GetAngularGaps().size() < fileNames.size()) {
+  while (geometryReader->GetGeometry()->GetGantryAngles().size() < fileNames.size()) {
 	  std::cout << "WARNING: Geometry has less entries than the number of files:\n"
 		  << "Assuming the last file is empty..."
 		  << std::endl;

--- a/src/rtkVarianProBeamGeometryReader.cxx
+++ b/src/rtkVarianProBeamGeometryReader.cxx
@@ -49,10 +49,19 @@ rtk::VarianProBeamGeometryReader
   const double sdd = dynamic_cast<MetaDataDoubleType *>(dic["SID"].GetPointer() )->GetMetaDataObjectValue();
   const double sid = dynamic_cast<MetaDataDoubleType *>(dic["SAD"].GetPointer() )->GetMetaDataObjectValue();
 
+  // Get count to avoid the possibly empty last projection
+  // see: https://public.kitware.com/pipermail/rtk-users/2018-August/010622.html
+  typedef itk::MetaDataObject< int > MetaDataIntType;
+  const int count = dynamic_cast<MetaDataIntType *>(dic["Count"].GetPointer())->GetMetaDataObjectValue();
+
   // Projections reader (for angle)
   rtk::XimImageIOFactory::RegisterOneFactory();
+
+  // if count negative it will underflow and number of files will be used.
+  const size_t noProjMax = std::min(m_ProjectionsFileNames.size(), static_cast<size_t>(count));
+
   // Projection matrices
-  for(unsigned int noProj=0; noProj<m_ProjectionsFileNames.size(); noProj++)
+  for(unsigned int noProj=0; noProj<noProjMax; noProj++)
     {
     typedef unsigned int                    InputPixelType;
     typedef itk::Image< InputPixelType, 2 > InputImageType;

--- a/src/rtkVarianProBeamXMLFileReader.cxx
+++ b/src/rtkVarianProBeamXMLFileReader.cxx
@@ -72,6 +72,12 @@ EndElement(const char *name)
     itk::EncapsulateMetaData<std::string>(m_Dictionary, metaName, m_CurCharacterData); \
     }
 
+#define ENCAPLULATE_META_DATA_INT(metaName) \
+  if(itksys::SystemTools::Strucmp(name, metaName) == 0) { \
+    int d = atoi(m_CurCharacterData.c_str() ); \
+    itk::EncapsulateMetaData<int>(m_Dictionary, metaName, d); \
+    }
+
   ENCAPLULATE_META_DATA_DOUBLE("Velocity");
   ENCAPLULATE_META_DATA_DOUBLE("SAD");
   ENCAPLULATE_META_DATA_DOUBLE("SID");
@@ -82,6 +88,7 @@ EndElement(const char *name)
   MODIFY_META_DATA_DOUBLE_MULTIPLY("ImagerResY", "DetectorSizeY");
   ENCAPLULATE_META_DATA_DOUBLE("ImagerLat");
   ENCAPLULATE_META_DATA_STRING("Fan");
+  ENCAPLULATE_META_DATA_INT("Count");
 }
 
 void


### PR DESCRIPTION
In connection with [the issue on the mailing-list](https://public.kitware.com/pipermail/rtk-users/2018-August/010622.html) I have added a check in `rtkGgoFunctions.h` to make sure the vector of filenames returned by regex is not longer than the number of entries in the geometry.
The check will only occur in when `TArgsInfo` has `geometry_arg`.

I have also made sure the `VarianProBeamGeometryReader` gets the number of projections from the `Scan.xml` and checks that against the filenumber when producing geometry entries.

The check is simple, if filenames too long: remove last file from list until equivalence is reached.

However, when the check is done, I could not find a better way to get geometry entries than by reading reading it from the file. This might be unnecessary as geometry is often read later. So it could be more optimal to change the IO causality all places `SetProjectionsReaderFromGgo` is called.

If this issue from the mailing list could NOT occur for other filetypes than Xim, an alternative solution could be to make `CanReadFile` of `XimImageIO.cxx` more advanced and do an attempt at opening the file and checking for image data?