### PR TITLE
COMP: Fix shared libs configuration for remote

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,10 @@ if(NOT ITK_SOURCE_DIR)
   include(itk-module-init.cmake)
 endif()
 
+# Propagate cmake options in a header file
+configure_file(${RTK_SOURCE_DIR}/rtkConfiguration.h.in
+  ${RTK_BINARY_DIR}/rtkConfiguration.h)
+
 #=========================================================
 # If choose to build documentation, then search for Doxygen executables.
 option(RTK_BUILD_DOXYGEN "Build Doxygen Documentation" OFF)

--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -23,6 +23,3 @@ if(RTK_USE_CUDA)
   set(RTK_CUDA_PROJECTIONS_SLAB_SIZE "16" CACHE STRING "Number of projections processed simultaneously in CUDA forward and back projections")
 endif()
 
-# Propagate cmake options in a header file
-configure_file(${RTK_SOURCE_DIR}/rtkConfiguration.h.in
-  ${RTK_BINARY_DIR}/rtkConfiguration.h)


### PR DESCRIPTION
When building RTK as an ITK Remote module, the itk-module-init.cmake file
is included prior to setting the RTK_BUILD_SHARED_LIBS variable. Thus
rtkConfiguration.h was missing RTK_BUILD_SHARED_LIBS value.

Solution: Moving configuration of rtkConfiguration.h.in to ensure that all
variable are set before configuring.