### PR TITLE
Using CanReadFile to remove unreadable files

### DIFF
--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -155,14 +155,16 @@ GetProjectionsFileNamesFromGgo(const TArgsInfo &args_info)
   std::vector<std::string> fileNames = names->GetFileNames();
   rtk::RegisterIOFactories();
   std::vector<size_t> idxtopop;
+  size_t i = 0;
   for (auto fn : fileNames) {
     itk::ImageIOBase::Pointer imageio = itk::ImageIOFactory::CreateImageIO(
       fn.c_str(), itk::ImageIOFactory::ReadMode);
 
     if (imageio.IsNull()) {
       std::cerr << "Ignoring file: " << fn << std::endl;
-      idxtopop.push_back(&fn - &fileNames[0]);
+      idxtopop.push_back(i);
     }
+    i++;
   }
   std::reverse(idxtopop.begin(), idxtopop.end());
   for (auto id : idxtopop) {

--- a/include/rtkXimImageIO.h
+++ b/include/rtkXimImageIO.h
@@ -50,23 +50,24 @@ public:
   typedef itk::ImageIOBase        Superclass;
   typedef itk::SmartPointer<Self> Pointer;
   typedef signed short int        PixelType;
+  typedef itk::int32_t            Int4; // int of 4 bytes as in xim docs
 
   typedef struct xim_header {
     //Actual Header:
     char sFileType[32];
-    itk::int32_t FileVersion;
-    itk::int32_t SizeX;
-    itk::int32_t SizeY;
-    itk::int32_t dBitsPerPixel;
-    itk::int32_t dBytesPerPixel;
-    itk::int32_t dCompressionIndicator;
-    itk::int32_t lookUpTableSize;
-    itk::int32_t compressedPixelBufferSize;
-    itk::int32_t unCompressedPixelBufferSize;
+    Int4 FileVersion;
+    Int4 SizeX;
+    Int4 SizeY;
+    Int4 dBitsPerPixel;
+    Int4 dBytesPerPixel;
+    Int4 dCompressionIndicator;
+    Int4 lookUpTableSize;
+    Int4 compressedPixelBufferSize;
+    Int4 unCompressedPixelBufferSize;
     //Header after pixel-data:
-    itk::int32_t binsInHistogram;
-    itk::int32_t * histogramData;
-    itk::int32_t numberOfProperties;
+    Int4 binsInHistogram;
+    Int4 * histogramData;
+    Int4 numberOfProperties;
     unsigned int nPixelOffset;
     double dCollX1;
     double dCollX2;
@@ -120,10 +121,11 @@ public:
   void Write(const void* buffer) ITK_OVERRIDE;
 
 private:
-  template<typename T> size_t SetPropertyValue(char *property_name, itk::uint32_t value_length, FILE *fp, Xim_header *xim);
+  template<typename T> size_t SetPropertyValue(char *property_name, Int4 value_length, FILE *fp, Xim_header *xim);
+  template<typename T> static T get_diff(char vsub, FILE* &fp);
 
   int          m_ImageDataStart;
-  itk::int32_t m_BytesPerPixel;
+  Int4 m_BytesPerPixel;
 
 }; // end class XimImageIO
 

--- a/include/rtkXimImageIO.h
+++ b/include/rtkXimImageIO.h
@@ -122,7 +122,7 @@ public:
 
 private:
   template<typename T> size_t SetPropertyValue(char *property_name, Int4 value_length, FILE *fp, Xim_header *xim);
-  template<typename T> static T get_diff(char vsub, FILE* &fp);
+  template<typename T> T get_diff(char vsub, FILE* &fp);
 
   int          m_ImageDataStart;
   Int4 m_BytesPerPixel;

--- a/src/rtkXimImageIO.cxx
+++ b/src/rtkXimImageIO.cxx
@@ -25,7 +25,7 @@
 #define PROPERTY_NAME_MAX_LENGTH 256
 
 template<typename T>
-size_t rtk::XimImageIO::SetPropertyValue(char *property_name, itk::uint32_t value_length, FILE *fp, Xim_header *xim)
+size_t rtk::XimImageIO::SetPropertyValue(char *property_name, Int4 value_length, FILE *fp, Xim_header *xim)
 {
   T property_value;
   T * unused_property_value;
@@ -108,67 +108,71 @@ void rtk::XimImageIO::ReadImageInformation()
     itkGenericExceptionMacro(<< "Could not open file (for reading): " << m_FileName);
   size_t nelements = 0;
   nelements += fread ( (void *) xim.sFileType, sizeof(char), 8, fp);
-  nelements += fread ( (void *) &xim.FileVersion, sizeof(itk::int32_t), 1, fp);
-  nelements += fread ( (void *) &xim.SizeX, sizeof(itk::int32_t), 1, fp);
-  nelements += fread ( (void *) &xim.SizeY, sizeof(itk::int32_t), 1, fp);
+  nelements += fread ( (void *) &xim.FileVersion, sizeof(Int4), 1, fp);
+  nelements += fread ( (void *) &xim.SizeX, sizeof(Int4), 1, fp);
+  nelements += fread ( (void *) &xim.SizeY, sizeof(Int4), 1, fp);
 
-  nelements += fread((void *)&xim.dBitsPerPixel, sizeof(itk::int32_t), 1, fp);
-  nelements += fread((void *)&xim.dBytesPerPixel, sizeof(itk::int32_t), 1, fp);
+  nelements += fread((void *)&xim.dBitsPerPixel, sizeof(Int4), 1, fp);
+  nelements += fread((void *)&xim.dBytesPerPixel, sizeof(Int4), 1, fp);
   m_BytesPerPixel = xim.dBytesPerPixel;
-  nelements += fread((void *)&xim.dCompressionIndicator, sizeof(itk::int32_t), 1, fp);
+  nelements += fread((void *)&xim.dCompressionIndicator, sizeof(Int4), 1, fp);
   m_ImageDataStart = ftell(fp);
   if (xim.dCompressionIndicator == 1)
   {
-    nelements += fread((void *)&xim.lookUpTableSize, sizeof(itk::int32_t), 1, fp);
+    nelements += fread((void *)&xim.lookUpTableSize, sizeof(Int4), 1, fp);
     fseek(fp, xim.lookUpTableSize, SEEK_CUR);
-    nelements += fread((void *)&xim.compressedPixelBufferSize, sizeof(itk::int32_t), 1, fp);
+    nelements += fread((void *)&xim.compressedPixelBufferSize, sizeof(Int4), 1, fp);
     fseek(fp, xim.compressedPixelBufferSize, SEEK_CUR);
-    nelements += fread((void *)&xim.unCompressedPixelBufferSize, sizeof(itk::int32_t), 1, fp);
-    if (nelements != /*char*/8 +/*itk::int32_t*/9)
+    nelements += fread((void *)&xim.unCompressedPixelBufferSize, sizeof(Int4), 1, fp);
+    if (nelements != /*char*/8 +/*Int4*/9)
       itkGenericExceptionMacro(<< "Could not read header data in " << m_FileName);
   }
   else
   {
-    nelements += fread((void *)&xim.unCompressedPixelBufferSize, sizeof(itk::int32_t), 1, fp);
+    nelements += fread((void *)&xim.unCompressedPixelBufferSize, sizeof(Int4), 1, fp);
     fseek(fp, xim.unCompressedPixelBufferSize, SEEK_CUR);
-    if (nelements != /*char*/8 +/*itk::uint32_t*/7)
+    if (nelements != /*char*/8 +/*Int4*/7)
       itkGenericExceptionMacro(<< "Could not read header data in " << m_FileName);
   }
 
   // Histogram Reading:
+  nelements += fread((void *)&xim.binsInHistogram, sizeof(Int4), 1, fp);
+  fseek(fp, xim.binsInHistogram * sizeof(Int4), SEEK_CUR);
+  /* // Replace the two lines above with this if you actually want the histogram:
   int nhistElements = 0;
-  nhistElements += fread((void *)&xim.binsInHistogram, sizeof(itk::int32_t), 1, fp);
+  nhistElements += fread((void *)&xim.binsInHistogram, sizeof(Int4), 1, fp);
 
-  xim.histogramData = new int[xim.binsInHistogram];
-  for (itk::int32_t i = 0; i < xim.binsInHistogram; i++)
-    xim.histogramData[i] = 0;
+  auto xim.histogramData = (int*) malloc(sizeof(int) * xim.binsInHistogram);
 
-  nhistElements += fread((void *)xim.histogramData, sizeof(itk::int32_t), xim.binsInHistogram, fp);
+  nhistElements += fread((void *)&xim.histogramData, sizeof(Int4), xim.binsInHistogram, fp);
   if (nhistElements != (xim.binsInHistogram + 1))
   {
     itkGenericExceptionMacro(<< "Could not read histogram from header data in " << m_FileName);
   }
+  // free(xim.histogramData); // <- Remember to put this after you are done with the histogram
+  */
+
   // Properties Readding:
-  nelements += fread((void *)&xim.numberOfProperties, sizeof(itk::int32_t), 1, fp);
-  itk::int32_t property_name_length;
+  nelements += fread((void *)&xim.numberOfProperties, sizeof(Int4), 1, fp);
+  Int4 property_name_length;
   char property_name[PROPERTY_NAME_MAX_LENGTH];
-  itk::int32_t property_type;
-  itk::int32_t property_value_length = 0;
+  Int4 property_type;
+  Int4 property_value_length = 0;
   size_t theoretical_nelements = nelements; // Same as reseting
 
-  for (itk::int32_t i = 0; i < xim.numberOfProperties; i++)
+  for (Int4 i = 0; i < xim.numberOfProperties; i++)
     {
-    nelements += fread((void *)&property_name_length, sizeof(itk::int32_t), 1, fp);
+    nelements += fread((void *)&property_name_length, sizeof(Int4), 1, fp);
     if(property_name_length>PROPERTY_NAME_MAX_LENGTH)
       itkGenericExceptionMacro(<< "Property name is too long, i.e., " << property_name_length);
     nelements += fread((void *)&property_name, sizeof(char), property_name_length, fp);
-    nelements += fread((void *)&property_type, sizeof(itk::int32_t), 1, fp);
+    nelements += fread((void *)&property_type, sizeof(Int4), 1, fp);
     theoretical_nelements += property_name_length + 2;
 
     switch (property_type)
     {
     case 0://property_value type = uint32
-      nelements += SetPropertyValue<itk::int32_t>(property_name, 1, fp, &xim);
+      nelements += SetPropertyValue<Int4>(property_name, 1, fp, &xim);
       theoretical_nelements++;
       break;
     case 1://property_value type = double
@@ -176,18 +180,18 @@ void rtk::XimImageIO::ReadImageInformation()
       nelements += SetPropertyValue<double>(property_name, 1, fp, &xim);
       break;
     case 2://property_value type = length * char
-      nelements += fread((void *)&property_value_length, sizeof(itk::int32_t), 1, fp);
+      nelements += fread((void *)&property_value_length, sizeof(Int4), 1, fp);
       theoretical_nelements += property_value_length+1;
       nelements += SetPropertyValue<char>(property_name, property_value_length, fp, &xim);
       break;
     case 4://property_value type = length * double
-      nelements += fread((void *)&property_value_length, sizeof(itk::int32_t), 1, fp);
+      nelements += fread((void *)&property_value_length, sizeof(Int4), 1, fp);
       nelements += SetPropertyValue<double>(property_name, property_value_length/8, fp, &xim);
       theoretical_nelements += property_value_length/8+1;
       break;
     case 5://property_value type = length * uint32
-      nelements += fread((void *)&property_value_length, sizeof(itk::int32_t), 1, fp);
-      nelements += SetPropertyValue<itk::int32_t>(property_name, property_value_length/4, fp, &xim);
+      nelements += fread((void *)&property_value_length, sizeof(Int4), 1, fp);
+      nelements += SetPropertyValue<Int4>(property_name, property_value_length/4, fp, &xim);
       theoretical_nelements += property_value_length/4+1;
       break;
     default:
@@ -203,25 +207,34 @@ void rtk::XimImageIO::ReadImageInformation()
     itkGenericExceptionMacro(<< "Could not close file: " << m_FileName);
 
   /* Convert xim to ITK image information */
-  SetNumberOfDimensions(2);
-  SetDimensions(0, xim.SizeX);
-  SetDimensions(1, xim.SizeY);
+  this->SetNumberOfDimensions(2);
+  this->SetDimensions(0, xim.SizeX);
+  this->SetDimensions(1, xim.SizeY);
 
-  SetSpacing(0, xim.dIDUResolutionX); // set to PixelHeight/Width
-  SetSpacing(1, xim.dIDUResolutionY);
-  SetOrigin(0, -0.5 * (xim.SizeX - 1) * xim.dIDUResolutionX); //SR: assumed centered
-  SetOrigin(1, -0.5 * (xim.SizeY - 1) * xim.dIDUResolutionY); //SR: assumed centered
+  this->SetSpacing(0, xim.dIDUResolutionX); // set to PixelHeight/Width
+  this->SetSpacing(1, xim.dIDUResolutionY);
+  this->SetOrigin(0, -0.5 * (xim.SizeX - 1) * xim.dIDUResolutionX); //SR: assumed centered
+  this->SetOrigin(1, -0.5 * (xim.SizeY - 1) * xim.dIDUResolutionY); //SR: assumed centered
 
-  SetComponentType(itk::ImageIOBase::UINT);
+  this->SetComponentType(itk::ImageIOBase::LONG); // 32 bit ints
+  
   /* Store important meta information in the meta data dictionary */
   if (xim.SizeX * xim.SizeY != 0){
     itk::EncapsulateMetaData<double>(this->GetMetaDataDictionary(), "dCTProjectionAngle", xim.dCTProjectionAngle);
     itk::EncapsulateMetaData<double>(this->GetMetaDataDictionary(), "dDetectorOffsetX", xim.dDetectorOffsetX * 10.0); //cm->mm Lat
     itk::EncapsulateMetaData<double>(this->GetMetaDataDictionary(), "dDetectorOffsetY", xim.dDetectorOffsetY * 10.0); //cm->mm Lng
   }
-  else
+  else {
+    itk::ImageIORegion ioreg;
+    ioreg.SetIndex(0, 0);
+    ioreg.SetIndex(1, 0);
+    ioreg.SetSize(0, 0);
+    ioreg.SetSize(1, 0);
+    this->SetIORegion(ioreg);
+    unsigned int imdim[] = {0, 0};
+    this->Resize(2, imdim);
     itk::EncapsulateMetaData<double>(this->GetMetaDataDictionary(), "dCTProjectionAngle", 6000);
-  delete[] xim.histogramData;
+  }
 }
 //--------------------------------------------------------------------
 bool rtk::XimImageIO::CanReadFile(const char* FileNameToRead)
@@ -232,88 +245,136 @@ bool rtk::XimImageIO::CanReadFile(const char* FileNameToRead)
 
   if (fileExt != std::string("xim"))
     return false;
+
+  FILE* fp;
+  fp = fopen(filename.c_str(), "rb");
+  if (fp == NULL) {
+    std::cerr << "Could not open file (for reading): "
+      << m_FileName
+      << std::endl;
+    return false;
+  }
+
+  size_t nelements = 0;
+  char sfiletype[8];
+  Int4 fileversion, sizex = 0, sizey = 0;
+
+  nelements += fread((void *)&sfiletype[0], sizeof(char), 8, fp);
+  nelements += fread((void *)&fileversion, sizeof(Int4), 1, fp);
+  nelements += fread((void *)&sizex, sizeof(Int4), 1, fp);
+  nelements += fread((void *)&sizey, sizeof(Int4), 1, fp);
+
+  if (nelements != 8 + 3) {
+    std::cerr << "Could not read initial header data in "
+      << m_FileName
+      << std::endl;
+    fclose(fp);
+    return false;
+  }
+  if (sizex*sizey <= 0) {
+    std::cerr << "Imagedata was of size (x, y)=("
+      << sizex << ", "
+      << sizey << ") in "
+      << filename << std::endl;
+    fclose(fp);
+    return false;
+  }
+
+  if (fclose(fp) != 0) {
+    std::cerr << "Could not close file (after reading): "
+      << m_FileName
+      << std::endl;
+    return false;
+  }
+
   return true;
 }
 
+
 //--------------------------------------------------------------------
+
+template<typename T>
+T rtk::XimImageIO::get_diff(char vsub, FILE* &fp)
+{
+  if (vsub == 0) {
+    char diff8;
+    fread(&diff8, sizeof(char), 1, fp);
+    return static_cast<T>(diff8);
+  }
+  else if (vsub == 1){
+    short diff16;
+    fread(&diff16, sizeof(short), 1, fp);
+    return static_cast<T>(diff16);
+  }
+  // else if vsub == 2: (only 0, 1 and 2 is possible according to Xim docs)
+  Int4 diff32;
+  fread(&diff32, sizeof(Int4), 1, fp);
+  return static_cast<T>(diff32);
+}
+
 // Read Image Content
 void rtk::XimImageIO::Read(void * buffer)
 {
   FILE *fp;
-  itk::uint32_t *buf = (itk::uint32_t*)buffer;
-  itk::int32_t  a;
-  itk::ImageIOBase::SizeValueType i;
+  Int4 *buf = (Int4*)buffer;
 
-  fp = fopen (m_FileName.c_str(), "rb");
+  fp = fopen(m_FileName.c_str(), "rb");
   if (fp == NULL)
     itkGenericExceptionMacro(<< "Could not open file (for reading): " << m_FileName);
 
-  if(fseek (fp, m_ImageDataStart, SEEK_SET) != 0)
+  if (fseek(fp, m_ImageDataStart, SEEK_SET) != 0)
     itkGenericExceptionMacro(<< "Could not seek to image data in: " << m_FileName);
 
   size_t nelements = 0;
-  itk::int32_t lookUpTableSize;
-  itk::int32_t compressedPixelBufferSize;
+  Int4 lookUpTableSize;
+  Int4 compressedPixelBufferSize;
   // De"compress" image
-  nelements += fread((void *)&lookUpTableSize, sizeof(itk::int32_t), 1, fp);
-  itk::uint8_t * m_lookup_table = (itk::uint8_t *) malloc(sizeof(itk::uint8_t) * lookUpTableSize);
-  nelements += fread((void *)m_lookup_table, sizeof(itk::uint8_t), lookUpTableSize, fp);
+  nelements += fread((void *)&lookUpTableSize, sizeof(Int4), 1, fp);
+  char * m_lookup_table = (char *) malloc(sizeof(char) * lookUpTableSize);
+  nelements += fread((void *)m_lookup_table, sizeof(char), lookUpTableSize, fp);
 
-  nelements += fread((void *)&compressedPixelBufferSize, sizeof(itk::int32_t), 1, fp);
+  nelements += fread((void *)&compressedPixelBufferSize, sizeof(Int4), 1, fp);
 
-  for (i = 0; i < (GetDimensions(0) + 1); i++) {
-    if (1 != fread(&a, sizeof(itk::uint32_t), 1, fp))
-      itkGenericExceptionMacro(<< "Could not read first row +1 in: " << m_FileName);
-    buf[i] = a;
+  auto xdim = GetDimensions(0);
+  auto ydim = GetDimensions(1);
+  if (xdim*ydim == 0) {
+    itkGenericExceptionMacro(<< "Dimensions of image was 0 in: " << m_FileName);
   }
 
-  char  diff8;
-  short diff16;
-  long  diff32, diff = 0;
-  int lut_off = 0, lut_idx = 0;
-  unsigned char v;
+  if ((xdim + 1) != fread(&buf[0], sizeof(Int4), xdim + 1, fp))
+    itkGenericExceptionMacro(<< "Could not read first row +1 in: " << m_FileName);
 
-  while( i < (GetDimensions(0)*GetDimensions(1))){
-    v = m_lookup_table[lut_idx];
-    switch (lut_off) {
-    case 0:
-      v = v & 0x03;
-      lut_off++;
-      break;
-    case 1:
-      v = (v & 0x0C) >> 2;
-      lut_off++;
-      break;
-    case 2:
-      v = (v & 0x30) >> 4;
-      lut_off++;
-      break;
-    case 3:
-      v = (v & 0xC0) >> 6;
-      lut_off = 0;
-      lut_idx++;
-      break;
-    }
-    switch (v) {
-      case 0:
-        nelements += fread(&diff8, sizeof(unsigned char), 1, fp);
-        diff = diff8;
-        break;
-      case 1:
-        nelements += fread(&diff16, sizeof(unsigned short), 1, fp);
-        diff = diff16;
-        break;
-      case 2:
-        nelements += fread(&diff32, sizeof(itk::uint32_t), 1, fp);
-        diff = diff32;
-        break;
-      }
-    buf[i] = diff + buf[i - 1] + buf[i - GetDimensions(0)] - buf[i - GetDimensions(0) - 1];
-    i++;
+  int lut_idx = 0;
+  char vsub;
+
+  size_t i = xdim;
+  size_t iminxdim = 0;
+  size_t imax = xdim * ydim - 1; // -1 bc how we index
+
+  for (int lut_idx = 0; lut_idx < lookUpTableSize; lut_idx++) {
+    char v = m_lookup_table[lut_idx];
+    
+    vsub =  v & 0b00000011;       // 0x03
+    auto diff1 = get_diff<Int4>(vsub, fp);
+    vsub = (v & 0b00001100) >> 2; // 0x0C
+    auto diff2 = get_diff<Int4>(vsub, fp);
+    vsub = (v & 0b00110000) >> 4; // 0x30
+    auto diff3 = get_diff<Int4>(vsub, fp);
+    vsub = (v & 0b11000000) >> 6; // 0xC0
+    auto diff4 = get_diff<Int4>(vsub, fp);
+
+    buf[i + 1] = diff1 + buf[i]     + buf[iminxdim + 1] - buf[iminxdim];
+    buf[i + 2] = diff2 + buf[i + 1] + buf[iminxdim + 2] - buf[iminxdim + 1];
+    buf[i + 3] = diff3 + buf[i + 2] + buf[iminxdim + 3] - buf[iminxdim + 2];
+    buf[i + 4] = diff4 + buf[i + 3] + buf[iminxdim + 4] - buf[iminxdim + 3];
+
+    i += 4;
+    iminxdim += 4;
   }
 
   /* Clean up */
   free(m_lookup_table);
+
   if(fclose (fp) != 0)
     itkGenericExceptionMacro(<< "Could not close file: " << m_FileName);
   return;

--- a/src/rtkXimImageIO.cxx
+++ b/src/rtkXimImageIO.cxx
@@ -294,7 +294,7 @@ bool rtk::XimImageIO::CanReadFile(const char* FileNameToRead)
 //--------------------------------------------------------------------
 
 template<typename T>
-T rtk::XimImageIO::get_diff(char vsub, FILE* &fp)
+inline T rtk::XimImageIO::get_diff(char vsub, FILE* &fp)
 {
   if (vsub == 0) {
     char diff8;
@@ -344,12 +344,10 @@ void rtk::XimImageIO::Read(void * buffer)
   if ((xdim + 1) != fread(&buf[0], sizeof(Int4), xdim + 1, fp))
     itkGenericExceptionMacro(<< "Could not read first row +1 in: " << m_FileName);
 
-  int lut_idx = 0;
   char vsub;
 
   size_t i = xdim;
   size_t iminxdim = 0;
-  size_t imax = xdim * ydim - 1; // -1 bc how we index
 
   for (int lut_idx = 0; lut_idx < lookUpTableSize; lut_idx++) {
     char v = m_lookup_table[lut_idx];


### PR DESCRIPTION
This PR adds a check after the file regex function to check if all matches are readable (And some improvements to the Xim reader).

When attempting `CreateImageIO` for a file, `CanReadFile` will be called on the filename for all registered readers.
If no reader where found it returns a NULL pointer, which we can use to identify and eliminate unreadable files from the regex matches.
`CanReadFile` is supposed to fail fast, by checking file extension first. Only a files matching the extension will run the rest of the function, therefore this should be an efficient test.

In connection with [the issue on the mailing list](https://public.kitware.com/pipermail/rtk-users/2018-August/010622.html), regarding a Xim file potentially not containing image data, a check for this was added to `XimImageIO::CanReadFile` by checking the size of the image in the header.

Additionally:
I did some optimization in `XimImageIO::Read`, I have not measured the improvement, but theoretically it could give fewer cache misses, and help the compiler a bit (investigation using [godbolt.org](https://gcc.godbolt.org/z/5HaXzc) gave approx half the lines of assembly, when comparing looping though a only a single look-up-table index). The same optimizations could be applied to `HndImageIO::Read`.