### PR TITLE
Iteration reporting

### DIFF
--- a/applications/rtkadmmtotalvariation/CMakeLists.txt
+++ b/applications/rtkadmmtotalvariation/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkadmmtotalvariation_GGO_C rtkadmmtotalvariation.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkadmmtotalvariation_GGO_C rtkadmmtotalvariation.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkadmmtotalvariation rtkadmmtotalvariation.cxx ${rtkadmmtotalvariation_GGO_C})
 target_link_libraries(rtkadmmtotalvariation RTK)
 

--- a/applications/rtkadmmtotalvariation/rtkadmmtotalvariation.cxx
+++ b/applications/rtkadmmtotalvariation/rtkadmmtotalvariation.cxx
@@ -134,6 +134,8 @@ int main(int argc, char * argv[])
     }
   admmFilter->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
 
+  REPORT_ITERATIONS(admmFilter, ADMM_TV_FilterType, OutputImageType)
+
   TRY_AND_EXIT_ON_ITK_EXCEPTION( admmFilter->Update() )
 
   // Set writer and write the output

--- a/applications/rtkadmmwavelets/CMakeLists.txt
+++ b/applications/rtkadmmwavelets/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkadmmwavelets_GGO_C rtkadmmwavelets.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkadmmwavelets_GGO_C rtkadmmwavelets.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkadmmwavelets rtkadmmwavelets.cxx ${rtkadmmwavelets_GGO_C})
 target_link_libraries(rtkadmmwavelets RTK)
 

--- a/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
+++ b/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
@@ -118,6 +118,8 @@ int main(int argc, char * argv[])
 
   admmFilter->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
 
+  REPORT_ITERATIONS(admmFilter, ADMM_Wavelets_FilterType, OutputImageType);
+
   TRY_AND_EXIT_ON_ITK_EXCEPTION( admmFilter->Update() )
 
   // Set writer and write the output

--- a/applications/rtkconjugategradient/CMakeLists.txt
+++ b/applications/rtkconjugategradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkconjugategradient_GGO_C rtkconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkconjugategradient_GGO_C rtkconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkconjugategradient rtkconjugategradient.cxx ${rtkconjugategradient_GGO_C})
 target_link_libraries(rtkconjugategradient RTK)
 

--- a/applications/rtkconjugategradient/rtkconjugategradient.cxx
+++ b/applications/rtkconjugategradient/rtkconjugategradient.cxx
@@ -21,6 +21,7 @@
 
 #include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 #include "rtkConjugateGradientConeBeamReconstructionFilter.h"
+#include "rtkIterationCommands.h"
 
 #include <iostream>
 #include <fstream>
@@ -135,6 +136,8 @@ int main(int argc, char * argv[])
   conjugategradient->SetGeometry( geometryReader->GetOutputObject() );
   conjugategradient->SetNumberOfIterations( args_info.niterations_arg );
   conjugategradient->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
+
+  REPORT_ITERATIONS(conjugategradient, ConjugateGradientFilterType, OutputImageType)
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION( conjugategradient->Update() )
 

--- a/applications/rtkconjugategradient/rtkconjugategradient.ggo
+++ b/applications/rtkconjugategradient/rtkconjugategradient.ggo
@@ -14,4 +14,3 @@ option "nocudacg"       - "Do not perform conjugate gradient calculations on GPU
 option "mask"           m "Apply a support binary mask: reconstruction kept null outside the mask)"                   string no
 option "costs"          - "Show residual costs at each iteration at the end of the process"                           flag   off
 option "nodisplaced"    - "Disable the displaced detector filter"                                                     flag   off
-

--- a/applications/rtkfourdconjugategradient/CMakeLists.txt
+++ b/applications/rtkfourdconjugategradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkfourdconjugategradient_GGO_C rtkfourdconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkfourdconjugategradient_GGO_C rtkfourdconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkfourdconjugategradient rtkfourdconjugategradient.cxx ${rtkfourdconjugategradient_GGO_C})
 target_link_libraries(rtkfourdconjugategradient RTK)
 

--- a/applications/rtkfourdconjugategradient/rtkfourdconjugategradient.cxx
+++ b/applications/rtkfourdconjugategradient/rtkfourdconjugategradient.cxx
@@ -127,6 +127,8 @@ int main(int argc, char * argv[])
   conjugategradient->SetWeights(signalToInterpolationWeights->GetOutput());
   conjugategradient->SetSignal(reorder->GetOutputSignal());
 
+  REPORT_ITERATIONS(conjugategradient, ConjugateGradientFilterType, VolumeSeriesType);
+
   TRY_AND_EXIT_ON_ITK_EXCEPTION( conjugategradient->Update() )
 
   // Write

--- a/applications/rtkfourdrooster/CMakeLists.txt
+++ b/applications/rtkfourdrooster/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkfourdrooster_GGO_C rtkfourdrooster.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkfourdrooster_GGO_C rtkfourdrooster.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkfourdrooster rtkfourdrooster.cxx ${rtkfourdrooster_GGO_C})
 target_link_libraries(rtkfourdrooster RTK)
 

--- a/applications/rtkfourdrooster/rtkfourdrooster.cxx
+++ b/applications/rtkfourdrooster/rtkfourdrooster.cxx
@@ -127,6 +127,8 @@ int main(int argc, char * argv[])
   rooster->SetUseCudaCyclicDeformation(args_info.cudadvfinterpolation_flag);
   rooster->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
 
+  REPORT_ITERATIONS(rooster, ROOSTERFilterType, VolumeSeriesType)
+
   // Set the newly ordered arguments
   rooster->SetInputProjectionStack( reorder->GetOutput() );
   rooster->SetGeometry( reorder->GetOutputGeometry() );

--- a/applications/rtkfourdsart/CMakeLists.txt
+++ b/applications/rtkfourdsart/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkfourdsart_GGO_C rtkfourdsart.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkfourdsart_GGO_C rtkfourdsart.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkfourdsart rtkfourdsart.cxx ${rtkfourdsart_GGO_C})
 target_link_libraries(rtkfourdsart RTK)
 

--- a/applications/rtkfourdsart/rtkfourdsart.cxx
+++ b/applications/rtkfourdsart/rtkfourdsart.cxx
@@ -98,8 +98,8 @@ int main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION( phaseReader->Update() )
 
   // 4D SART reconstruction filter
-  rtk::FourDSARTConeBeamReconstructionFilter< VolumeSeriesType, ProjectionStackType >::Pointer fourdsart =
-      rtk::FourDSARTConeBeamReconstructionFilter< VolumeSeriesType, ProjectionStackType >::New();
+  using FourDSARTConeBeamReconstructionFilterType = rtk::FourDSARTConeBeamReconstructionFilter< VolumeSeriesType, ProjectionStackType >;
+  FourDSARTConeBeamReconstructionFilterType::Pointer fourdsart = FourDSARTConeBeamReconstructionFilterType::New();
 
   // Set the forward and back projection filters
   SetForwardProjectionFromGgo(args_info, fourdsart.GetPointer());
@@ -118,6 +118,8 @@ int main(int argc, char * argv[])
     {
     fourdsart->SetEnforcePositivity(true);
     }
+
+  REPORT_ITERATIONS(fourdsart, FourDSARTConeBeamReconstructionFilterType, VolumeSeriesType)
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION( fourdsart->Update() )
 

--- a/applications/rtkiterations_section.ggo
+++ b/applications/rtkiterations_section.ggo
@@ -1,0 +1,3 @@
+section "Iteration reporting"
+option "output-every"   - "Output intermediate reconstruction after some iterations"                                  int    no
+option "iteration-file-name" - "File name to output intermediate iterations with %d as a placeholder for iteration number" string no

--- a/applications/rtkiterativefdk/CMakeLists.txt
+++ b/applications/rtkiterativefdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkiterativefdk_GGO_C rtkiterativefdk.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkiterativefdk_GGO_C rtkiterativefdk.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkiterativefdk rtkiterativefdk.cxx ${rtkiterativefdk_GGO_C})
 target_link_libraries(rtkiterativefdk RTK)
 

--- a/applications/rtkiterativefdk/rtkiterativefdk.cxx
+++ b/applications/rtkiterativefdk/rtkiterativefdk.cxx
@@ -25,6 +25,7 @@
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaIterativeFDKConeBeamReconstructionFilter.h"
 #endif
+
 #include <itkStreamingImageFilter.h>
 #include <itkImageFileWriter.h>
 
@@ -102,6 +103,7 @@ int main(int argc, char * argv[])
   if(!strcmp(args_info.hardware_arg, "cpu") )
     {
     ifdk = IFDKCPUType::New();
+    REPORT_ITERATIONS(ifdk, IFDKCPUType, OutputImageType)
     SET_IFDK_OPTIONS( ifdk );
     IFDKOutputPointer = ifdk->GetOutput();
     }
@@ -109,6 +111,7 @@ int main(int argc, char * argv[])
   else if(!strcmp(args_info.hardware_arg, "cuda") )
     {
     ifdkCUDA = IFDKCUDAType::New();
+    REPORT_ITERATIONS(ifdkCUDA, IFDKCPUType, OutputImageType)
     SET_IFDK_OPTIONS( ifdkCUDA );
     IFDKOutputPointer = ifdkCUDA->GetOutput();
     }

--- a/applications/rtkmotioncompensatedfourdconjugategradient/CMakeLists.txt
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkmotioncompensatedfourdconjugategradient_GGO_C rtkmotioncompensatedfourdconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkmotioncompensatedfourdconjugategradient_GGO_C rtkmotioncompensatedfourdconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk4Doutputimage_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkmotioncompensatedfourdconjugategradient rtkmotioncompensatedfourdconjugategradient.cxx ${rtkmotioncompensatedfourdconjugategradient_GGO_C})
 target_link_libraries(rtkmotioncompensatedfourdconjugategradient RTK)
 

--- a/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
@@ -114,6 +114,8 @@ int main(int argc, char * argv[])
   mcfourdcg->SetSignal(rtk::ReadSignalFile(args_info.signal_arg));
   mcfourdcg->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
 
+  REPORT_ITERATIONS(mcfourdcg, MCFourDCGFilterType, VolumeSeriesType)
+
   // Read DVF
   DVFReaderType::Pointer dvfReader = DVFReaderType::New();
   dvfReader->SetFileName( args_info.dvf_arg );

--- a/applications/rtkosem/CMakeLists.txt
+++ b/applications/rtkosem/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkosem_GGO_C rtkosem.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkosem_GGO_C rtkosem.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkosem rtkosem.cxx ${rtkosem_GGO_C})
 target_link_libraries(rtkosem RTK)
 

--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -22,6 +22,7 @@
 #include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 #include "rtkOSEMConeBeamReconstructionFilter.h"
 #include "rtkPhaseGatingImageFilter.h"
+#include "rtkIterationCommands.h"
 
 #ifdef RTK_USE_CUDA
   #include "itkCudaImage.h"
@@ -103,6 +104,8 @@ int main(int argc, char * argv[])
 
   osem->SetNumberOfIterations( args_info.niterations_arg );
   osem->SetNumberOfProjectionsPerSubset( args_info.nprojpersubset_arg );
+
+  REPORT_ITERATIONS(osem, rtk::OSEMConeBeamReconstructionFilter< OutputImageType >, OutputImageType)
 
   // Write
   using WriterType = itk::ImageFileWriter< OutputImageType >;

--- a/applications/rtkregularizedconjugategradient/CMakeLists.txt
+++ b/applications/rtkregularizedconjugategradient/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkregularizedconjugategradient_GGO_C rtkregularizedconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkregularizedconjugategradient_GGO_C rtkregularizedconjugategradient.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkregularizedconjugategradient rtkregularizedconjugategradient.cxx ${rtkregularizedconjugategradient_GGO_C})
 target_link_libraries(rtkregularizedconjugategradient RTK)
 

--- a/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
+++ b/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
@@ -167,6 +167,8 @@ int main(int argc, char * argv[])
   else
     regularizedConjugateGradient->SetSoftThresholdOnImage(false);
 
+  REPORT_ITERATIONS(regularizedConjugateGradient, ConjugateGradientFilterType, OutputImageType)
+
   TRY_AND_EXIT_ON_ITK_EXCEPTION( regularizedConjugateGradient->Update() )
 
   // Write

--- a/applications/rtksart/CMakeLists.txt
+++ b/applications/rtksart/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtksart_GGO_C rtksart.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtksart_GGO_C rtksart.ggo ../rtkinputprojections_section.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtksart rtksart.cxx ${rtksart_GGO_C})
 target_link_libraries(rtksart RTK)
 

--- a/applications/rtksart/rtksart.cxx
+++ b/applications/rtksart/rtksart.cxx
@@ -22,6 +22,7 @@
 #include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 #include "rtkSARTConeBeamReconstructionFilter.h"
 #include "rtkPhaseGatingImageFilter.h"
+#include "rtkIterationCommands.h"
 
 #ifdef RTK_USE_CUDA
   #include "itkCudaImage.h"
@@ -119,6 +120,8 @@ int main(int argc, char * argv[])
     {
     sart->SetEnforcePositivity(true);
     }
+
+  REPORT_ITERATIONS(sart, rtk::SARTConeBeamReconstructionFilter< OutputImageType >, OutputImageType)
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION( sart->Update() )
 

--- a/applications/rtkspectralonestep/CMakeLists.txt
+++ b/applications/rtkspectralonestep/CMakeLists.txt
@@ -1,4 +1,4 @@
-WRAP_GGO(rtkspectralonestep_GGO_C rtkspectralonestep.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
+WRAP_GGO(rtkspectralonestep_GGO_C rtkspectralonestep.ggo ../rtk3Doutputimage_section.ggo ../rtkprojectors_section.ggo ../rtkiterations_section.ggo ${RTK_BINARY_DIR}/rtkVersion.ggo)
 add_executable(rtkspectralonestep rtkspectralonestep.cxx ${rtkspectralonestep_GGO_C})
 target_link_libraries(rtkspectralonestep RTK)
 

--- a/applications/rtkspectralonestep/rtkspectralonestep.cxx
+++ b/applications/rtkspectralonestep/rtkspectralonestep.cxx
@@ -232,6 +232,8 @@ void rtkspectralonestep(const args_info_rtkspectralonestep &args_info)
     mechlemOneStep->SetGeometry(geometryReader->GetOutputObject());
     }
 
+  REPORT_ITERATIONS(mechlemOneStep, MechlemFilterType, MaterialVolumesType);
+
   mechlemOneStep->Update();
 
   // Write

--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
@@ -21,6 +21,8 @@
 
 #include "rtkADMMTotalVariationConeBeamReconstructionFilter.h"
 
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 
@@ -213,6 +215,7 @@ template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::GenerateData()
 {
+  itk::IterationReporter iterationReporter(this, 0, 1);
   for (unsigned int iter = 0; iter < m_AL_iterations; iter++)
   {
     SetBetaForCurrentIteration(iter);
@@ -238,8 +241,9 @@ ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImag
       m_SubtractFilter2->SetInput1(m_SoftThresholdFilter->GetOutput());
     }
     m_SubtractFilter2->Update();
+    this->GraftOutput(m_ConjugateGradientFilter->GetOutput());
+    iterationReporter.CompletedStep();
   }
-  this->GraftOutput(m_ConjugateGradientFilter->GetOutput());
 }
 
 } // namespace rtk

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
@@ -21,6 +21,8 @@
 
 #include "rtkADMMWaveletsConeBeamReconstructionFilter.h"
 
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 
@@ -163,6 +165,8 @@ ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::GenerateData()
   typename TOutputImage::Pointer W_t_G_k_plus_one;
   typename TOutputImage::Pointer W_t_D_k_plus_one;
 
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   for (unsigned int iter = 0; iter < m_AL_iterations; iter++)
   {
     // After the first update, we need to use some outputs as inputs
@@ -186,8 +190,9 @@ ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::GenerateData()
       m_SubtractFilter2->SetInput1(m_SoftThresholdFilter->GetOutput());
     }
     m_SubtractFilter2->Update();
+    this->GraftOutput(m_ConjugateGradientFilter->GetOutput());
+    iterationReporter.CompletedStep();
   }
-  this->GraftOutput(m_ConjugateGradientFilter->GetOutput());
 }
 
 } // namespace rtk

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -21,6 +21,10 @@
 
 #include <itkMultiplyImageFilter.h>
 #include <itkDivideOrZeroOutImageFilter.h>
+#include <itkProcessObject.h>
+#include <itkObject.h>
+#include <itkCommand.h>
+#include <itkIterationReporter.h>
 
 #include "rtkConjugateGradientImageFilter.h"
 #include "rtkReconstructionConjugateGradientOperator.h"
@@ -270,6 +274,10 @@ protected:
   ConjugateGradientFilterPointer
   InstantiateCudaConjugateGradientImageFilter();
 
+  /** Iteration reporter */
+  void
+  ReportProgress(itk::Object *, const itk::EventObject &);
+
 private:
   ThreeDCircularProjectionGeometry::ConstPointer m_Geometry;
 
@@ -279,6 +287,9 @@ private:
   bool  m_IterationCosts;
   bool  m_CudaConjugateGradient;
   bool  m_DisableDisplacedDetectorFilter;
+
+  // Iteration reporting
+  itk::IterationReporter m_IterationReporter;
 };
 } // namespace rtk
 

--- a/include/rtkConjugateGradientImageFilter.hxx
+++ b/include/rtkConjugateGradientImageFilter.hxx
@@ -24,6 +24,8 @@
 #  include <itkMultiThreaderBase.h>
 #  include <mutex>
 #endif
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 
@@ -210,7 +212,8 @@ ConjugateGradientImageFilter<OutputImageType>::GenerateData()
     nullptr);
 #endif
 
-  bool stopIterations = false;
+  itk::IterationReporter iterationReporter(this, 0, 1);
+  bool                   stopIterations = false;
   for (int iter = 0; (iter < m_NumberOfIterations) && !stopIterations; iter++)
   {
     // Compute A * Pk
@@ -350,6 +353,7 @@ ConjugateGradientImageFilter<OutputImageType>::GenerateData()
     // Let the m_A filter know that Pk has been modified, and it should
     // recompute its output at the beginning of next iteration
     Pk->Modified();
+    iterationReporter.CompletedStep();
   }
   m_A->GetOutput()->ReleaseData();
 }

--- a/include/rtkCudaConjugateGradientImageFilter.hxx
+++ b/include/rtkCudaConjugateGradientImageFilter.hxx
@@ -28,6 +28,7 @@
 #  include "rtkCudaConstantVolumeSource.h"
 
 #  include <itkMacro.h>
+#  include <itkIterationReporter.h>
 
 namespace rtk
 {
@@ -87,6 +88,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
   CUDA_copy(numberOfElements, pR, pP);
 
   // Start iterations
+  itk::IterationReporter iterationReporter(this, 0, 1);
   for (int iter = 0; iter < this->m_NumberOfIterations; iter++)
   {
     // Compute A * P_k
@@ -105,6 +107,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
     CUDA_conjugate_gradient(numberOfElements, pX, pR, pP, pAOut);
 
     P_k->Modified();
+    iterationReporter.CompletedStep();
   }
 
   P_k->ReleaseData();

--- a/include/rtkDeconstructImageFilter.h
+++ b/include/rtkDeconstructImageFilter.h
@@ -245,9 +245,9 @@ private:
     false
   }; // Filters instantiated by GenerateOutputInformation() should be instantiated only once
 
-  typename std::vector<typename InputImageType::SizeType> m_Sizes;    // Holds the size of sub-images at each level
-  typename std::vector<typename InputImageType::IndexType> m_Indices; // Holds the size of sub-images at each level
-  typename std::vector<typename PadFilterType::Pointer> m_PadFilters; // Holds a vector of padding filters
+  typename std::vector<typename InputImageType::SizeType>  m_Sizes;      // Holds the size of sub-images at each level
+  typename std::vector<typename InputImageType::IndexType> m_Indices;    // Holds the size of sub-images at each level
+  typename std::vector<typename PadFilterType::Pointer>    m_PadFilters; // Holds a vector of padding filters
   typename std::vector<typename ConvolutionFilterType::Pointer>
     m_ConvolutionFilters; // Holds a vector of convolution filters
   typename std::vector<typename DownsampleImageFilterType::Pointer>

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -30,6 +30,7 @@
 #include <itkExtractImageFilter.h>
 #include <itkSubtractImageFilter.h>
 #include <itkMultiplyImageFilter.h>
+#include <itkIterationReporter.h>
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaConjugateGradientImageFilter.h"
 #endif
@@ -220,12 +221,19 @@ protected:
   std::vector<double> m_Signal;
   bool                m_DisableDisplacedDetectorFilter;
 
+  // Iteration reporting
+  itk::IterationReporter m_IterationReporter;
+
 private:
   /** Geometry object */
   ThreeDCircularProjectionGeometry::ConstPointer m_Geometry;
 
   /** Number of conjugate gradient descent iterations */
   unsigned int m_NumberOfIterations;
+
+  /** Iteration reporter */
+  void
+  ReportProgress(itk::Object *, const itk::EventObject &);
 
 }; // end of class
 

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
@@ -26,6 +26,7 @@
 #include <algorithm>
 
 #include <itkImageFileWriter.h>
+#include <itkIterationReporter.h>
 
 namespace rtk
 {
@@ -33,6 +34,7 @@ namespace rtk
 template <class VolumeSeriesType, class ProjectionStackType>
 FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::
   FourDConjugateGradientConeBeamReconstructionFilter()
+  : m_IterationReporter(this, 0, 1)
 {
   this->SetNumberOfRequiredInputs(2); // 4D sequence, projections
 
@@ -223,6 +225,26 @@ FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionS
   pimg->DisconnectPipeline();
 
   this->GraftOutput(pimg);
+}
+
+template <class VolumeSeriesType, class ProjectionStackType>
+void
+FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::ReportProgress(
+  itk::Object *            caller,
+  const itk::EventObject & event)
+{
+  {
+    if (!itk::IterationEvent().CheckEvent(&event))
+    {
+      return;
+    }
+    auto * cgCaller = dynamic_cast<rtk::ConjugateGradientImageFilter<VolumeSeriesType> *>(caller);
+    if (cgCaller)
+    {
+      this->GraftOutput(cgCaller->GetOutput());
+      m_IterationReporter.CompletedStep();
+    }
+  }
 }
 
 } // end namespace rtk

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "rtkFourDROOSTERConeBeamReconstructionFilter.h"
 #include <itkImageFileWriter.h>
+#include <itkIterationReporter.h>
 
 namespace rtk
 {
@@ -474,6 +475,8 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>:
   // Declare the pointer that will be used to plug the output back as input
   typename VolumeSeriesType::Pointer pimg;
 
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   for (int i = 0; i < m_MainLoop_iterations; i++)
   {
     // After the first iteration, we need to use the output as input
@@ -489,9 +492,9 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>:
     }
 
     m_DownstreamFilter->Update();
+    this->GraftOutput(m_DownstreamFilter->GetOutput());
+    iterationReporter.CompletedStep();
   }
-
-  this->GraftOutput(m_DownstreamFilter->GetOutput());
 }
 
 } // namespace rtk

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
@@ -23,6 +23,7 @@
 #include "rtkGeneralPurposeFunctions.h"
 
 #include <algorithm>
+#include <itkIterationReporter.h>
 
 namespace rtk
 {
@@ -325,6 +326,8 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Ge
   typename VolumeSeriesType::Pointer pimg;
   typename VolumeSeriesType::Pointer pimg2;
 
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   // For each iteration, go over each projection
   for (unsigned int iter = 0; iter < m_NumberOfIterations; iter++)
   {
@@ -390,15 +393,17 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Ge
           m_ThresholdFilter->Update();
         }
       }
+
+      if (m_EnforcePositivity)
+      {
+        this->GraftOutput(m_ThresholdFilter->GetOutput());
+      }
+      else
+      {
+        this->GraftOutput(m_AddFilter2->GetOutput());
+      }
     }
-  }
-  if (m_EnforcePositivity)
-  {
-    this->GraftOutput(m_ThresholdFilter->GetOutput());
-  }
-  else
-  {
-    this->GraftOutput(m_AddFilter2->GetOutput());
+    iterationReporter.CompletedStep();
   }
 }
 

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -155,7 +155,7 @@ GetProjectionsFileNamesFromGgo(const TArgsInfo & args_info)
   for (const auto & fn : fileNames)
   {
     itk::ImageIOBase::Pointer imageio =
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
       itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
       itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);

--- a/include/rtkImagXGeometryReader.hxx
+++ b/include/rtkImagXGeometryReader.hxx
@@ -262,7 +262,7 @@ ImagXGeometryReader<TInputImage>::GetGeometryForAI1p5()
 
   // Create and set ImageIO
   itk::ImageIOBase::Pointer imageIO =
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
     itk::ImageIOFactory::CreateImageIO(m_ProjectionsFileNames[0].c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
     itk::ImageIOFactory::CreateImageIO(m_ProjectionsFileNames[0].c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
@@ -482,7 +482,7 @@ ImagXGeometryReader<TInputImage>::getAIversion()
 {
   // Create and set ImageIO
   itk::ImageIOBase::Pointer imageIO =
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
     itk::ImageIOFactory::CreateImageIO(m_ProjectionsFileNames[0].c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
     itk::ImageIOFactory::CreateImageIO(m_ProjectionsFileNames[0].c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
@@ -555,7 +555,7 @@ ImagXGeometryReader<TInputImage>::GenerateData()
   for (unsigned int noProj = 0; noProj < m_ProjectionsFileNames.size(); noProj++)
   {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(m_ProjectionsFileNames[0].c_str(),
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
                                                                            itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
                                                                            itk::ImageIOFactory::FileModeType::ReadMode);

--- a/include/rtkIterationCommands.h
+++ b/include/rtkIterationCommands.h
@@ -1,0 +1,156 @@
+/*=========================================================================
+ *
+ *  Copyright RTK Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef rtkIterationCommands_h
+#define rtkIterationCommands_h
+
+#include <itkImageFileWriter.h>
+
+namespace rtk
+{
+
+/** \class IterationCommand
+ * \brief Abstract superclass to all iteration callbacks.
+ * Derived classes must implement the Run() method. Run() can be triggered
+ * only once in every n iterations.
+ *
+ * \author Aurélien Coussat
+ *
+ * \ingroup RTK
+ *
+ */
+template <typename TCaller>
+class IterationCommand : public itk::Command
+{
+protected:
+  /** How many times this command has been executed. */
+  unsigned int m_IterationCount = 0;
+
+  /** Trigger the callback every n iterations. */
+  unsigned int m_TriggerEvery = 1;
+
+  /** Callback function to be redefined by derived classes. */
+  virtual void
+  Run(const TCaller * caller) = 0;
+
+public:
+  /** Standard class typedefs. */
+  typedef IterationCommand        Self;
+  typedef itk::Command            Superclass;
+  typedef itk::SmartPointer<Self> Pointer;
+
+  itkSetMacro(TriggerEvery, unsigned int)
+
+    void Execute(itk::Object * caller, const itk::EventObject & event) override
+  {
+    Execute((const itk::Object *)caller, event);
+  }
+
+  void
+  Execute(const itk::Object * caller, const itk::EventObject & event) override
+  {
+    if (!itk::IterationEvent().CheckEvent(&event))
+    {
+      return;
+    }
+    ++m_IterationCount;
+    if ((m_IterationCount % m_TriggerEvery) == 0)
+    {
+      const auto * cCaller = dynamic_cast<const TCaller *>(caller);
+      if (cCaller)
+      {
+        Run(cCaller);
+      } // TODO fail when cast fails
+    }
+  }
+};
+
+/** \class VerboseIterationCommand
+ * \brief Outputs to standard output when an iteration completes.
+ *
+ * \author Aurélien Coussat
+ *
+ * \ingroup RTK
+ *
+ */
+template <typename TCaller>
+class VerboseIterationCommand : public IterationCommand<TCaller>
+{
+public:
+  /** Standard class typedefs. */
+  typedef VerboseIterationCommand   Self;
+  typedef IterationCommand<TCaller> Superclass;
+  typedef itk::SmartPointer<Self>   Pointer;
+  itkNewMacro(Self);
+
+protected:
+  void
+  Run(const TCaller * caller) override
+  {
+    std::cout << "Iteration " << this->m_IterationCount << " completed."
+              << std::endl; // TODO allow string personnalization
+  }
+};
+
+/** \class OutputIterationCommand
+ * \brief Output intermediate iterations in a file.
+ * This class is useful to check convergence of an iterative method
+ * and to avoid starting over similar computations when testing
+ * hyperparameters of an iterative algorithm.
+ *
+ * \author Aurélien Coussat
+ *
+ * \ingroup RTK
+ *
+ */
+template <typename TCaller, typename TOutputImage>
+class OutputIterationCommand : public IterationCommand<TCaller>
+{
+public:
+  /** Standard class typedefs. */
+  typedef OutputIterationCommand    Self;
+  typedef IterationCommand<TCaller> Superclass;
+  typedef itk::SmartPointer<Self>   Pointer;
+  itkNewMacro(Self);
+
+  itkSetMacro(FileFormat, std::string)
+
+    protected
+    :
+
+    /** Output file name, where %d is the current iteration number */
+    std::string m_FileFormat;
+
+  void
+  Run(const TCaller * caller) override
+  {
+    typedef itk::ImageFileWriter<TOutputImage> WriterType;
+    typename WriterType::Pointer               writer = WriterType::New();
+
+    char         buffer[100];
+    unsigned int size = sprintf(buffer, m_FileFormat.c_str(), this->m_IterationCount);
+    writer->SetFileName(std::string(buffer, size));
+
+    writer->SetInput(caller->GetOutput());
+    writer->Update();
+  }
+};
+
+} // end namespace rtk
+
+#endif

--- a/include/rtkMacro.h
+++ b/include/rtkMacro.h
@@ -23,6 +23,7 @@
 #include <itkMacro.h>
 #include <itkImageBase.h>
 #include "rtkGgoArgsInfoManager.h"
+#include "rtkIterationCommands.h"
 
 //--------------------------------------------------------------------
 #ifndef CLANG_PRAGMA_PUSH
@@ -196,6 +197,43 @@
       return smartPtr;                                                                                                 \
     }
 #endif // RTK_PROBE_EACH_FILTER
+//--------------------------------------------------------------------
+
+//--------------------------------------------------------------------
+/** \brief Manage iteration reporting for filters supporting it.
+ *
+ * If verbose flag is set, outputs a string noticing iteration completion.
+ * If output-every argument is provided, save intermediate output in a file.
+ * If iteration-file-name is provided, the intermediate output is saved in a file
+ * having custom name and location.
+ *
+ * \author Aurélien Coussat
+ *
+ * \ingroup RTK
+ */
+#define REPORT_ITERATIONS(filter, filter_type, output_image_type)                                                      \
+  if (args_info.verbose_flag)                                                                                          \
+  {                                                                                                                    \
+    using VerboseIterationCommandType = rtk::VerboseIterationCommand<filter_type>;                                     \
+    typename VerboseIterationCommandType::Pointer verboseIterationCommand = VerboseIterationCommandType::New();        \
+    filter->AddObserver(itk::IterationEvent(), verboseIterationCommand);                                               \
+  }                                                                                                                    \
+  if (args_info.output_every_given)                                                                                    \
+  {                                                                                                                    \
+    typedef rtk::OutputIterationCommand<filter_type, output_image_type> OutputIterationCommand;                        \
+    typename OutputIterationCommand::Pointer outputIterationCommand = OutputIterationCommand::New();                   \
+    outputIterationCommand->SetTriggerEvery(args_info.output_every_arg);                                               \
+    if (args_info.iteration_file_name_given)                                                                           \
+    {                                                                                                                  \
+      outputIterationCommand->SetFileFormat(args_info.iteration_file_name_arg);                                        \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+      outputIterationCommand->SetFileFormat("iter%d.mha");                                                             \
+    }                                                                                                                  \
+    filter->AddObserver(itk::IterationEvent(), outputIterationCommand);                                                \
+  }
+//--------------------------------------------------------------------
 
 
 #endif

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -21,6 +21,8 @@
 
 #include "rtkMechlemOneStepSpectralReconstructionFilter.h"
 
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 
@@ -398,6 +400,8 @@ template <class TOutputImage, class TPhotonCounts, class TSpectrum>
 void
 MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::GenerateData()
 {
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   // Run the iteration loop
   typename TOutputImage::Pointer Next_Zk;
   for (int iter = 0; iter < m_NumberOfIterations; iter++)
@@ -479,9 +483,10 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectru
         m_NesterovFilter->Update();
         Next_Zk = m_NesterovFilter->GetOutput();
       }
+      this->GraftOutput(Next_Zk);
+      iterationReporter.CompletedStep();
     }
   }
-  this->GraftOutput(Next_Zk);
 }
 
 } // namespace rtk

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -27,6 +27,8 @@
 
 #include <itkImageFileWriter.h>
 
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 template <class TVolumeImage, class TProjectionImage>
@@ -215,6 +217,8 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
   typename TVolumeImage::Pointer pimg;
   typename TVolumeImage::Pointer norm;
 
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   // For each iteration, go over each projection
   for (unsigned int iter = 0; iter < m_NumberOfIterations; iter++)
   {
@@ -275,8 +279,9 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
         m_BackProjectionNormalizationFilter->SetInput(0, norm);
       }
     }
+    this->GraftOutput(pimg);
+    iterationReporter.CompletedStep();
   }
-  this->GraftOutput(pimg);
 }
 
 } // end namespace rtk

--- a/include/rtkOraLookupTableImageFilter.hxx
+++ b/include/rtkOraLookupTableImageFilter.hxx
@@ -43,7 +43,7 @@ OraLookupTableImageFilter<TOutputImage>::BeforeThreadedGenerateData()
   int                       fileIdx = this->GetOutput()->GetRequestedRegion().GetIndex()[2];
   itk::ImageIOBase::Pointer reader;
   reader =
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
     itk::ImageIOFactory::CreateImageIO(m_FileNames[fileIdx].c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
     itk::ImageIOFactory::CreateImageIO(m_FileNames[fileIdx].c_str(), itk::ImageIOFactory::FileModeType::ReadMode);

--- a/include/rtkProjectionsReader.hxx
+++ b/include/rtkProjectionsReader.hxx
@@ -150,7 +150,7 @@ ProjectionsReader<TOutputImage>::GenerateOutputInformation(void)
   firstTime = false;
 
   itk::ImageIOBase::Pointer imageIO =
-#if (ITK_VERSION_MAJOR==5) && (ITK_VERSION_MINOR>=1)
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
     itk::ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
 #else
     itk::ImageIOFactory::CreateImageIO(m_FileNames[0].c_str(), itk::ImageIOFactory::FileModeType::ReadMode);

--- a/include/rtkReconstructImageFilter.h
+++ b/include/rtkReconstructImageFilter.h
@@ -243,8 +243,8 @@ private:
     false
   }; // Filters instantiated by GenerateOutputInformation() should be instantiated only once
 
-  typename InputImageType::SizeType * m_Sizes;                        // Holds the size of sub-images at each level
-  typename InputImageType::IndexType * m_Indices;                     // Holds the size of sub-images at each level
+  typename InputImageType::SizeType *                   m_Sizes;      // Holds the size of sub-images at each level
+  typename InputImageType::IndexType *                  m_Indices;    // Holds the size of sub-images at each level
   typename std::vector<typename AddFilterType::Pointer> m_AddFilters; // Holds a vector of add filters
   typename std::vector<typename ConvolutionFilterType::Pointer>
     m_ConvolutionFilters; // Holds a vector of convolution filters

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -226,8 +226,8 @@ protected:
 
   /** Member attributes */
   rtk::ThreeDCircularProjectionGeometry::ConstPointer m_Geometry{ nullptr };
-  float m_Gamma{ 0 };    // Strength of the laplacian regularization
-  float m_Tikhonov{ 0 }; // Strength of the Tikhonov regularization
+  float                                               m_Gamma{ 0 };    // Strength of the laplacian regularization
+  float                                               m_Tikhonov{ 0 }; // Strength of the Tikhonov regularization
 
   /** Pointers to intermediate images, used to simplify complex branching */
   typename TOutputImage::Pointer m_FloatingInputPointer, m_FloatingOutputPointer;

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
@@ -20,6 +20,8 @@
 
 #include "rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h"
 
+#include <itkIterationReporter.h>
+
 namespace rtk
 {
 
@@ -239,6 +241,8 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::GenerateData()
   typename itk::ImageToImageFilter<TImage, TImage>::Pointer currentDownstreamFilter;
   typename TImage::Pointer                                  pimg;
 
+  itk::IterationReporter iterationReporter(this, 0, 1);
+
   for (int i = 0; i < m_MainLoop_iterations; i++)
   {
     // After the first iteration, we need to use the output as input
@@ -272,9 +276,9 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::GenerateData()
     }
 
     currentDownstreamFilter->Update();
+    this->GraftOutput(currentDownstreamFilter->GetOutput());
+    iterationReporter.CompletedStep();
   }
-
-  this->GraftOutput(currentDownstreamFilter->GetOutput());
 }
 
 } // namespace rtk

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -22,6 +22,7 @@
 #include "rtkSARTConeBeamReconstructionFilter.h"
 
 #include <algorithm>
+#include <itkIterationReporter.h>
 
 namespace rtk
 {
@@ -276,6 +277,8 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
   typename TVolumeImage::Pointer pimg;
   typename TVolumeImage::Pointer norm;
 
+  itk::IterationReporter iterationReporter(this, 0, 1); // report every iteration
+
   // For each iteration, go over each projection
   for (unsigned int iter = 0; iter < m_NumberOfIterations; iter++)
   {
@@ -341,8 +344,9 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
         m_BackProjectionNormalizationFilter->SetInput(0, norm);
       }
     }
+    this->GraftOutput(pimg);
+    iterationReporter.CompletedStep();
   }
-  this->GraftOutput(pimg);
 }
 
 } // end namespace rtk


### PR DESCRIPTION
First steps towards an iteration reporting system in RTK. The goal is to allow users to plug their own custom callback called on each completion of any iteration filter. This is still a work in progress.

So far only [`rtkSARTConeBeamReconstructionFilter`](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkSARTConeBeamReconstructionFilter.h) and [`rtkConjugateGradientConeBeamReconstructionFilter`](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkConjugateGradientConeBeamReconstructionFilter.h) have been updated. The simplest way of testing the reporting is by using `rtksart` with the `-v` (verbose) flag.

Allows filters to [observe another filter](https://github.com/acoussat/RTK/blob/dc9c02076b3d818b9061ec67bfb5d5ded5d26fef/applications/rtksart/rtksart.cxx#L124) and invoke a callback upon iteration completion. [Some default callbacks](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkIterationCommands.h) were defined but you can easily define your own callbacks by deriving [`IterationCommand`](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkIterationCommands.h#L36).

This is done by exploiting the possibilities of [`itk::IterationReporter`](https://itk.org/Doxygen/html/classitk_1_1IterationReporter.html). Note that [`itk::ProgressReporter`](https://itk.org/Doxygen/html/classitk_1_1ProgressReporter.html) also exists but using [`itk::IterationReporter`](https://itk.org/Doxygen/html/classitk_1_1IterationReporter.html) seems more semantically correct to me.

Also note [the trick](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx#L394) used for [`rtkConjugateGradientConeBeamReconstructionFilter`](https://github.com/acoussat/RTK/blob/iteration-reporting/include/rtkConjugateGradientConeBeamReconstructionFilter.h). The filter listens to its sub-filter `m_ConjugateGradientFilter` and automatically passes up the notification.

Passing a callback should work using the Python wrapping as well, like so:
```python3
def callback():
  pass # code of your callback
filter.AddObserver(itk.IterationEvent(), callback)
```

Things left to do:
- [ ] decide whether to use [`itk::IterationReporter`](https://itk.org/Doxygen/html/classitk_1_1IterationReporter.html) or [`itk::ProgressReporter`](https://itk.org/Doxygen/html/classitk_1_1ProgressReporter.html)
- [ ] implement the notification mechanism in all iterative filters