### PR TITLE
COMP: remove cmake CMP0077 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,10 @@ endif()
 # --------------------------------------------------------
 # Shared libraries option
 if(NOT ITK_SOURCE_DIR)
-  set(BUILD_SHARED_LIBS ${ITK_BUILD_SHARED})
+  set(RTK_BUILD_SHARED_LIBS ${ITK_BUILD_SHARED})
+else()
+  set(RTK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 endif()
-set(RTK_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 
 # ----------------------------------------------------------------------------
 # Set RTK_DATA_ROOT

--- a/cmake/FindCUDA_wrap.cmake
+++ b/cmake/FindCUDA_wrap.cmake
@@ -21,9 +21,6 @@ else ()
     string (REPLACE " " "," TMP "${TMP}")
     set (CUDA_CXX_FLAGS ${CUDA_CXX_FLAGS} ${TMP})
   endif ()
-
-  # GCS 2012-05-07: Workaround for poor, troubled FindCUDA
-  set (CUDA_ATTACH_VS_BUILD_RULE_TO_CUDA_FILE FALSE)
   find_package (CUDA QUIET)
 endif ()
 


### PR DESCRIPTION
@LucasGandel Can you have a look to this one to remove [cmake warnings](https://my.cdash.org/viewConfigure.php?buildid=1631189)? Thanks in advance.