### PR TITLE
ENH: Export RTK cmake variables on find_package(ITK COMPONENTS RTK)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,34 @@ set(RTK_SYSTEM_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 set(RTK_SYSTEM_INCLUDE_DIRS ${RTK_INCLUDE_DIRS})
 
 #=========================================================
+# Generate RTKConfig.cmake for the build tree.
+set(RTK_MODULE_PATH_CONFIG ${CMAKE_MODULE_PATH})
+set(RTK_USE_FILE "${RTK_SOURCE_DIR}/cmake/UseRTK.cmake")
+set(RTK_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+configure_file(cmake/RTKConfig.cmake.in RTKConfig.cmake @ONLY)
+configure_file(cmake/RTKConfigVersion.cmake.in RTKConfigVersion.cmake @ONLY)
+
+configure_file(CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
+
+set(RTK_EXPORT_CODE_BUILD "
+  # The RTK version number
+  set(RTK_VERSION_MAJOR ${RTK_VERSION_MAJOR})
+  set(RTK_VERSION_MINOR ${RTK_VERSION_MINOR})
+  set(RTK_VERSION_PATCH ${RTK_VERSION_PATCH})
+
+  # Whether the compiled version of RTK uses CUDA
+  set(RTK_USE_CUDA ${RTK_USE_CUDA})
+
+  if(${RTK_USE_CUDA})
+    set(CMAKE_MODULE_PATH ${RTK_MODULE_PATH_CONFIG} ${CMAKE_MODULE_PATH})
+    # if we are using CUDA, make sure CUDA libraries are available
+    find_package(CUDA_wrap REQUIRED)
+    include_directories(${CUDA_INCLUDE_DIRS})
+    set(RTK_CUDA_PROJECTIONS_SLAB_SIZE \"16\" CACHE STRING \"Number of projections processed simultaneously in CUDA forward and back projections\")
+  endif()
+  ")
+
+#=========================================================
 # Configure and build ITK external module
 #=========================================================
 if(NOT ITK_SOURCE_DIR)
@@ -201,15 +229,6 @@ else()
   itk_module_impl()
 endif()
 
-#=========================================================
-# Generate RTKConfig.cmake for the build tree.
-set(RTK_MODULE_PATH_CONFIG ${CMAKE_MODULE_PATH})
-set(RTK_USE_FILE "${RTK_SOURCE_DIR}/cmake/UseRTK.cmake")
-set(RTK_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-configure_file(cmake/RTKConfig.cmake.in RTKConfig.cmake @ONLY)
-configure_file(cmake/RTKConfigVersion.cmake.in RTKConfigVersion.cmake @ONLY)
-
-configure_file(CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 #-----------------------------------------------------------------------------
 # The subdirectories added below this line should use only the public
 # interface with find_package(ITK). Set ITK_DIR to use this ITK build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,10 +196,6 @@ set(RTK_SYSTEM_INCLUDE_DIRS ${RTK_INCLUDE_DIRS})
 set(RTK_MODULE_PATH_CONFIG ${CMAKE_MODULE_PATH})
 set(RTK_USE_FILE "${RTK_SOURCE_DIR}/cmake/UseRTK.cmake")
 set(RTK_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-configure_file(cmake/RTKConfig.cmake.in RTKConfig.cmake @ONLY)
-configure_file(cmake/RTKConfigVersion.cmake.in RTKConfigVersion.cmake @ONLY)
-
-configure_file(CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
 set(RTK_EXPORT_CODE_BUILD "
   # The RTK version number
@@ -218,6 +214,11 @@ set(RTK_EXPORT_CODE_BUILD "
     set(RTK_CUDA_PROJECTIONS_SLAB_SIZE \"16\" CACHE STRING \"Number of projections processed simultaneously in CUDA forward and back projections\")
   endif()
   ")
+
+configure_file(cmake/RTKConfig.cmake.in RTKConfig.cmake @ONLY)
+configure_file(cmake/RTKConfigVersion.cmake.in RTKConfigVersion.cmake @ONLY)
+
+configure_file(CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 
 #=========================================================
 # Configure and build ITK external module

--- a/cmake/RTKConfig.cmake.in
+++ b/cmake/RTKConfig.cmake.in
@@ -4,22 +4,7 @@ get_filename_component(_TEMP "${RTK_PACKAGE_DIR}" PATH) # lib/cmake
 get_filename_component(_TEMP "${_TEMP}" PATH) # lib
 get_filename_component(RTK_INSTALL_PATH "${_TEMP}" PATH)
 
-# The RTK version number
-set(RTK_VERSION_MAJOR "@RTK_VERSION_MAJOR@")
-set(RTK_VERSION_MINOR "@RTK_VERSION_MINOR@")
-set(RTK_VERSION_PATCH "@RTK_VERSION_PATCH@")
-
-# Whether the compiled version of RTK uses CUDA
-set(RTK_USE_CUDA @RTK_USE_CUDA@)
-
-if(${RTK_USE_CUDA})
-set(CMAKE_MODULE_PATH "@RTK_MODULE_PATH_CONFIG@" ${CMAKE_MODULE_PATH})
-
-# if we are using CUDA, make sure CUDA libraries are available
-  find_package(CUDA_wrap REQUIRED)
-  include_directories(${CUDA_INCLUDE_DIRS})
-  set(RTK_CUDA_PROJECTIONS_SLAB_SIZE "16" CACHE STRING "Number of projections processed simultaneously in CUDA forward and back projections")
-endif()
+@RTK_EXPORT_CODE_BUILD@
 
 set(RTK_INCLUDE_DIRS "@RTK_INCLUDE_DIRS@")
 set(RTK_LIBRARY_DIRS "@RTK_LIBRARY_DIRS@")

--- a/examples/FirstReconstruction/CMakeLists.txt
+++ b/examples/FirstReconstruction/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(FirstReconstruction)
 
 # Find ITK with RTK
-find_package(RTK)
-include(${RTK_USE_FILE})
+find_package(ITK REQUIRED COMPONENTS RTK)
+include(${ITK_USE_FILE})
         
 # Executable(s)
 add_executable(FirstReconstruction FirstReconstruction.cxx )


### PR DESCRIPTION
Set RTK_EXPORT_CODE_BUILD to specify cmake variable that should be set when
trying to find package RTK.
This allows for calling only find_package(ITK COMPONENTS RTK) when an
external builds against RTK.