### PR TITLE
(Very) Minor performance improvements

### DIFF
--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -156,18 +156,18 @@ GetProjectionsFileNamesFromGgo(const TArgsInfo &args_info)
   rtk::RegisterIOFactories();
   std::vector<size_t> idxtopop;
   size_t i = 0;
-  for (auto fn : fileNames) {
+  for (const auto& fn : fileNames) {
     itk::ImageIOBase::Pointer imageio = itk::ImageIOFactory::CreateImageIO(
       fn.c_str(), itk::ImageIOFactory::ReadMode);
 
     if (imageio.IsNull()) {
-      std::cerr << "Ignoring file: " << fn << std::endl;
+      std::cerr << "Ignoring file: " << fn << "\n";
       idxtopop.push_back(i);
     }
     i++;
   }
   std::reverse(idxtopop.begin(), idxtopop.end());
-  for (auto id : idxtopop) {
+  for (const auto& id : idxtopop) {
     fileNames.erase(fileNames.begin() + id);
   }
 

--- a/include/rtkVarianObiRawImageFilter.h
+++ b/include/rtkVarianObiRawImageFilter.h
@@ -56,7 +56,7 @@ public:
     }
   inline TOutput operator()( const TInput & A ) const
     {
-    return (!A)?0.:TOutput( std::log(m_I0-m_IDark) - std::log( A-m_IDark ) );
+    return (!A)?0.:TOutput( std::log( (m_I0-m_IDark) / ( A-m_IDark ) ) );
     }
   void SetI0(double i0) {m_I0 = i0;}
   void SetIDark(double idark) {m_IDark = idark;}


### PR DESCRIPTION
The following is a bit overkill for such a minor change, based on something as trivial as the `log` quotient rule, but anyway:

Discovered when running `callgrind`, because almost 30% of CPU time for my Xim image reader test (for my own app) were spend in `log`, this fix reduces it to about 17%. 
42% -> 50% of CPU-time spend in `fread`, a regular release is almost only bottlenecked by `fread`, _I think_.
2770 -> 1975 seconds for a `callgrind` (GCC 7.3 `RelWithDebug`) test run.
No significant difference on a regular `Release` test run, when also reading image from a regular SSD in the same test.

One would think the compiler were smart enough to look through this, but no: https://godbolt.org/z/3mqS1s

Because either of the `std::log` could raise and error, and because of special cases.
Therefore this mathematical equivalent is not necessarily computationally equivalent.

Relevant special case:
If `m_IDark > A`:
 The **division**-method will return a **number**.
 The **subtraction**-method will return **`NaN`**.
https://wandbox.org/permlink/xdT5pLysXxYW2FJ9 
I think a number would be preferred in this case?

(The `rtkGgoFunctions` change only bothered me because `git blame -L 159,172 rtkGgoFunctions.h` => agravgaard.)