### PR TITLE
BUG: Force wrapping of ExtractPhaseImageFilter

### DIFF
--- a/wrapping/rtkExtractPhaseImageFilter.wrap
+++ b/wrapping/rtkExtractPhaseImageFilter.wrap
@@ -1,3 +1,10 @@
 itk_wrap_class("rtk::ExtractPhaseImageFilter" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 1 1)
+  # WARNING: Do not use "itk_wrap_image_filter(${WRAP_ITK_REAL} 1 1)" macro.
+  # The "itk_wrap_image_filter" macro verifies that the dimension parameter
+  # exists in ITK_WRAP_IMAGE_DIMS before wrapping anything.
+  # Instead, RTK should force wrapping of dimension 1 even if it was not
+  # requested in ITK_WRAP_IMAGE_DIMS.
+  foreach(t ${WRAP_ITK_REAL})
+    itk_wrap_template("I${ITKM_${t}}1" "itk::Image<${ITKT_${t}}, 1>")
+  endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
When using itk_wrap_image_filter with dimension restriction, the
macro verifies that the dimension parameter is included in CMake
ITK_WRAP_IMAGE_DIMS variable.
Because RTK handle wrapping of dimension 1 regardless of
ITK_WRAP_IMAGE_DIMS value, this filter should not use the macro if we
want to ensure that it is wrapped for Python.