### PR TITLE
COMP: fix cmake shared libs config to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,10 @@ endif()
 
 # --------------------------------------------------------
 # Shared libraries option
-if("${ITK_LIBRARY_BUILD_TYPE}" STREQUAL "SHARED")
-  set(RTK_BUILD_SHARED_LIBS ON)
-else()
-  set(RTK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+if(NOT ITK_SOURCE_DIR)
+  set(BUILD_SHARED_LIBS ${ITK_BUILD_SHARED})
 endif()
+set(RTK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
 # ----------------------------------------------------------------------------
 # Set RTK_DATA_ROOT


### PR DESCRIPTION
This fixes the warning:
/usr/lib64/gcc/x86_64-suse-linux/4.8/../../../../x86_64-suse-linux/bin/ld:
Warning: type of symbol `randomseed' changed from 1 to 2 in
../lib/liblpsolve55.a(myblas.c.o)

@LucasGandel Can you have a look and let me know if you (dis)agree? Thanks in advance.