### PR TITLE
COMP: Change header include to robust pathing

### DIFF
--- a/include/rtkAddMatrixAndDiagonalImageFilter.hxx
+++ b/include/rtkAddMatrixAndDiagonalImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "rtkAddMatrixAndDiagonalImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
-#include "vnl_inverse.h"
+#include "vnl/vnl_inverse.h"
 
 namespace rtk
 {

--- a/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.hxx
+++ b/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
-#include "vnl_inverse.h"
+#include "vnl/vnl_inverse.h"
 
 namespace rtk
 {

--- a/include/rtkGetNewtonUpdateImageFilter.hxx
+++ b/include/rtkGetNewtonUpdateImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "rtkGetNewtonUpdateImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
-#include "vnl_inverse.h"
+#include "vnl/vnl_inverse.h"
 
 namespace rtk
 {


### PR DESCRIPTION
The vnl_include.h file should be included as vnl/vnl_include.h
to provide maximum compatibility with include directories.  This
is the path used internally in vnl as well.  By using this path
backwards compatibility is maintained, and the code is also
compatible with future versions of vnl where extraneous
include paths are now not exported.