### PR TITLE
STYLE: Use default member initialization

### DIFF
--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -242,12 +242,12 @@ protected:
     void GenerateOutputInformation() override;
 
 private:
-    float           m_Alpha;
-    float           m_Beta;
-    unsigned int    m_AL_iterations;
-    unsigned int    m_CG_iterations;
-    unsigned int    m_Order;
-    unsigned int    m_NumberOfLevels;
+    float           m_Alpha{1};
+    float           m_Beta{1};
+    unsigned int    m_AL_iterations{10};
+    unsigned int    m_CG_iterations{3};
+    unsigned int    m_Order{3};
+    unsigned int    m_NumberOfLevels{5};
     bool            m_DisableDisplacedDetectorFilter;
 
     ThreeDCircularProjectionGeometry::Pointer m_Geometry;

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
@@ -26,13 +26,7 @@ namespace rtk
 
 template< typename TOutputImage >
 ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>
-::ADMMWaveletsConeBeamReconstructionFilter():
-  m_Alpha(1),
-  m_Beta(1),
-  m_AL_iterations(10),
-  m_CG_iterations(3),
-  m_Order(3),
-  m_NumberOfLevels(5)
+::ADMMWaveletsConeBeamReconstructionFilter()
 {
   this->SetNumberOfRequiredInputs(2);
 

--- a/include/rtkAmsterdamShroudImageFilter.h
+++ b/include/rtkAmsterdamShroudImageFilter.h
@@ -162,10 +162,10 @@ private:
   typename ConvolutionType::Pointer m_ConvolutionFilter;
   typename SubtractType::Pointer    m_SubtractFilter;
   typename PermuteType::Pointer     m_PermuteFilter;
-  unsigned int                      m_UnsharpMaskSize;
-  GeometryPointer                   m_Geometry;
-  PointType                         m_Corner1;
-  PointType                         m_Corner2;
+  unsigned int                      m_UnsharpMaskSize{17};
+  GeometryPointer                   m_Geometry{nullptr};
+  PointType                         m_Corner1{0.};
+  PointType                         m_Corner2{0.};
 }; // end of class
 
 } // end namespace rtk

--- a/include/rtkAmsterdamShroudImageFilter.hxx
+++ b/include/rtkAmsterdamShroudImageFilter.hxx
@@ -30,11 +30,7 @@ namespace rtk
 
 template <class TInputImage>
 AmsterdamShroudImageFilter<TInputImage>
-::AmsterdamShroudImageFilter():
-  m_UnsharpMaskSize(17),
-  m_Geometry(nullptr),
-  m_Corner1(0.),
-  m_Corner2(0.)
+::AmsterdamShroudImageFilter()
 {
   m_DerivativeFilter = DerivativeType::New();
   m_NegativeFilter = NegativeType::New();

--- a/include/rtkBackProjectionImageFilter.h
+++ b/include/rtkBackProjectionImageFilter.h
@@ -83,7 +83,7 @@ public:
   itkSetMacro(Transpose, bool);
 
 protected:
-  BackProjectionImageFilter() : m_Geometry(nullptr), m_Transpose(false) {
+  BackProjectionImageFilter() : m_Geometry(nullptr) {
     this->SetNumberOfRequiredInputs(2); this->SetInPlace( true );
   };
   ~BackProjectionImageFilter() override = default;
@@ -144,7 +144,7 @@ protected:
 private:
   /** Flip projection flag: infludences GetProjection and
     GetIndexToIndexProjectionMatrix for optimization */
-  bool m_Transpose;
+  bool m_Transpose{false};
 };
 
 } // end namespace rtk

--- a/include/rtkBoellaardScatterCorrectionImageFilter.h
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.h
@@ -92,13 +92,13 @@ protected:
 
 private:
   /** Air threshold on projection images. */
-  double m_AirThreshold;
+  double m_AirThreshold{32000};
 
   /** Scatter to primary ratio */
-  double m_ScatterToPrimaryRatio;
+  double m_ScatterToPrimaryRatio{0.};
 
   /** Non-negativity constraint threshold */
-  double m_NonNegativityConstraintThreshold;
+  double m_NonNegativityConstraintThreshold{20};
 }; // end of class
 
 } // end namespace rtk

--- a/include/rtkBoellaardScatterCorrectionImageFilter.hxx
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.hxx
@@ -29,10 +29,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 BoellaardScatterCorrectionImageFilter<TInputImage, TOutputImage>
-::BoellaardScatterCorrectionImageFilter():
-m_AirThreshold(32000),
-m_ScatterToPrimaryRatio(0.),
-m_NonNegativityConstraintThreshold(20)
+::BoellaardScatterCorrectionImageFilter()
 {
 #if ITK_VERSION_MAJOR>4
   this->DynamicMultiThreadingOff();

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
@@ -83,9 +83,9 @@ protected:
     void AfterThreadedGenerateData() override;
 
 private:
-    double m_Alphak;
-    double m_SquaredNormR_k;
-    double m_SquaredNormR_kPlusOne;
+    double m_Alphak{0.};
+    double m_SquaredNormR_k{0.};
+    double m_SquaredNormR_kPlusOne{0.};
 
     // Thread synchronization tool
     itk::Barrier::Pointer m_Barrier;

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.hxx
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.hxx
@@ -29,10 +29,7 @@ namespace rtk
 {
 
 template< typename TInputType>
-ConjugateGradientGetR_kPlusOneImageFilter<TInputType>::ConjugateGradientGetR_kPlusOneImageFilter():
-    m_Alphak(0.),
-    m_SquaredNormR_k(0.),
-    m_SquaredNormR_kPlusOne(0.)
+ConjugateGradientGetR_kPlusOneImageFilter<TInputType>::ConjugateGradientGetR_kPlusOneImageFilter()
 {
 #if ITK_VERSION_MAJOR>4
   this->DynamicMultiThreadingOff();

--- a/include/rtkConvexShape.h
+++ b/include/rtkConvexShape.h
@@ -111,7 +111,7 @@ protected:
   itk::LightObject::Pointer InternalClone() const override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{0.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 };

--- a/include/rtkCyclicDeformationImageFilter.h
+++ b/include/rtkCyclicDeformationImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkSetMacro(Frame, unsigned int);
 
 protected:
-  CyclicDeformationImageFilter(): m_Frame(0) {}
+  CyclicDeformationImageFilter() {}
   ~CyclicDeformationImageFilter() override = default;
 
   void GenerateOutputInformation() override;
@@ -100,7 +100,7 @@ protected:
   double       m_WeightSup;
 
 private:
-  unsigned int m_Frame;
+  unsigned int m_Frame{0};
 
   std::string         m_SignalFilename;
   std::vector<double> m_Signal;

--- a/include/rtkDPExtractShroudSignalImageFilter.h
+++ b/include/rtkDPExtractShroudSignalImageFilter.h
@@ -76,7 +76,7 @@ protected:
   void GenerateData() override;
 
 private:
-  double    m_Amplitude;
+  double    m_Amplitude{0.};
 
 }; // end of class
 

--- a/include/rtkDPExtractShroudSignalImageFilter.hxx
+++ b/include/rtkDPExtractShroudSignalImageFilter.hxx
@@ -28,8 +28,7 @@ namespace rtk
 
 template<class TInputPixel, class TOutputPixel>
 DPExtractShroudSignalImageFilter<TInputPixel, TOutputPixel>
-::DPExtractShroudSignalImageFilter() :
-  m_Amplitude(0.)
+::DPExtractShroudSignalImageFilter()
 {
 }
 

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
@@ -127,10 +127,10 @@ private:
     CoefficientVector GenerateCoefficientsHighpassReconstruct();
 
     /** Specifies the wavelet type name */
-    unsigned int m_Order;
+    unsigned int m_Order{3};
 
     /** Specifies the filter pass along each dimension */
-    PassVector m_Pass;
+    PassVector m_Pass{PassVector(typename PassVector::ComponentType(0))};
 
     /** Specifies the filter type */
     Type m_Type;

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
@@ -31,9 +31,7 @@ namespace rtk
 
 template<typename TImage>
 DaubechiesWaveletsConvolutionImageFilter<TImage>
-::DaubechiesWaveletsConvolutionImageFilter():
-  m_Order(3),
-  m_Pass(PassVector(typename PassVector::ComponentType(0)))
+::DaubechiesWaveletsConvolutionImageFilter()
 {
   this->SetDeconstruction();
 }

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
@@ -128,9 +128,9 @@ protected:
     typename TImageSequence::RegionType             m_ExtractAndPasteRegion;
 
     /** Information for the wavelets denoising filter */
-    unsigned int    m_Order;
-    float           m_Threshold;
-    unsigned int    m_NumberOfLevels;
+    unsigned int    m_Order{5};
+    float           m_Threshold{1};
+    unsigned int    m_NumberOfLevels{3};
 
 };
 } //namespace ITK

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.hxx
@@ -27,10 +27,7 @@ namespace rtk
 
 template< typename TImageSequence>
 DaubechiesWaveletsDenoiseSequenceImageFilter< TImageSequence>
-::DaubechiesWaveletsDenoiseSequenceImageFilter():
-  m_Order(5),
-  m_Threshold(1),
-  m_NumberOfLevels(3)
+::DaubechiesWaveletsDenoiseSequenceImageFilter()
 {
   // Create the filters
   m_WaveletsDenoisingFilter = WaveletsDenoisingFilterType::New();

--- a/include/rtkDeconstructImageFilter.h
+++ b/include/rtkDeconstructImageFilter.h
@@ -220,9 +220,9 @@ protected:
     void GeneratePassVectors();
 
 private:
-    unsigned int m_NumberOfLevels;        // Holds the number of deconstruction levels
-    unsigned int m_Order;                 // Holds the order of the wavelet filters
-    bool         m_PipelineConstructed;   // Filters instantiated by GenerateOutputInformation() should be instantiated only once
+    unsigned int m_NumberOfLevels{5};        // Holds the number of deconstruction levels
+    unsigned int m_Order{3};                 // Holds the order of the wavelet filters
+    bool         m_PipelineConstructed{false};   // Filters instantiated by GenerateOutputInformation() should be instantiated only once
 
     typename std::vector<typename InputImageType::SizeType>             m_Sizes; //Holds the size of sub-images at each level
     typename std::vector<typename InputImageType::IndexType>            m_Indices; //Holds the size of sub-images at each level

--- a/include/rtkDeconstructImageFilter.hxx
+++ b/include/rtkDeconstructImageFilter.hxx
@@ -27,10 +27,7 @@ namespace rtk
 /////////////////////////////////////////////////////////
 //Default Constructor
 template <class TImage>
-DeconstructImageFilter<TImage>::DeconstructImageFilter():
-  m_NumberOfLevels(5),
-  m_Order(3),
-  m_PipelineConstructed(false)
+DeconstructImageFilter<TImage>::DeconstructImageFilter()
 {
 }
 

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
@@ -81,9 +81,9 @@ private:
   /**
    * Center coordinates and size of the FOV cylinder.
    */
-  double m_FOVRadius;
-  double m_FOVCenterX;
-  double m_FOVCenterZ;
+  double m_FOVRadius{-1.};
+  double m_FOVCenterX{0.};
+  double m_FOVCenterZ{0.};
 }; // end of class
 
 } // end namespace rtk

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
@@ -32,10 +32,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 DisplacedDetectorForOffsetFieldOfViewImageFilter<TInputImage, TOutputImage>
-::DisplacedDetectorForOffsetFieldOfViewImageFilter():
-  m_FOVRadius(-1.),
-  m_FOVCenterX(0.),
-  m_FOVCenterZ(0.)
+::DisplacedDetectorForOffsetFieldOfViewImageFilter()
 {
 }
 

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -128,7 +128,7 @@ protected:
 #endif
 
   // Iterative filters do not need padding
-  bool m_PadOnTruncatedSide;
+  bool m_PadOnTruncatedSide{true};
 
 private:
   /** RTK geometry object */
@@ -139,24 +139,24 @@ private:
    * If a priori known, these values can be given as input. Otherwise, they are computed from the
    * complete geometry.
    */
-  double m_MinimumOffset;
-  double m_MaximumOffset;
+  double m_MinimumOffset{0.};
+  double m_MaximumOffset{0.};
 
   /**
    * Flag used to know if the user has entered the min/max values of the detector offset.
    */
-  bool m_OffsetsSet;
+  bool m_OffsetsSet{false};
 
   /** Superior and inferior position of the detector along the weighting
    *  direction, i.e., the virtual detector described in ToUntiltedCoordinate.
    */
-  double m_InferiorCorner;
-  double m_SuperiorCorner;
+  double m_InferiorCorner{0.};
+  double m_SuperiorCorner{0.};
 
   /** When using a geometry that the displaced detector cannot manage,
    * it has to be disabled
    */
-  bool m_Disable;
+  bool m_Disable{false};
 
 }; // end of class
 

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -30,14 +30,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 DisplacedDetectorImageFilter<TInputImage, TOutputImage>
-::DisplacedDetectorImageFilter():
-  m_PadOnTruncatedSide(true),
-  m_MinimumOffset(0.),
-  m_MaximumOffset(0.),
-  m_OffsetsSet(false),
-  m_InferiorCorner(0.),
-  m_SuperiorCorner(0.),
-  m_Disable(false)
+::DisplacedDetectorImageFilter()
 {
 }
 

--- a/include/rtkDrawBoxImageFilter.h
+++ b/include/rtkDrawBoxImageFilter.h
@@ -90,12 +90,12 @@ protected:
   void BeforeThreadedGenerateData ( ) override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
-  VectorType         m_BoxMin;
-  VectorType         m_BoxMax;
+  VectorType         m_BoxMin{0.};
+  VectorType         m_BoxMax{0.};
   RotationMatrixType m_Direction;
 };
 

--- a/include/rtkDrawBoxImageFilter.hxx
+++ b/include/rtkDrawBoxImageFilter.hxx
@@ -30,10 +30,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 DrawBoxImageFilter<TInputImage, TOutputImage>
-::DrawBoxImageFilter():
-  m_Density(1.),
-  m_BoxMin(0.),
-  m_BoxMax(0.)
+::DrawBoxImageFilter()
 {
   m_Direction.SetIdentity();
 }

--- a/include/rtkDrawEllipsoidImageFilter.h
+++ b/include/rtkDrawEllipsoidImageFilter.h
@@ -88,13 +88,13 @@ protected:
   void BeforeThreadedGenerateData() override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
   PointType  m_Center;
   VectorType m_Axis;
-  ScalarType m_Angle;
+  ScalarType m_Angle{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkDrawEllipsoidImageFilter.hxx
+++ b/include/rtkDrawEllipsoidImageFilter.hxx
@@ -31,9 +31,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 DrawEllipsoidImageFilter<TInputImage, TOutputImage>
-::DrawEllipsoidImageFilter():
-    m_Density(1.),
-    m_Angle(0.)
+::DrawEllipsoidImageFilter()
 {
   m_Center.Fill(0.);
   m_Axis.Fill(90.);

--- a/include/rtkDrawGeometricPhantomImageFilter.h
+++ b/include/rtkDrawGeometricPhantomImageFilter.h
@@ -96,9 +96,9 @@ protected:
 private:
   GeometricPhantomConstPointer m_GeometricPhantom;
   StringType                   m_ConfigFile;
-  VectorType                   m_PhantomScale;
-  VectorType                   m_OriginOffset;
-  bool                         m_IsForbildConfigFile;
+  VectorType                   m_PhantomScale{1.};
+  VectorType                   m_OriginOffset{0.};
+  bool                         m_IsForbildConfigFile{false};
   RotationMatrixType           m_RotationMatrix;
 };
 

--- a/include/rtkDrawGeometricPhantomImageFilter.hxx
+++ b/include/rtkDrawGeometricPhantomImageFilter.hxx
@@ -34,10 +34,7 @@ namespace rtk
 {
 template <class TInputImage, class TOutputImage>
 DrawGeometricPhantomImageFilter<TInputImage, TOutputImage>
-::DrawGeometricPhantomImageFilter():
-m_PhantomScale(1.),
-m_OriginOffset(0.),
-m_IsForbildConfigFile(false)
+::DrawGeometricPhantomImageFilter()
 {
   m_RotationMatrix.SetIdentity();
 }

--- a/include/rtkDrawQuadricImageFilter.h
+++ b/include/rtkDrawQuadricImageFilter.h
@@ -96,20 +96,20 @@ protected:
   void BeforeThreadedGenerateData ( ) override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
-  ScalarType m_A;
-  ScalarType m_B;
-  ScalarType m_C;
-  ScalarType m_D;
-  ScalarType m_E;
-  ScalarType m_F;
-  ScalarType m_G;
-  ScalarType m_H;
-  ScalarType m_I;
-  ScalarType m_J;
+  ScalarType m_A{0.};
+  ScalarType m_B{0.};
+  ScalarType m_C{0.};
+  ScalarType m_D{0.};
+  ScalarType m_E{0.};
+  ScalarType m_F{0.};
+  ScalarType m_G{0.};
+  ScalarType m_H{0.};
+  ScalarType m_I{0.};
+  ScalarType m_J{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkDrawQuadricImageFilter.hxx
+++ b/include/rtkDrawQuadricImageFilter.hxx
@@ -31,18 +31,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 DrawQuadricImageFilter<TInputImage, TOutputImage>
-::DrawQuadricImageFilter():
-  m_Density(1.),
-  m_A(0.),
-  m_B(0.),
-  m_C(0.),
-  m_D(0.),
-  m_E(0.),
-  m_F(0.),
-  m_G(0.),
-  m_H(0.),
-  m_I(0.),
-  m_J(0.)
+::DrawQuadricImageFilter()
 {
 }
 

--- a/include/rtkElektaXVI5GeometryXMLFile.h
+++ b/include/rtkElektaXVI5GeometryXMLFile.h
@@ -89,26 +89,26 @@ protected:
   void CharacterDataHandler(const char *inData, int inLength) override;
 
 private:
-  GeometryPointer m_Geometry;
+  GeometryPointer m_Geometry{GeometryType::New()};
 
   std::string m_CurCharacterData;
 
   /** Projection parameters */
-  double m_InPlaneAngle;
-  double m_OutOfPlaneAngle;
-  double m_GantryAngle;
-  double m_SourceToIsocenterDistance;
-  double m_SourceOffsetX;
-  double m_SourceOffsetY;
-  double m_SourceToDetectorDistance;
-  double m_ProjectionOffsetX;
-  double m_ProjectionOffsetY;
+  double m_InPlaneAngle{0.};
+  double m_OutOfPlaneAngle{0.};
+  double m_GantryAngle{0.};
+  double m_SourceToIsocenterDistance{1000.};
+  double m_SourceOffsetX{0.};
+  double m_SourceOffsetY{0.};
+  double m_SourceToDetectorDistance{1536.};
+  double m_ProjectionOffsetX{0.};
+  double m_ProjectionOffsetY{0.};
 
   /** Projection matrix */
   ThreeDCircularProjectionGeometry::MatrixType m_Matrix;
 
   /** File format version */
-  unsigned int m_Version;
+  unsigned int m_Version{0};
 };
 }
 

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -136,7 +136,7 @@ protected:
 
 private:
   /** Number of projections processed at a time. */
-  unsigned int m_ProjectionSubsetSize;
+  unsigned int m_ProjectionSubsetSize{16};
 
   /** Geometry propagated to subfilters of the mini-pipeline. */
   ThreeDCircularProjectionGeometry::Pointer m_Geometry;

--- a/include/rtkFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkFDKConeBeamReconstructionFilter.hxx
@@ -26,8 +26,7 @@ namespace rtk
 
 template<class TInputImage, class TOutputImage, class TFFTPrecision>
 FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>
-::FDKConeBeamReconstructionFilter():
-  m_ProjectionSubsetSize(16)
+::FDKConeBeamReconstructionFilter()
 {
   this->SetNumberOfRequiredInputs(2);
 

--- a/include/rtkFDKWarpBackProjectionImageFilter.h
+++ b/include/rtkFDKWarpBackProjectionImageFilter.h
@@ -89,7 +89,7 @@ protected:
 private:
   DeformationPointer    m_Deformation;
   itk::Barrier::Pointer m_Barrier;
-  bool                  m_DeformationUpdateError;
+  bool                  m_DeformationUpdateError{false};
 };
 
 } // end namespace rtk

--- a/include/rtkFDKWarpBackProjectionImageFilter.hxx
+++ b/include/rtkFDKWarpBackProjectionImageFilter.hxx
@@ -31,8 +31,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage, class TDeformation>
 FDKWarpBackProjectionImageFilter<TInputImage,TOutputImage,TDeformation>
-::FDKWarpBackProjectionImageFilter():
-    m_DeformationUpdateError(false)
+::FDKWarpBackProjectionImageFilter()
 {
 #if ITK_VERSION_MAJOR>4
   this->DynamicMultiThreadingOff();

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -158,7 +158,7 @@ protected:
 
     /** Must be set to fix whether the kernel is 1D or 2D. Will have an effect on
    * the padded region and the input requested region. */
-  int m_KernelDimension;
+  int m_KernelDimension{1};
 
   /**
     * FFT of the convolution kernel that each daughter class must update.
@@ -169,7 +169,7 @@ private:
   /** Percentage of the image width which is feathered with data to correct for truncation.
     * 0 (default) means no correction.
     */
-  double m_TruncationCorrection;
+  double m_TruncationCorrection{0.};
   int GetTruncationCorrectionExtent();
 
   /** Zero padding factors in x and y directions. Accepted values are either 1
@@ -180,8 +180,8 @@ private:
   /**
    * Greatest prime factor of the FFT input.
    */
-  int m_GreatestPrimeFactor;
-  int m_BackupNumberOfThreads;
+  int m_GreatestPrimeFactor{2};
+  int m_BackupNumberOfThreads{1};
 }; // end of class
 
 } // end namespace rtk

--- a/include/rtkFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.hxx
@@ -34,11 +34,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
-::FFTProjectionsConvolutionImageFilter() :
-  m_KernelDimension(1),
-  m_TruncationCorrection(0.),
-  m_GreatestPrimeFactor(2),
-  m_BackupNumberOfThreads(1)
+::FFTProjectionsConvolutionImageFilter()
 {
 #if defined(USE_FFTWD)
   if(typeid(TFFTPrecision).name() == typeid(double).name() )

--- a/include/rtkFFTRampImageFilter.h
+++ b/include/rtkFFTRampImageFilter.h
@@ -142,15 +142,15 @@ private:
    * Cut frequency of Hann, Cosine and Hamming windows. The first one which is
    * non-zero is used.
    */
-  double m_HannCutFrequency;
-  double m_CosineCutFrequency;
-  double m_HammingFrequency;
-  double m_HannCutFrequencyY;
+  double m_HannCutFrequency{0.};
+  double m_CosineCutFrequency{0.};
+  double m_HammingFrequency{0.};
+  double m_HannCutFrequencyY{0.};
 
   /** Cut frequency of Ram-Lak and Shepp-Logan
     */
-  double m_RamLakCutFrequency;
-  double m_SheppLoganCutFrequency;
+  double m_RamLakCutFrequency{0.};
+  double m_SheppLoganCutFrequency{0.};
 
   SizeType m_PreviousKernelUpdateSize;
 }; // end of class

--- a/include/rtkFFTRampImageFilter.hxx
+++ b/include/rtkFFTRampImageFilter.hxx
@@ -34,13 +34,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 FFTRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>
-::FFTRampImageFilter() :
-  m_HannCutFrequency(0.),
-  m_CosineCutFrequency(0.),
-  m_HammingFrequency(0.),
-  m_HannCutFrequencyY(0.),
-  m_RamLakCutFrequency(0.),
-  m_SheppLoganCutFrequency(0.)
+::FFTRampImageFilter()
 {
 }
 

--- a/include/rtkFieldOfViewImageFilter.h
+++ b/include/rtkFieldOfViewImageFilter.h
@@ -124,17 +124,17 @@ protected:
 #endif
 
 private:
-  GeometryConstPointer    m_Geometry;
-  bool                    m_Mask;
+  GeometryConstPointer    m_Geometry{nullptr};
+  bool                    m_Mask{false};
   ProjectionsStackPointer m_ProjectionsStack;
-  double                  m_Radius;
-  double                  m_CenterX;
-  double                  m_CenterZ;
+  double                  m_Radius{-1};
+  double                  m_CenterX{0.};
+  double                  m_CenterZ{0.};
   double                  m_HatTangentInf;
   double                  m_HatTangentSup;
   double                  m_HatHeightInf;
   double                  m_HatHeightSup;
-  bool                    m_DisplacedDetector;
+  bool                    m_DisplacedDetector{false};
 };
 
 } // end namespace rtk

--- a/include/rtkFieldOfViewImageFilter.hxx
+++ b/include/rtkFieldOfViewImageFilter.hxx
@@ -34,13 +34,7 @@ namespace rtk
 
 template<class TInputImage, class TOutputImage>
 FieldOfViewImageFilter<TInputImage, TOutputImage>
-::FieldOfViewImageFilter():
-  m_Geometry(nullptr),
-  m_Mask(false),
-  m_Radius(-1),
-  m_CenterX(0.),
-  m_CenterZ(0.),
-  m_DisplacedDetector(false)
+::FieldOfViewImageFilter()
 {
 }
 

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -287,8 +287,8 @@ protected:
   TSplatWeightMultiplication         m_SplatWeightMultiplication;
   TInterpolationWeightMultiplication m_InterpolationWeightMultiplication;
   TSumAlongRay                       m_SumAlongRay;
-  double                             m_InferiorClip;
-  double                             m_SuperiorClip;
+  double                             m_InferiorClip{0.};
+  double                             m_SuperiorClip{1.};
 
 };
 

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -42,9 +42,7 @@ JosephBackProjectionImageFilter<TInputImage,
                                 TInterpolationWeightMultiplication,
                                 TSplatWeightMultiplication,
                                 TSumAlongRay >
-::JosephBackProjectionImageFilter():
-    m_InferiorClip(0.),
-    m_SuperiorClip(1.)
+::JosephBackProjectionImageFilter()
 {
 }
 

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -270,8 +270,8 @@ private:
   TInterpolationWeightMultiplication m_InterpolationWeightMultiplication;
   TProjectedValueAccumulation        m_ProjectedValueAccumulation;
   TSumAlongRay                       m_SumAlongRay;
-  double                             m_InferiorClip;
-  double                             m_SuperiorClip;
+  double                             m_InferiorClip{0.};
+  double                             m_SuperiorClip{1.};
 };
 
 } // end namespace rtk

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -40,9 +40,7 @@ TOutputImage,
 TInterpolationWeightMultiplication,
 TProjectedValueAccumulation,
 TSumAlongRay>
-::JosephForwardProjectionImageFilter():
-  m_InferiorClip(0.),
-  m_SuperiorClip(1.)
+::JosephForwardProjectionImageFilter()
 {
 #if ITK_VERSION_MAJOR>4
   this->DynamicMultiThreadingOff();

--- a/include/rtkOraLookupTableImageFilter.h
+++ b/include/rtkOraLookupTableImageFilter.h
@@ -89,11 +89,11 @@ public:
     }
 
 protected:
-  OraLookupTableImageFilter(): m_ComputeLineIntegral(true){}
+  OraLookupTableImageFilter() {}
   ~OraLookupTableImageFilter() override = default;
 
 private:
-  bool                      m_ComputeLineIntegral;
+  bool                      m_ComputeLineIntegral{true};
 
   /** A list of filenames to be processed. */
   FileNamesContainer        m_FileNames;

--- a/include/rtkPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkPolynomialGainCorrectionImageFilter.h
@@ -94,9 +94,9 @@ protected:
   void DynamicThreadedGenerateData( const OutputImageRegionType& outputRegionForThread) override;
 #endif
 
-  bool               m_MapsLoaded;        // True if gain maps loaded
-  int                m_ModelOrder;        // Polynomial correction order
-  float              m_K;                 // Scaling constant, a 0 means no correction
+  bool               m_MapsLoaded{false};        // True if gain maps loaded
+  int                m_ModelOrder{1};        // Polynomial correction order
+  float              m_K{1.0f};                 // Scaling constant, a 0 means no correction
   VectorType         m_PowerLut;          // Vector containing I^n
   InputImagePointer  m_DarkImage;         // Dark image
   OutputImagePointer m_GainImage;         // Gain coefficients (A matrix)

--- a/include/rtkPolynomialGainCorrectionImageFilter.hxx
+++ b/include/rtkPolynomialGainCorrectionImageFilter.hxx
@@ -30,10 +30,7 @@ namespace rtk
 
 template<class TInputImage, class TOutputImage>
 PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>
-::PolynomialGainCorrectionImageFilter():
-    m_MapsLoaded(false),
-    m_ModelOrder(1),
-    m_K(1.0f)
+::PolynomialGainCorrectionImageFilter()
 {
 }
 

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -104,9 +104,9 @@ private:
   GeometricPhantomConstPointer m_GeometricPhantom;
   GeometryConstPointer         m_Geometry;
   StringType                   m_ConfigFile;
-  VectorType                   m_PhantomScale;
-  VectorType                   m_OriginOffset;
-  bool                         m_IsForbildConfigFile;
+  VectorType                   m_PhantomScale{1.};
+  VectorType                   m_OriginOffset{0.};
+  bool                         m_IsForbildConfigFile{false};
   RotationMatrixType           m_RotationMatrix;
 };
 

--- a/include/rtkProjectGeometricPhantomImageFilter.hxx
+++ b/include/rtkProjectGeometricPhantomImageFilter.hxx
@@ -34,10 +34,7 @@ namespace rtk
 {
 template <class TInputImage, class TOutputImage>
 ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>
-::ProjectGeometricPhantomImageFilter():
-m_PhantomScale(1.),
-m_OriginOffset(0.),
-m_IsForbildConfigFile(false)
+::ProjectGeometricPhantomImageFilter()
 {
   m_RotationMatrix.SetIdentity();
 }

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -297,7 +297,7 @@ private:
   typename StreamingType::Pointer          m_StreamingFilter;
 
   /** Image IO object which is stored to create the pipe only when required */
-  itk::ImageIOBase::Pointer m_ImageIO;
+  itk::ImageIOBase::Pointer m_ImageIO{nullptr};
 
   /** Copy of parameters for the mini-pipeline. Parameters are checked and
    * propagated when required in the GenerateOutputInformation. Refer to the
@@ -309,15 +309,15 @@ private:
   OutputImageSizeType          m_UpperBoundaryCropSize;
   ShrinkFactorsType            m_ShrinkFactors;
   MedianRadiusType             m_MedianRadius;
-  double                       m_AirThreshold;
-  double                       m_ScatterToPrimaryRatio;
-  double                       m_NonNegativityConstraintThreshold;
-  double                       m_I0;
-  double                       m_IDark;
-  double                       m_ConditionalMedianThresholdMultiplier;
+  double                       m_AirThreshold{32000};
+  double                       m_ScatterToPrimaryRatio{0.};
+  double                       m_NonNegativityConstraintThreshold{itk::NumericTraits<double>::NonpositiveMin()};
+  double                       m_I0{itk::NumericTraits<double>::NonpositiveMin()};
+  double                       m_IDark{0.};
+  double                       m_ConditionalMedianThresholdMultiplier{1.};
   WaterPrecorrectionVectorType m_WaterPrecorrectionCoefficients;
-  bool                         m_ComputeLineIntegral;
-  unsigned int                 m_VectorComponent;
+  bool                         m_ComputeLineIntegral{true};
+  unsigned int                 m_VectorComponent{0};
 };
 
 } //namespace rtk

--- a/include/rtkProjectionsReader.hxx
+++ b/include/rtkProjectionsReader.hxx
@@ -105,16 +105,7 @@ namespace rtk
 //--------------------------------------------------------------------
 template <class TOutputImage>
 ProjectionsReader<TOutputImage>
-::ProjectionsReader():
-  m_ImageIO(nullptr),
-  m_AirThreshold(32000),
-  m_ScatterToPrimaryRatio(0.),
-  m_NonNegativityConstraintThreshold( itk::NumericTraits<double>::NonpositiveMin() ),
-  m_I0( itk::NumericTraits<double>::NonpositiveMin() ),
-  m_IDark( 0. ),
-  m_ConditionalMedianThresholdMultiplier( 1. ),
-  m_ComputeLineIntegral(true),
-  m_VectorComponent(0)
+::ProjectionsReader()
 {
   // Filters common to all input types and that do not depend on the input image type.
   m_WaterPrecorrectionFilter = WaterPrecorrectionType::New();

--- a/include/rtkQuadricShape.h
+++ b/include/rtkQuadricShape.h
@@ -111,16 +111,16 @@ public:
 private:
   QuadricShape();
 
-  ScalarType m_A;
-  ScalarType m_B;
-  ScalarType m_C;
-  ScalarType m_D;
-  ScalarType m_E;
-  ScalarType m_F;
-  ScalarType m_G;
-  ScalarType m_H;
-  ScalarType m_I;
-  ScalarType m_J;
+  ScalarType m_A{0.};
+  ScalarType m_B{0.};
+  ScalarType m_C{0.};
+  ScalarType m_D{0.};
+  ScalarType m_E{0.};
+  ScalarType m_F{0.};
+  ScalarType m_G{0.};
+  ScalarType m_H{0.};
+  ScalarType m_I{0.};
+  ScalarType m_J{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkRayBoxIntersectionImageFilter.h
+++ b/include/rtkRayBoxIntersectionImageFilter.h
@@ -90,12 +90,12 @@ protected:
   void BeforeThreadedGenerateData ( ) override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
-  PointType               m_BoxMin;
-  PointType               m_BoxMax;
+  PointType               m_BoxMin{0.};
+  PointType               m_BoxMax{0.};
   RotationMatrixType      m_Direction;
 };
 

--- a/include/rtkRayBoxIntersectionImageFilter.hxx
+++ b/include/rtkRayBoxIntersectionImageFilter.hxx
@@ -31,10 +31,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 RayBoxIntersectionImageFilter<TInputImage, TOutputImage>
-::RayBoxIntersectionImageFilter():
-  m_Density(1.),
-  m_BoxMin(0.),
-  m_BoxMax(0.)
+::RayBoxIntersectionImageFilter()
 {
   m_Direction.SetIdentity();
 }

--- a/include/rtkRayEllipsoidIntersectionImageFilter.h
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.h
@@ -93,13 +93,13 @@ protected:
   void BeforeThreadedGenerateData() override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
   PointType               m_Center;
   VectorType              m_Axis;
-  ScalarType              m_Angle;
+  ScalarType              m_Angle{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkRayEllipsoidIntersectionImageFilter.hxx
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.hxx
@@ -27,9 +27,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 RayEllipsoidIntersectionImageFilter<TInputImage, TOutputImage>
-::RayEllipsoidIntersectionImageFilter():
-    m_Density(1.),
-    m_Angle(0.)
+::RayEllipsoidIntersectionImageFilter()
 {
   m_Center.Fill(0.);
   m_Axis.Fill(0.);

--- a/include/rtkRayQuadricIntersectionImageFilter.h
+++ b/include/rtkRayQuadricIntersectionImageFilter.h
@@ -98,20 +98,20 @@ protected:
   void BeforeThreadedGenerateData ( ) override;
 
 private:
-  ScalarType              m_Density;
+  ScalarType              m_Density{1.};
   std::vector<VectorType> m_PlaneDirections;
   std::vector<ScalarType> m_PlanePositions;
 
-  ScalarType m_A;
-  ScalarType m_B;
-  ScalarType m_C;
-  ScalarType m_D;
-  ScalarType m_E;
-  ScalarType m_F;
-  ScalarType m_G;
-  ScalarType m_H;
-  ScalarType m_I;
-  ScalarType m_J;
+  ScalarType m_A{0.};
+  ScalarType m_B{0.};
+  ScalarType m_C{0.};
+  ScalarType m_D{0.};
+  ScalarType m_E{0.};
+  ScalarType m_F{0.};
+  ScalarType m_G{0.};
+  ScalarType m_H{0.};
+  ScalarType m_I{0.};
+  ScalarType m_J{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkRayQuadricIntersectionImageFilter.hxx
+++ b/include/rtkRayQuadricIntersectionImageFilter.hxx
@@ -31,18 +31,7 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 RayQuadricIntersectionImageFilter<TInputImage, TOutputImage>
-::RayQuadricIntersectionImageFilter():
-  m_Density(1.),
-  m_A(0.),
-  m_B(0.),
-  m_C(0.),
-  m_D(0.),
-  m_E(0.),
-  m_F(0.),
-  m_G(0.),
-  m_H(0.),
-  m_I(0.),
-  m_J(0.)
+::RayQuadricIntersectionImageFilter()
 {
 }
 

--- a/include/rtkReconstructImageFilter.h
+++ b/include/rtkReconstructImageFilter.h
@@ -218,9 +218,9 @@ protected:
     void GeneratePassVectors();
 
 private:
-    unsigned int m_NumberOfLevels;        // Holds the number of Reconstruction levels
-    unsigned int m_Order;                 // Holds the order of the wavelet filters
-    bool         m_PipelineConstructed;   // Filters instantiated by GenerateOutputInformation() should be instantiated only once
+    unsigned int m_NumberOfLevels{5};         // Holds the number of Reconstruction levels
+    unsigned int m_Order{3};                  // Holds the order of the wavelet filters
+    bool         m_PipelineConstructed{false};// Filters instantiated by GenerateOutputInformation() should be instantiated only once
 
     typename InputImageType::SizeType                                  *m_Sizes; //Holds the size of sub-images at each level
     typename InputImageType::IndexType                                 *m_Indices; //Holds the size of sub-images at each level

--- a/include/rtkReconstructImageFilter.hxx
+++ b/include/rtkReconstructImageFilter.hxx
@@ -28,10 +28,7 @@ namespace rtk
 /////////////////////////////////////////////////////////
 //Default Constructor
 template <class TImage>
-ReconstructImageFilter<TImage>::ReconstructImageFilter():
-  m_NumberOfLevels(5),
-  m_Order(3),
-  m_PipelineConstructed(false)
+ReconstructImageFilter<TImage>::ReconstructImageFilter()
 {
 }
 

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -215,9 +215,9 @@ protected:
   typename MultiplyWithWeightsFilterType::Pointer                       m_MultiplyWithWeightsFilter;
 
   /** Member attributes */
-  rtk::ThreeDCircularProjectionGeometry::ConstPointer    m_Geometry;
-  float                                                  m_Gamma; //Strength of the laplacian regularization
-  float                                                  m_Tikhonov; //Strength of the Tikhonov regularization
+  rtk::ThreeDCircularProjectionGeometry::ConstPointer    m_Geometry{nullptr};
+  float                                                  m_Gamma{0}; //Strength of the laplacian regularization
+  float                                                  m_Tikhonov{0}; //Strength of the Tikhonov regularization
 
   /** Pointers to intermediate images, used to simplify complex branching */
   typename TOutputImage::Pointer m_FloatingInputPointer, m_FloatingOutputPointer;

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -30,10 +30,7 @@ template< typename TOutputImage,
 ReconstructionConjugateGradientOperator<TOutputImage,
                                         TSingleComponentImage,
                                         TWeightsImage>
-::ReconstructionConjugateGradientOperator():
-  m_Geometry(nullptr),
-  m_Gamma(0),
-  m_Tikhonov(0)
+::ReconstructionConjugateGradientOperator()
 {
   this->SetNumberOfRequiredInputs(3);
 

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.h
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.h
@@ -68,7 +68,7 @@ protected:
 
 private:
   std::string         m_SignalFilename;
-  double              m_Phase;
+  double              m_Phase{0.};
   std::vector<double> m_Signal;
 };
 } //namespace ITK

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
@@ -26,8 +26,7 @@ namespace rtk
 
 template<typename ProjectionStackType>
 SelectOneProjectionPerCycleImageFilter<ProjectionStackType>
-::SelectOneProjectionPerCycleImageFilter():
-  m_Phase(0.)
+::SelectOneProjectionPerCycleImageFilter()
 {
 }
 

--- a/include/rtkThreeDCircularProjectionGeometry.h
+++ b/include/rtkThreeDCircularProjectionGeometry.h
@@ -356,7 +356,7 @@ protected:
   std::vector<double> m_ProjectionOffsetsY;
 
   /** Radius of curved detector. The default is 0 and it means a flat detector. */
-  double m_RadiusCylindricalDetector;
+  double m_RadiusCylindricalDetector{0.};
 
   /** Parameters of the collimation jaws.
    * The collimation position is with respect to the distance of the m_RotationCenter along

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
@@ -87,30 +87,30 @@ protected:
   void CharacterDataHandler(const char *inData, int inLength) override;
 
 private:
-  GeometryPointer m_Geometry;
+  GeometryPointer m_Geometry{GeometryType::New()};
 
-  std::string m_CurCharacterData;
+  std::string m_CurCharacterData{""};
 
   /** Projection parameters */
-  double m_InPlaneAngle;
-  double m_OutOfPlaneAngle;
-  double m_GantryAngle;
-  double m_SourceToIsocenterDistance;
-  double m_SourceOffsetX;
-  double m_SourceOffsetY;
-  double m_SourceToDetectorDistance;
-  double m_ProjectionOffsetX;
-  double m_ProjectionOffsetY;
-  double m_CollimationUInf;
-  double m_CollimationUSup;
-  double m_CollimationVInf;
-  double m_CollimationVSup;
+  double m_InPlaneAngle{0.};
+  double m_OutOfPlaneAngle{0.};
+  double m_GantryAngle{0.};
+  double m_SourceToIsocenterDistance{0.};
+  double m_SourceOffsetX{0.};
+  double m_SourceOffsetY{0.};
+  double m_SourceToDetectorDistance{0.};
+  double m_ProjectionOffsetX{0.};
+  double m_ProjectionOffsetY{0.};
+  double m_CollimationUInf{std::numeric_limits< double >::max()};
+  double m_CollimationUSup{std::numeric_limits< double >::max()};
+  double m_CollimationVInf{std::numeric_limits< double >::max()};
+  double m_CollimationVSup{std::numeric_limits< double >::max()};
 
   /** Projection matrix */
   ThreeDCircularProjectionGeometry::MatrixType m_Matrix;
 
   /** File format version */
-  unsigned int m_Version;
+  unsigned int m_Version{0};
 };
 }
 #endif

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.h
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.h
@@ -134,8 +134,8 @@ protected:
     typename TImageSequence::RegionType       m_ExtractAndPasteRegion;
 
     /** Information for the total variation denoising filter */
-    double m_Gamma;
-    int    m_NumberOfIterations;
+    double m_Gamma{1.};
+    int    m_NumberOfIterations{1};
     bool   m_DimensionsProcessed[TImage::ImageDimension];
 };
 } //namespace ITK

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
@@ -27,9 +27,7 @@ namespace rtk
 
 template< typename TImageSequence>
 TotalVariationDenoiseSequenceImageFilter< TImageSequence>
-::TotalVariationDenoiseSequenceImageFilter():
-  m_Gamma(1.),
-  m_NumberOfIterations(1)
+::TotalVariationDenoiseSequenceImageFilter()
 {
   // Create the filters
   m_TVDenoisingFilter = TVDenoisingFilterType::New();

--- a/include/rtkVarianObiRawImageFilter.h
+++ b/include/rtkVarianObiRawImageFilter.h
@@ -115,8 +115,8 @@ protected:
   ~VarianObiRawImageFilter() override = default;
 
 private:
-  double m_I0;
-  double m_IDark;
+  double m_I0{139000.};
+  double m_IDark{0.};
 };
 
 } // end namespace rtk

--- a/include/rtkVarianObiRawImageFilter.hxx
+++ b/include/rtkVarianObiRawImageFilter.hxx
@@ -27,9 +27,7 @@ namespace rtk
 
 template< typename TInputImage, typename TOutputImage >
 VarianObiRawImageFilter< TInputImage, TOutputImage >
-::VarianObiRawImageFilter():
-  m_I0(139000.),
-  m_IDark(0.)
+::VarianObiRawImageFilter()
 {
 }
 

--- a/include/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.h
@@ -177,7 +177,7 @@ protected:
     /** Member pointers to the filters used internally (for convenience)*/
     typename CPUDVFInterpolatorType::Pointer m_DVFInterpolatorFilter;
     std::vector<double>                      m_Signal;
-    bool                                     m_UseCudaCyclicDeformation;
+    bool                                     m_UseCudaCyclicDeformation{false};
 
 };
 } //namespace ITK

--- a/include/rtkWarpFourDToProjectionStackImageFilter.hxx
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.hxx
@@ -24,8 +24,7 @@ namespace rtk
 {
 
 template< typename VolumeSeriesType, typename ProjectionStackType>
-WarpFourDToProjectionStackImageFilter< VolumeSeriesType, ProjectionStackType>::WarpFourDToProjectionStackImageFilter():
-    m_UseCudaCyclicDeformation(false)
+WarpFourDToProjectionStackImageFilter< VolumeSeriesType, ProjectionStackType>::WarpFourDToProjectionStackImageFilter()
 {
   this->SetNumberOfRequiredInputs(3);
 

--- a/src/rtkConvexShape.cxx
+++ b/src/rtkConvexShape.cxx
@@ -22,8 +22,7 @@ namespace rtk
 {
 
 ConvexShape
-::ConvexShape():
-    m_Density(0.)
+::ConvexShape()
 {
 }
 

--- a/src/rtkElektaXVI5GeometryXMLFile.cxx
+++ b/src/rtkElektaXVI5GeometryXMLFile.cxx
@@ -28,19 +28,7 @@ namespace rtk
 {
 
 ElektaXVI5GeometryXMLFileReader::
-  ElektaXVI5GeometryXMLFileReader() :
-  m_Geometry(GeometryType::New() ),
-  m_CurCharacterData(""),
-  m_InPlaneAngle(0.),
-  m_OutOfPlaneAngle(0.),
-  m_GantryAngle(0.),
-  m_SourceToIsocenterDistance(1000.),
-  m_SourceOffsetX(0.),
-  m_SourceOffsetY(0.),
-  m_SourceToDetectorDistance(1536.),
-  m_ProjectionOffsetX(0.),
-  m_ProjectionOffsetY(0.),
-  m_Version(0)
+  ElektaXVI5GeometryXMLFileReader()
 {
   this->m_OutputObject = &(*m_Geometry);
 }

--- a/src/rtkQuadricShape.cxx
+++ b/src/rtkQuadricShape.cxx
@@ -22,17 +22,7 @@ namespace rtk
 {
 
 QuadricShape
-::QuadricShape():
-    m_A(0.),
-    m_B(0.),
-    m_C(0.),
-    m_D(0.),
-    m_E(0.),
-    m_F(0.),
-    m_G(0.),
-    m_H(0.),
-    m_I(0.),
-    m_J(0.)
+::QuadricShape()
 {
 }
 

--- a/src/rtkThreeDCircularProjectionGeometry.cxx
+++ b/src/rtkThreeDCircularProjectionGeometry.cxx
@@ -25,8 +25,7 @@
 #include <itkCenteredEuler3DTransform.h>
 #include <itkEuler3DTransform.h>
 
-rtk::ThreeDCircularProjectionGeometry::ThreeDCircularProjectionGeometry():
-    m_RadiusCylindricalDetector(0.)
+rtk::ThreeDCircularProjectionGeometry::ThreeDCircularProjectionGeometry()
 {
 }
 

--- a/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
+++ b/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
@@ -31,23 +31,7 @@ namespace rtk
 {
 
 ThreeDCircularProjectionGeometryXMLFileReader::
-ThreeDCircularProjectionGeometryXMLFileReader():
-  m_Geometry(GeometryType::New() ),
-  m_CurCharacterData(""),
-  m_InPlaneAngle(0.),
-  m_OutOfPlaneAngle(0.),
-  m_GantryAngle(0.),
-  m_SourceToIsocenterDistance(0.),
-  m_SourceOffsetX(0.),
-  m_SourceOffsetY(0.),
-  m_SourceToDetectorDistance(0.),
-  m_ProjectionOffsetX(0.),
-  m_ProjectionOffsetY(0.),
-  m_CollimationUInf(std::numeric_limits< double >::max()),
-  m_CollimationUSup(std::numeric_limits< double >::max()),
-  m_CollimationVInf(std::numeric_limits< double >::max()),
-  m_CollimationVSup(std::numeric_limits< double >::max()),
-  m_Version(0)
+ThreeDCircularProjectionGeometryXMLFileReader()
 {
   this->m_OutputObject = &(*m_Geometry);
 }

--- a/test/rtkargsinfomanagertest.cxx
+++ b/test/rtkargsinfomanagertest.cxx
@@ -5,10 +5,9 @@
 class args_info_test
 {
 public:
-  int testVar;
-  int verbose_flag;
-  args_info_test() : testVar(true), verbose_flag(0)
-  {}
+  int testVar{true};
+  int verbose_flag{0};
+  args_info_test(){}
 };
 
 class cleanup_functor


### PR DESCRIPTION
Converts a default constructor’s member initializers into the new
default member initializers in C++11. Other member initializers that match the
default member initializer are removed. This can reduce repeated code or allow
use of ‘= default’.