### PR TITLE
FIX Change from std::random_shuffle to std::shuffle

### DIFF
--- a/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
@@ -205,7 +205,7 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
       m_ProjectionsOrder.push_back(i);
       }
 
-    std::random_shuffle( m_ProjectionsOrder.begin(), m_ProjectionsOrder.end() );
+    std::shuffle( m_ProjectionsOrder.begin(), m_ProjectionsOrder.end(), Superclass::m_dre );
     m_ProjectionsOrderInitialized = true;
     }
 

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -33,6 +33,9 @@
 # include "rtkCudaRayCastBackProjectionImageFilter.h"
 #endif
 
+#include <random>
+#include <algorithm>
+
 namespace rtk
 {
 
@@ -109,6 +112,10 @@ protected:
     and back projection methods */
   ForwardProjectionType m_CurrentForwardProjectionConfiguration;
   BackProjectionType    m_CurrentBackProjectionConfiguration;
+
+  /** A random generating engine is needed to use the C++17 comliant code for std::shuffle.
+   */
+  std::default_random_engine m_dre = std::default_random_engine{};
 
   /** Instantiate forward and back projectors using SFINAE. */
   using CPUImageType = typename itk::Image<typename ProjectionStackType::PixelType, ProjectionStackType::ImageDimension>;

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -45,7 +45,7 @@ class InterpolationWeightMultiplicationAttenuated
 public:
   InterpolationWeightMultiplicationAttenuated()
   {
-    for (std::size_t i = 0; i < ITK_MAX_THREADS; i++)
+    for (std::size_t i = 0; i < itk::ITK_MAX_THREADS; i++)
       {
       m_AttenuationRay[i] = 0;
       m_AttenuationPixel[i] = 0;
@@ -83,9 +83,9 @@ public:
 
 private:
   std::ptrdiff_t m_AttenuationMinusEmissionMapsPtrDiff;
-  TInput m_AttenuationRay[ITK_MAX_THREADS];
-  TInput m_AttenuationPixel[ITK_MAX_THREADS];
-  TInput m_ex1[ITK_MAX_THREADS];
+  TInput m_AttenuationRay[itk::ITK_MAX_THREADS];
+  TInput m_AttenuationPixel[itk::ITK_MAX_THREADS];
+  TInput m_ex1[itk::ITK_MAX_THREADS];
 };
 
 /** \class ComputeAttenuationCorrection

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -215,7 +215,7 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 
   for(unsigned int i = 0; i < nProj; i++)
     projOrder[i] = i;
-  std::random_shuffle( projOrder.begin(), projOrder.end() );
+  std::shuffle( projOrder.begin(), projOrder.end(), Superclass::m_dre );
 
   // Declare the image used in the main loop
   typename TVolumeImage::Pointer pimg;

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -273,7 +273,7 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 
   for(unsigned int i = 0; i < nProj; i++)
     projOrder[i] = i;
-  std::random_shuffle( projOrder.begin(), projOrder.end() );
+  std::shuffle( projOrder.begin(), projOrder.end(), Superclass::m_dre );
 
   m_MultiplyFilter->SetInput1( (const float) m_Lambda );
 

--- a/utilities/gengetopt/gm_utils.h
+++ b/utilities/gengetopt/gm_utils.h
@@ -18,6 +18,13 @@
 
 #include "ggos.h"
 
+template< typename ArgumentType, typename ResultType >
+struct unary_function
+{
+  using argument_type = ArgumentType;
+  using result_type = ResultType;
+};
+
 using std::string;
 
 /**
@@ -107,7 +114,7 @@ int not_newlines(const string &buf, int &num_of_newlines);
  * Function object to print something into a stream (to be used with for_each)
  */
 template<class T>
-struct print_f : public std::unary_function<T, void>
+struct print_f : public unary_function<T, void >
 {
     print_f(std::ostream& out, const string &s = ", ") : os(out), sep(s) {}
     void operator() (T x) { os << x << sep; }
@@ -119,7 +126,7 @@ struct print_f : public std::unary_function<T, void>
  * Function object to print a pair into two streams (to be used with for_each)
  */
 template<class T>
-struct pair_print_f : public std::unary_function<T, void>
+struct pair_print_f : public unary_function<T, void >
 {
     pair_print_f(std::ostream& out1, std::ostream& out2, const string &s = ", ") :
         os1(out1), os2(out2), sep(s) {}


### PR DESCRIPTION
with C++17 the std::random_shuffle is deleted. This function is replaced by std::shuffle that does the same with the option for a different random generator.