### PR TITLE
fix imagx geocal reader for AI2.x

### DIFF
--- a/include/rtkImagXGeometryReader.hxx
+++ b/include/rtkImagXGeometryReader.hxx
@@ -543,7 +543,7 @@ void ImagXGeometryReader<TInputImage>::GenerateData()
     else if (isImagX2pX) // Using flexmap
       {
       float cbctTubeAngle = std::atof(value.c_str() );
-      float gantryAngle = cbctTubeAngle + flex.sourceToNozzleOffsetAngle;
+	  float gantryAngle = cbctTubeAngle; // Warning: no correction by sourceToNozzleOffsetAngle as radiographic angle read
       gantryAngle = (gantryAngle > 180.f) ? (gantryAngle - 360.f) : gantryAngle;
       gantryAngle = (gantryAngle < -180.f) ? (gantryAngle + 360.f) : gantryAngle;
       addEntryToGeometry(flex, gantryAngle);


### PR DESCRIPTION
The angle in dicom files is already the radiographic angle and not the nozzle angle