### PR TITLE
COMP: Address compiler warnings

### DIFF
--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.h
@@ -41,10 +41,7 @@ class InterpolationWeightMultiplicationAttenuatedBackProjection
 public:
   InterpolationWeightMultiplicationAttenuatedBackProjection()
   {
-    for (int i = 0; i < ITK_MAX_THREADS; i++)
-      {
       m_AttenuationPixel = 0;
-      }
   }
 
   ~InterpolationWeightMultiplicationAttenuatedBackProjection() {}

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -45,7 +45,7 @@ class InterpolationWeightMultiplicationAttenuated
 public:
   InterpolationWeightMultiplicationAttenuated()
   {
-    for (int i = 0; i < ITK_MAX_THREADS; i++)
+    for (std::size_t i = 0; i < ITK_MAX_THREADS; i++)
       {
       m_AttenuationRay[i] = 0;
       m_AttenuationPixel[i] = 0;
@@ -173,7 +173,7 @@ public:
                           const TInput &input,
                           TOutput &output,
                           const TOutput &rayCastValue,
-                          const VectorType &stepInMM,
+                          const VectorType & /*stepInMM*/,
                           const VectorType &itkNotUsed(source),
                           const VectorType &itkNotUsed(sourceToPixel),
                           const VectorType &itkNotUsed(nearestPoint),

--- a/include/rtkRayBoxIntersectionImageFilter.hxx
+++ b/include/rtkRayBoxIntersectionImageFilter.hxx
@@ -73,7 +73,7 @@ RayBoxIntersectionImageFilter<TInputImage, TOutputImage>
 template <class TInputImage, class TOutputImage>
 void
 RayBoxIntersectionImageFilter<TInputImage,TOutputImage>
-::SetBoxFromImage(const ImageBaseType *_arg, bool bWithExternalHalfPixelBorder )
+::SetBoxFromImage(const ImageBaseType *_arg, bool /*bWithExternalHalfPixelBorder*/ )
 {
   if( this->GetConvexShape() == ITK_NULLPTR )
     this->SetConvexShape( BoxShape::New().GetPointer() );

--- a/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
+++ b/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
@@ -68,7 +68,7 @@ protected:
   virtual ~SeparableQuadraticSurrogateRegularizationImageFilter() ITK_OVERRIDE {}
 
   /** Creates the Outputs */
-  itk::DataObject::Pointer MakeOutput(unsigned int idx);
+  itk::DataObject::Pointer MakeOutput(unsigned int idx) override;
 
   /** Does the real work. */
 #if ITK_VERSION_MAJOR<5

--- a/include/rtkSingularValueThresholdImageFilter.hxx
+++ b/include/rtkSingularValueThresholdImageFilter.hxx
@@ -57,7 +57,7 @@ template< typename TInputImage, typename TRealType, typename TOutputImage >
 void
 SingularValueThresholdImageFilter< TInputImage, TRealType, TOutputImage >
 ::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-                       itk::ThreadIdType threadId)
+                       itk::ThreadIdType /*threadId*/)
 {
   // Walks the first frame of the outputRegionForThread
   // For each voxel, creates an input iterator that walks

--- a/include/rtkWeidingerForwardModelImageFilter.h
+++ b/include/rtkWeidingerForwardModelImageFilter.h
@@ -110,7 +110,7 @@ protected:
 #endif
 
     /** Creates the Outputs */
-    itk::DataObject::Pointer MakeOutput(unsigned int idx);
+    itk::DataObject::Pointer MakeOutput(unsigned int idx) override;
 
     /** Getters for the inputs */
     typename TMaterialProjections::ConstPointer GetInputMaterialProjections();

--- a/src/rtkConvexShape.cxx
+++ b/src/rtkConvexShape.cxx
@@ -29,7 +29,7 @@ ConvexShape
 
 bool
 ConvexShape
-::IsInside(const PointType& point) const
+::IsInside(const PointType& /*point*/) const
 {
   itkExceptionMacro(<< "This method should have been reimplemented in base classe");
   return false;
@@ -37,10 +37,10 @@ ConvexShape
 
 bool
 ConvexShape
-::IsIntersectedByRay(const PointType & rayOrigin,
-                     const VectorType & rayDirection,
-                     ScalarType & nearDist,
-                     ScalarType & farDist) const
+::IsIntersectedByRay(const PointType & /*rayOrigin*/,
+                     const VectorType & /*rayDirection*/,
+                     ScalarType & /*nearDist*/,
+                     ScalarType & /*farDist*/) const
 {
   itkExceptionMacro(<< "This method should have been reimplemented in base classe");
   return false;

--- a/src/rtkForbildPhantomFileReader.cxx
+++ b/src/rtkForbildPhantomFileReader.cxx
@@ -277,14 +277,14 @@ ForbildPhantomFileReader
 
 void
 ForbildPhantomFileReader
-::CreateForbildCone(const std::string &s, const std::string &fig)
+::CreateForbildCone(const std::string & /*s*/, const std::string & /*fig*/)
 {
   itkExceptionMacro(<< "Cones have not been implemented (yet).");
 }
 
 void
 ForbildPhantomFileReader
-::CreateForbildTetrahedron(const std::string &s)
+::CreateForbildTetrahedron(const std::string & /*s*/)
 {
 }
 

--- a/utilities/lp_solve/lp_rlp.h
+++ b/utilities/lp_solve/lp_rlp.h
@@ -1650,7 +1650,7 @@ static int lp_yy_get_next_buffer (lp_yyscan_t lp_yyscanner)
 #ifdef __cplusplus
     static inline int lp_yyinput (lp_yyscan_t lp_yyscanner)
 #else
-    static int input  (lp_yyscan_t lp_yyscanner)
+    static inline int input  (lp_yyscan_t lp_yyscanner)
 #endif
 
 {


### PR DESCRIPTION
Unused variable warnings resolved.

RTK/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h:71:28: warning: 'rtk::SeparableQuadraticSurrogateRegularizationImageFilter<itk::Image<itk::Vector<float, 3>, 3> >::MakeOutput' hides overloaded virtual functions [-Woverloaded-virtual]
RTK/include/rtkSingularValueThresholdImageFilter.hxx:60:42: warning: unused parameter 'threadId' [-Wunused-parameter]
RTK/include/rtkWeidingerForwardModelImageFilter.h:113:30: warning: 'rtk::WeidingerForwardModelImageFilter<itk::Image<itk::Vector<float, 3>, 3>, itk::Image<itk::Vector<float, 5>, 3>, itk::Image<float, 3>, itk::Image<float, 3> >::MakeOutput' hides overloaded virtual functions [-Woverloaded-virtual]
RTK/utilities/lp_solve/lp_rlp.h:1653:16: warning: 'static' function 'input' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]