### PR TITLE
COMP: Fix testing when building RTK as a remote module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,12 +236,6 @@ else()
   itk_module_impl()
 endif()
 
-#-----------------------------------------------------------------------------
-# The subdirectories added below this line should use only the public
-# interface with find_package(ITK). Set ITK_DIR to use this ITK build.
-if(ITK_SOURCE_DIR)
-  set(ITK_DIR "${ITK_BINARY_DIR}")
-endif()
 #=========================================================
 # Build applications
 #=========================================================

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -26,7 +26,10 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${RTK_INSTALL_LIB_DIR}")
 # Required to include ITK_USE_FILE in order to Register IO factories
 # Force requested modules to be RTK dependencies only, otherwise all
 # available factories will try to register themselves.
-if (NOT ITK_SOURCE_DIR)
+if(${RTK_SOURCE_DIR} MATCHES "^(${ITK_SOURCE_DIR}/Modules/Remote)" OR NOT ITK_SOURCE_DIR)
+  if (NOT ITK_DIR)
+    set(ITK_DIR ${ITK_BINARY_DIR})
+  endif()
   find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
   include(${ITK_USE_FILE})
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,10 @@ configure_file (${CMAKE_CURRENT_SOURCE_DIR}/rtkTestConfiguration.h.in
 # Required to include ITK_USE_FILE in order to Register IO factories
 # Force requested modules to be RTK dependencies only, otherwise all
 # available factories will try to register themselves.
-if (NOT ITK_SOURCE_DIR)
+if(${RTK_SOURCE_DIR} MATCHES "^(${ITK_SOURCE_DIR}/Modules/Remote)" OR NOT ITK_SOURCE_DIR)
+  if (NOT ITK_DIR)
+    set(ITK_DIR ${ITK_BINARY_DIR})
+  endif()
   find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
   include(${ITK_USE_FILE})
 endif()


### PR DESCRIPTION
When building RTK as a remote module, test applications should register IO
factories.