### PR TITLE
ENH: Add Zeng forward and back projectors to perform PSF correction

### DIFF
--- a/applications/rtkbackprojections/rtkbackprojections.cxx
+++ b/applications/rtkbackprojections/rtkbackprojections.cxx
@@ -24,6 +24,7 @@
 #include "rtkFDKWarpBackProjectionImageFilter.h"
 #include "rtkJosephBackProjectionImageFilter.h"
 #include "rtkJosephBackAttenuatedProjectionImageFilter.h"
+#include "rtkZengBackProjectionImageFilter.h"
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaFDKBackProjectionImageFilter.h"
 #  include "rtkCudaBackProjectionImageFilter.h"
@@ -126,6 +127,9 @@ int main(int argc, char * argv[])
     case(bp_arg_JosephAttenuated):
       bp = rtk::JosephBackAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>::New();
       break;
+    case(bp_arg_Zeng):
+      bp = rtk::ZengBackProjectionImageFilter<OutputImageType, OutputImageType>::New();
+      break;
     case(bp_arg_CudaFDKBackProjection):
 #ifdef RTK_USE_CUDA
       bp = rtk::CudaFDKBackProjectionImageFilter::New();
@@ -159,6 +163,10 @@ int main(int argc, char * argv[])
   bp->SetInput( 1, reader->GetOutput() );
   if(args_info.attenuationmap_given)
     bp->SetInput(2, attenuationFilter->GetOutput());
+  if(args_info.sigmazero_given && args_info.bp_arg == bp_arg_Zeng)
+    dynamic_cast<rtk::ZengBackProjectionImageFilter<OutputImageType, OutputImageType>*>(bp.GetPointer())->SetSigmaZero(args_info.sigmazero_arg);
+  if(args_info.alphapsf_given && args_info.bp_arg == bp_arg_Zeng)
+    dynamic_cast<rtk::ZengBackProjectionImageFilter<OutputImageType, OutputImageType>*>(bp.GetPointer())->SetAlpha(args_info.alphapsf_arg);
   bp->SetGeometry( geometryReader->GetOutputObject() );
   TRY_AND_EXIT_ON_ITK_EXCEPTION( bp->Update() )
 

--- a/applications/rtkbackprojections/rtkbackprojections.ggo
+++ b/applications/rtkbackprojections/rtkbackprojections.ggo
@@ -5,10 +5,12 @@ option "verbose"   v "Verbose execution"                                        
 option "config"    - "Config file"                                               string   no
 option "geometry"  g  "XML geometry file name"                                   string   yes
 option "output"    o "Output volume file name"                                   string   yes
-option "attenuationmap" a "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
 
 section "Projectors"
-option "bp"    - "Backprojection method" values="VoxelBasedBackProjection","FDKBackProjection","FDKWarpBackProjection","Joseph","JosephAttenuated","CudaFDKBackProjection","CudaBackProjection","CudaRayCast"  enum no default="VoxelBasedBackProjection"
+option "bp"    - "Backprojection method" values="VoxelBasedBackProjection","FDKBackProjection","FDKWarpBackProjection","Joseph","JosephAttenuated", "Zeng", "CudaFDKBackProjection","CudaBackProjection","CudaRayCast"  enum no default="VoxelBasedBackProjection"
+option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
+option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
+option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 
 
 section "Warped backprojection"
 option "signal"    - "Signal file name"          string    no

--- a/applications/rtkforwardprojections/rtkforwardprojections.cxx
+++ b/applications/rtkforwardprojections/rtkforwardprojections.cxx
@@ -22,6 +22,7 @@
 #include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 #include "rtkJosephForwardProjectionImageFilter.h"
 #include "rtkJosephForwardAttenuatedProjectionImageFilter.h"
+#include "rtkZengForwardProjectionImageFilter.h"
 #ifdef RTK_USE_CUDA
 #include "rtkCudaForwardProjectionImageFilter.h"
 #endif
@@ -107,6 +108,9 @@ int main(int argc, char * argv[])
   case(fp_arg_JosephAttenuated):
     forwardProjection = rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>::New();
       break;
+  case(fp_arg_Zeng):
+    forwardProjection = rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
+    break;
   case(fp_arg_CudaRayCast):
 #ifdef RTK_USE_CUDA
     forwardProjection = rtk::CudaForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
@@ -124,6 +128,10 @@ int main(int argc, char * argv[])
   forwardProjection->SetInput( 1, reader->GetOutput() );
   if(args_info.attenuationmap_given)
     forwardProjection->SetInput(2, attenuationFilter->GetOutput());
+  if(args_info.sigmazero_given && args_info.fp_arg == fp_arg_Zeng)
+     dynamic_cast<rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>*>(forwardProjection.GetPointer())->SetSigmaZero(args_info.sigmazero_arg);
+  if(args_info.alphapsf_given && args_info.fp_arg == fp_arg_Zeng)
+    dynamic_cast<rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>*>(forwardProjection.GetPointer())->SetAlpha(args_info.alphapsf_arg);
   forwardProjection->SetGeometry( geometryReader->GetOutputObject() );
   if(!args_info.lowmem_flag)
     {

--- a/applications/rtkforwardprojections/rtkforwardprojections.ggo
+++ b/applications/rtkforwardprojections/rtkforwardprojections.ggo
@@ -6,10 +6,11 @@ option "config"    - "Config file"                                              
 option "geometry"  g  "XML geometry file name"                                   string   yes
 option "input"     i "Input volume file name"                                    string   yes
 option "output"    o "Output projections file name"                              string   yes
-option "attenuationmap" a "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
 option "step"      s "Step size along ray (for CudaRayCast only)"                double   no   default="1"
 option "lowmem"    l "Compute only one projection at a time"                     flag     off
 
 section "Projectors"
-option "fp"    f "Forward projection method" values="Joseph","JosephAttenuated","CudaRayCast" enum no default="Joseph"
-
+option "fp"    f "Forward projection method" values="Joseph","JosephAttenuated","CudaRayCast","Zeng" enum no default="Joseph"
+option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
+option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
+option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 

--- a/applications/rtkiterativefdk/rtkiterativefdk.ggo
+++ b/applications/rtkiterativefdk/rtkiterativefdk.ggo
@@ -18,4 +18,4 @@ option "hann"      - "Cut frequency for hann window in ]0,1] (0.0 disables it)" 
 option "hannY"     - "Cut frequency for hann window in ]0,1] (0.0 disables it)"  double                       no   default="0.0"
 
 section "Projectors"
-option "fp"    f "Forward projection method" values="Joseph","CudaRayCast","JosephAttenuated" enum no default="Joseph"
+option "fp"    f "Forward projection method" values="Joseph","CudaRayCast","JosephAttenuated","Zeng" enum no default="Joseph"

--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -100,6 +100,10 @@ int main(int argc, char * argv[])
   osem->SetInput(1, reader->GetOutput());
   if(args_info.attenuationmap_given)
     osem->SetInput(2, attenuationFilter->GetOutput());
+  if(args_info.sigmazero_given)
+    osem->SetSigmaZero(args_info.sigmazero_arg);
+  if(args_info.alphapsf_given)
+    osem->SetAlpha(args_info.alphapsf_arg);
   osem->SetGeometry( geometryReader->GetOutputObject() );
 
   osem->SetNumberOfIterations( args_info.niterations_arg );

--- a/applications/rtkosem/rtkosem.ggo
+++ b/applications/rtkosem/rtkosem.ggo
@@ -8,4 +8,3 @@ option "output"      o "Output file name"                                      s
 option "niterations" n "Number of iterations"                                  int    no   default="5"
 option "input"     i "Input volume"              string          no
 option "nprojpersubset" - "Number of projections processed between each update of the reconstructed volume (several for OSEM, all for MLEM)" int no default="1"
-option "attenuationmap" a "Attenuation map relative to the volume to perfom the attenuation correction"   string  no

--- a/applications/rtkprojectors_section.ggo
+++ b/applications/rtkprojectors_section.ggo
@@ -1,4 +1,6 @@
 section "Projectors"
-option "fp"    f "Forward projection method" values="Joseph","CudaRayCast","JosephAttenuated" enum no default="Joseph"
-option "bp"    b "Back projection method" values="VoxelBasedBackProjection","Joseph","CudaVoxelBased","CudaRayCast","JosephAttenuated" enum no default="VoxelBasedBackProjection"
-
+option "fp"    f "Forward projection method" values="Joseph","CudaRayCast","JosephAttenuated","Zeng" enum no default="Joseph"
+option "bp"    b "Back projection method" values="VoxelBasedBackProjection","Joseph","CudaVoxelBased","CudaRayCast","JosephAttenuated", "Zeng" enum no default="VoxelBasedBackProjection"
+option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no 
+option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
+option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 

--- a/include/rtkForwardProjectionImageFilter.hxx
+++ b/include/rtkForwardProjectionImageFilter.hxx
@@ -46,7 +46,7 @@ ForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedR
     return;
 
   typename TInputImage::RegionType reqRegion = inputPtr1->GetLargestPossibleRegion();
-  inputPtr1->SetRequestedRegion( reqRegion );
+  inputPtr1->SetRequestedRegion(reqRegion);
 }
 
 } // end namespace rtk

--- a/include/rtkForwardProjectionImageFilter.hxx
+++ b/include/rtkForwardProjectionImageFilter.hxx
@@ -46,15 +46,7 @@ ForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedR
     return;
 
   typename TInputImage::RegionType reqRegion = inputPtr1->GetLargestPossibleRegion();
-  inputPtr1->SetRequestedRegion(reqRegion);
-
-  // Input 2 is the attenuation map relative to the volume
-  typename Superclass::InputImagePointer inputPtr2 = const_cast<TInputImage *>(this->GetInput(2));
-  if (!inputPtr2)
-    return;
-
-  typename TInputImage::RegionType reqRegion2 = inputPtr2->GetLargestPossibleRegion();
-  inputPtr2->SetRequestedRegion(reqRegion2);
+  inputPtr1->SetRequestedRegion( reqRegion );
 }
 
 } // end namespace rtk

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -305,6 +305,9 @@ SetBackProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructionFi
     case (4): // bp_arg_JosephAttenuated
       recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_JOSEPHATTENUATED);
       break;
+    case (5): // bp_arg_RotationBased
+      recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_ZENG);
+      break;
   }
 }
 
@@ -333,6 +336,9 @@ SetForwardProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructio
       break;
     case (2): // fp_arg_JosephAttenuated
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_JOSEPHATTENUATED);
+      break;
+    case (3): // fp_arg_RotationBased
+      recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_ZENG);
       break;
   }
 }

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -24,8 +24,10 @@
 // Forward projection filters
 #include "rtkConfiguration.h"
 #include "rtkJosephForwardAttenuatedProjectionImageFilter.h"
+#include "rtkZengForwardProjectionImageFilter.h"
 // Back projection filters
 #include "rtkJosephBackAttenuatedProjectionImageFilter.h"
+#include "rtkZengBackProjectionImageFilter.h"
 
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaForwardProjectionImageFilter.h"
@@ -70,7 +72,8 @@ public:
     FP_UNKNOWN = -1,
     FP_JOSEPH = 0,
     FP_CUDARAYCAST = 2,
-    FP_JOSEPHATTENUATED = 3
+    FP_JOSEPHATTENUATED = 3,
+    FP_ZENG = 4
   } ForwardProjectionType;
   typedef enum
   {
@@ -79,7 +82,8 @@ public:
     BP_JOSEPH = 1,
     BP_CUDAVOXELBASED = 2,
     BP_CUDARAYCAST = 4,
-    BP_JOSEPHATTENUATED = 5
+    BP_JOSEPHATTENUATED = 5,
+    BP_ZENG = 6
   } BackProjectionType;
 
   /** Typedefs of each subfilter of this composite filter */
@@ -207,6 +211,23 @@ protected:
     return fw;
   }
 
+  template <typename ImageType, EnableVectorType<ImageType> * = nullptr>
+  ForwardProjectionPointerType
+  InstantiateZengForwardProjection()
+  {
+    itkGenericExceptionMacro(<< "JosephForwardAttenuatedProjectionImageFilter only available with scalar pixel types.");
+    return nullptr;
+  }
+
+
+  template <typename ImageType, DisableVectorType<ImageType> * = nullptr>
+  ForwardProjectionPointerType
+  InstantiateZengForwardProjection()
+  {
+    ForwardProjectionPointerType fw;
+    fw = ZengForwardProjectionImageFilter<VolumeType, ProjectionStackType>::New();
+    return fw;
+  }
 
   template <typename ImageType, EnableCudaScalarAndVectorType<ImageType> * = nullptr>
   BackProjectionPointerType
@@ -266,6 +287,24 @@ protected:
   {
     BackProjectionPointerType bp;
     bp = JosephBackAttenuatedProjectionImageFilter<ImageType, ImageType>::New();
+    return bp;
+  }
+
+  template <typename ImageType, EnableVectorType<ImageType> * = nullptr>
+  BackProjectionPointerType
+  InstantiateZengBackProjection()
+  {
+    itkGenericExceptionMacro(<< "JosephBackAttenuatedProjectionImageFilter only available with scalar pixel types.");
+    return nullptr;
+  }
+
+
+  template <typename ImageType, DisableVectorType<ImageType> * = nullptr>
+  BackProjectionPointerType
+  InstantiateZengBackProjection()
+  {
+    BackProjectionPointerType bp;
+    bp = ZengBackProjectionImageFilter<ImageType, ImageType>::New();
     return bp;
   }
 

--- a/include/rtkIterativeConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeConeBeamReconstructionFilter.hxx
@@ -47,6 +47,9 @@ IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::Instan
     case (FP_JOSEPHATTENUATED):
       fw = InstantiateJosephForwardAttenuatedProjection<ProjectionStackType>();
       break;
+    case (FP_ZENG):
+      fw = InstantiateZengForwardProjection<ProjectionStackType>();
+      break;
     default:
       itkGenericExceptionMacro(<< "Unhandled --fp value.");
   }
@@ -74,6 +77,9 @@ IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::Instan
       break;
     case (BP_JOSEPHATTENUATED):
       bp = InstantiateJosephBackAttenuatedProjection<ProjectionStackType>();
+      break;
+    case (BP_ZENG):
+      bp = InstantiateZengBackProjection<ProjectionStackType>();
       break;
     default:
       itkGenericExceptionMacro(<< "Unhandled --bp value.");

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
@@ -62,20 +62,7 @@ JosephForwardAttenuatedProjectionImageFilter<TInputImage,
                                              TProjectedValueAccumulation,
                                              TComputeAttenuationCorrection>::GenerateInputRequestedRegion()
 {
-  // Input 0 is the stack of projections in which we project
-  typename Superclass::InputImagePointer inputPtr0 = const_cast<TInputImage *>(this->GetInput(0));
-  if (!inputPtr0)
-    return;
-  inputPtr0->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
-
-  // Input 1 is the volume to forward project
-  typename Superclass::InputImagePointer inputPtr1 = const_cast<TInputImage *>(this->GetInput(1));
-  if (!inputPtr1)
-    return;
-
-  typename TInputImage::RegionType reqRegion = inputPtr1->GetLargestPossibleRegion();
-  inputPtr1->SetRequestedRegion(reqRegion);
-
+  Superclass::GenerateInputRequestedRegion();
   // Input 2 is the attenuation map relative to the volume
   typename Superclass::InputImagePointer inputPtr2 = const_cast<TInputImage *>(this->GetInput(2));
   if (!inputPtr2)

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -156,6 +156,14 @@ public:
   itkGetMacro(NumberOfProjectionsPerSubset, unsigned int);
   itkSetMacro(NumberOfProjectionsPerSubset, unsigned int);
 
+  /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
+  itkGetMacro(SigmaZero, float);
+  itkSetMacro(SigmaZero, float);
+
+  /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
+  itkGetMacro(Alpha, float);
+  itkSetMacro(Alpha, float);
+
   /** Select the ForwardProjection filter */
   void
   SetForwardProjectionFilter(ForwardProjectionType _arg) override;
@@ -210,6 +218,10 @@ private:
 
   /** Number of iterations */
   unsigned int m_NumberOfIterations;
+
+  /** PSF correction coefficients */
+  float m_SigmaZero;
+  float m_Alpha;
 
 }; // end of class
 

--- a/include/rtkZengBackProjectionImageFilter.h
+++ b/include/rtkZengBackProjectionImageFilter.h
@@ -1,0 +1,182 @@
+/*=========================================================================
+ *
+ *  Copyright RTK Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef rtkZengBackProjectionImageFilter_h
+#define rtkZengBackProjectionImageFilter_h
+
+#include "rtkConfiguration.h"
+#include "rtkBackProjectionImageFilter.h"
+#include "rtkMacro.h"
+#include <itkPixelTraits.h>
+
+#include <itkMultiplyImageFilter.h>
+#include <itkAddImageFilter.h>
+#include <itkDiscreteGaussianImageFilter.h>
+#include <itkPasteImageFilter.h>
+#include <itkResampleImageFilter.h>
+#include <itkVector.h>
+#include <itkCenteredEuler3DTransform.h>
+#include <itkChangeInformationImageFilter.h>
+#include <itkExtractImageFilter.h>
+#include <itkExpImageFilter.h>
+#include <itkRegionOfInterestImageFilter.h>
+#include <itkConstantBoundaryCondition.h>
+
+#include "rtkConstantImageSource.h"
+
+#include <itkVectorImage.h>
+namespace rtk
+{
+
+/** \class ZengBackProjectionImageFilter
+ * \brief Zeng back projection.
+ *
+ * Performs a rotation based back projection, i.e. the volume is rotated so that
+ * the face of the image volume is parallel to the detector and the projection is done
+ * by summing the collumn. This projector is used to perform the PSF correction
+ * describe in [Zeng 1996]. The back projector tests if the detector
+ * has been placed after the source and the volume. If the detector is in the volume
+ * the sum is performed only until that point.
+ *
+ * \test rtkZengBackprojectiontest.cxx
+ *
+ * \author Antoine Robert
+ *
+ * \ingroup RTK Projector
+ */
+
+template <class TInputImage, class TOutputImage>
+class ITK_EXPORT ZengBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
+{
+public:
+  /** Standard class usings. */
+  using VectorType = itk::Vector<double, 3>;
+  using InputPixelType = typename TInputImage::PixelType;
+  using OutputPixelType = typename TOutputImage::PixelType;
+  using OutputImageRegionType = typename TOutputImage::RegionType;
+  using InputCPUImageType = itk::Image<InputPixelType, 3>;
+  using OuputCPUImageType = itk::Image<OutputPixelType, 3>;
+  using PointType = typename OuputCPUImageType::PointType;
+
+  using Self = ZengBackProjectionImageFilter;
+  using Superclass = BackProjectionImageFilter<TInputImage, TOutputImage>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+  using AddImageFilterType = itk::AddImageFilter<InputCPUImageType, InputCPUImageType>;
+  using AddImageFilterPointerType = typename AddImageFilterType::Pointer;
+  using PasteImageFilterType = itk::PasteImageFilter<InputCPUImageType, OuputCPUImageType>;
+  using PasteImageFilterPointerType = typename PasteImageFilterType::Pointer;
+  using DiscreteGaussianFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using DiscreteGaussianFilterPointeurType = typename DiscreteGaussianFilterType::Pointer;
+  using ResampleImageFilterType = itk::ResampleImageFilter<InputCPUImageType, InputCPUImageType>;
+  using ResampleImageFilterPointerType = typename ResampleImageFilterType::Pointer;
+  using TransformType = itk::CenteredEuler3DTransform<double>;
+  using TransformPointerType = typename TransformType::Pointer;
+  using ChangeInformationFilterType = itk::ChangeInformationImageFilter<OuputCPUImageType>;
+  using ChangeInformationPointerType = typename ChangeInformationFilterType::Pointer;
+  using MultiplyImageFilterType = itk::MultiplyImageFilter<InputCPUImageType, InputCPUImageType>;
+  using MultpiplyImageFilterPointerType = typename MultiplyImageFilterType::Pointer;
+  using ConstantVolumeSourceType = rtk::ConstantImageSource<InputCPUImageType>;
+  using ConstantVolumeSourcePointerType = typename ConstantVolumeSourceType::Pointer;
+  using ExtractImageFilterType = itk::ExtractImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using ExtractImageFilterPointerType = typename ExtractImageFilterType::Pointer;
+  using ExpImageFilterType = itk::ExpImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using ExpImageFilterPointerType = typename ExpImageFilterType::Pointer;
+  using RegionOfInterestFilterType = itk::RegionOfInterestImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using RegionOfInterestPointerType = typename RegionOfInterestFilterType::Pointer;
+
+  /** ImageDimension constants */
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+
+  /** Typedef for the boundary condition */
+  using BoundaryCondition = itk::ConstantBoundaryCondition<OuputCPUImageType>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ZengBackProjectionImageFilter, BackProjectionImageFilter);
+
+  /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
+  itkGetMacro(SigmaZero, float);
+  itkSetMacro(SigmaZero, float);
+
+  /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
+  itkGetMacro(Alpha, float);
+  itkSetMacro(Alpha, float);
+
+
+protected:
+  ZengBackProjectionImageFilter();
+  virtual ~ZengBackProjectionImageFilter() ITK_OVERRIDE {}
+
+  /** Apply changes to the input image requested region. */
+  void
+  GenerateInputRequestedRegion() override;
+
+  void
+  GenerateOutputInformation() ITK_OVERRIDE;
+
+  void
+  GenerateData() ITK_OVERRIDE;
+
+  /** The two inputs should not be in the same space so there is nothing
+   * to verify. */
+#if ITK_VERSION_MAJOR < 5
+  void
+  VerifyInputInformation() ITK_OVERRIDE;
+#else
+  void
+  VerifyInputInformation() const ITK_OVERRIDE;
+#endif
+
+  AddImageFilterPointerType          m_AddImageFilter;
+  PasteImageFilterPointerType        m_PasteImageFilter;
+  DiscreteGaussianFilterPointeurType m_DiscreteGaussianFilter;
+  ResampleImageFilterPointerType     m_ResampleImageFilter;
+  TransformPointerType               m_Transform;
+  MultpiplyImageFilterPointerType    m_MultiplyImageFilter;
+  ConstantVolumeSourcePointerType    m_ConstantVolumeSource;
+  ExtractImageFilterPointerType      m_ExtractImageFilter;
+  MultpiplyImageFilterPointerType    m_AttenuationMapMultiplyImageFilter;
+  RegionOfInterestPointerType        m_AttenuationMapRegionOfInterest;
+  ExpImageFilterPointerType          m_AttenuationMapExpImageFilter;
+  ResampleImageFilterPointerType     m_AttenuationMapResampleImageFilter;
+  MultpiplyImageFilterPointerType    m_AttenuationMapConstantMultiplyImageFilter;
+  ChangeInformationPointerType       m_AttenuationMapChangeInformation;
+  TransformPointerType               m_AttenuationMapTransform;
+  BoundaryCondition                  m_BoundsCondition;
+
+private:
+  ZengBackProjectionImageFilter(const Self &); // purposely not implemented
+  void
+  operator=(const Self &); // purposely not implemented
+
+  float      m_SigmaZero;
+  float      m_Alpha;
+  VectorType m_VectorOrthogonalDetector;
+  PointType  m_centerVolume;
+};
+
+} // end namespace rtk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "rtkZengBackProjectionImageFilter.hxx"
+#endif
+
+#endif

--- a/include/rtkZengBackProjectionImageFilter.hxx
+++ b/include/rtkZengBackProjectionImageFilter.hxx
@@ -1,0 +1,469 @@
+/*=========================================================================
+ *
+ *  Copyright RTK Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef rtkZengBackProjectionImageFilter_hxx
+#define rtkZengBackProjectionImageFilter_hxx
+
+#include <math.h>
+
+#include "rtkZengBackProjectionImageFilter.h"
+
+#include "rtkHomogeneousMatrix.h"
+#include "rtkBoxShape.h"
+#include "rtkProjectionsRegionConstIteratorRayBased.h"
+#include <itkImageFileWriter.h>
+
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkInputDataObjectConstIterator.h>
+
+namespace rtk
+{
+
+template <class TInputImage, class TOutputImage>
+ZengBackProjectionImageFilter<TInputImage, TOutputImage>::ZengBackProjectionImageFilter()
+{
+  // Set default parameters
+  m_SigmaZero = 1.5417233052142099;
+  m_Alpha = 0.016241189545787734;
+  m_VectorOrthogonalDetector[0] = 0;
+  m_VectorOrthogonalDetector[1] = 0;
+  m_VectorOrthogonalDetector[2] = 1;
+  m_centerVolume.Fill(0);
+
+  // Create each filter of the composite filter
+  m_AddImageFilter = AddImageFilterType::New();
+  m_PasteImageFilter = PasteImageFilterType::New();
+  m_DiscreteGaussianFilter = DiscreteGaussianFilterType::New();
+  m_ResampleImageFilter = ResampleImageFilterType::New();
+  m_Transform = TransformType::New();
+  m_MultiplyImageFilter = MultiplyImageFilterType::New();
+  m_ExtractImageFilter = ExtractImageFilterType::New();
+  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_AttenuationMapExpImageFilter = nullptr;
+  m_AttenuationMapMultiplyImageFilter = nullptr;
+  m_AttenuationMapRegionOfInterest = nullptr;
+  m_AttenuationMapResampleImageFilter = nullptr;
+  m_AttenuationMapConstantMultiplyImageFilter = nullptr;
+  m_AttenuationMapChangeInformation = nullptr;
+  m_AttenuationMapTransform = nullptr;
+
+  // Permanent internal connections
+  m_AddImageFilter->SetInput2(m_MultiplyImageFilter->GetOutput());
+  m_MultiplyImageFilter->SetInput(m_ResampleImageFilter->GetOutput());
+
+  // Default parameters
+  m_DiscreteGaussianFilter->SetMaximumError(0.00001);
+  m_DiscreteGaussianFilter->SetFilterDimensionality(2);
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
+  m_DiscreteGaussianFilter->SetInputBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianFilter->SetRealBoundaryCondition(&m_BoundsCondition);
+#endif
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
+{
+  Superclass::GenerateInputRequestedRegion();
+  // Input 2 is the attenuation map relative to the volume
+  typename Superclass::InputImagePointer inputPtr2 = const_cast<TInputImage *>(this->GetInput(2));
+  if (!inputPtr2)
+    return;
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengBackProjectionImageFilter<TInputImage, TOutputImage>
+#if ITK_VERSION_MAJOR < 5
+  ::VerifyInputInformation()
+#else
+  ::VerifyInputInformation() const
+#endif
+{
+  using ImageBaseType = const itk::ImageBase<InputImageDimension>;
+
+  ImageBaseType * inputPtr1 = nullptr;
+
+  itk::InputDataObjectConstIterator it(this);
+  for (; !it.IsAtEnd(); ++it)
+  {
+    // Check whether the output is an image of the appropriate
+    // dimension (use ProcessObject's version of the GetInput()
+    // method since it returns the input as a pointer to a
+    // DataObject as opposed to the subclass version which
+    // static_casts the input to an TInputImage).
+    if (it.GetName() != "_1")
+    {
+      inputPtr1 = dynamic_cast<ImageBaseType *>(it.GetInput());
+    }
+    if (inputPtr1)
+    {
+      break;
+    }
+  }
+
+  for (; !it.IsAtEnd(); ++it)
+  {
+    if (it.GetName() != "_1")
+    {
+      auto * inputPtrN = dynamic_cast<ImageBaseType *>(it.GetInput());
+      // Physical space computation only matters if we're using two
+      // images, and not an image and a constant.
+      if (inputPtrN)
+      {
+        // check that the image occupy the same physical space, and that
+        // each index is at the same physical location
+
+        // tolerance for origin and spacing depends on the size of pixel
+        // tolerance for directions a fraction of the unit cube.
+        const double coordinateTol = itk::Math::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                                    inputPtr1->GetSpacing()[0]); // use first dimension spacing
+
+        if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+        {
+          std::ostringstream originString, spacingString, directionString;
+          if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
+          {
+            originString.setf(std::ios::scientific);
+            originString.precision(7);
+            originString << "InputImage Origin: " << inputPtr1->GetOrigin() << ", InputImage" << it.GetName()
+                         << " Origin: " << inputPtrN->GetOrigin() << std::endl;
+            originString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol))
+          {
+            spacingString.setf(std::ios::scientific);
+            spacingString.precision(7);
+            spacingString << "InputImage Spacing: " << inputPtr1->GetSpacing() << ", InputImage" << it.GetName()
+                          << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
+            spacingString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+                inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+          {
+            directionString.setf(std::ios::scientific);
+            directionString.precision(7);
+            directionString << "InputImage Direction: " << inputPtr1->GetDirection() << ", InputImage" << it.GetName()
+                            << " Direction: " << inputPtrN->GetDirection() << std::endl;
+            directionString << "\tTolerance: " << Self::GetGlobalDefaultDirectionTolerance() << std::endl;
+          }
+          itkExceptionMacro(<< "Inputs do not occupy the same physical space! " << std::endl
+                            << originString.str() << spacingString.str() << directionString.str());
+        }
+      }
+    }
+  }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
+{
+
+  // Info of the input volume
+  const typename InputCPUImageType::PointType   originVolume = this->GetInput(0)->GetOrigin();
+  const typename InputCPUImageType::SpacingType spacingVolume = this->GetInput(0)->GetSpacing();
+  const typename InputCPUImageType::SizeType    sizeVolume = this->GetInput(0)->GetLargestPossibleRegion().GetSize();
+
+  // Info of the input stack of projections
+  const typename OuputCPUImageType::SpacingType spacingProjections = this->GetInput(1)->GetSpacing();
+  const typename OuputCPUImageType::SizeType  sizeProjection = this->GetInput(1)->GetLargestPossibleRegion().GetSize();
+  const typename OuputCPUImageType::PointType originProjection = this->GetInput(1)->GetOrigin();
+
+  // Find the center of the volume
+  m_centerVolume[0] = originVolume[0] + spacingVolume[0] * (double)(sizeVolume[0] - 1) / 2.0;
+  m_centerVolume[1] = originVolume[1] + spacingVolume[1] * (double)(sizeVolume[1] - 1) / 2.0;
+  m_centerVolume[2] = originVolume[2] + spacingVolume[2] * (double)(sizeVolume[2] - 1) / 2.0;
+
+  PointType centerRotation;
+  centerRotation.Fill(0);
+  m_Transform->SetCenter(centerRotation);
+  m_ResampleImageFilter->SetTransform(m_Transform);
+  m_ResampleImageFilter->SetOutputParametersFromImage(this->GetInput(0));
+
+  // Set the output size of volume
+  typename InputCPUImageType::SizeType outputSize;
+  outputSize[0] = sizeProjection[0];
+  outputSize[1] = sizeProjection[1];
+  outputSize[2] = sizeVolume[2] * std::sqrt(2);
+
+  // Set the new origin of the volume
+  typename InputCPUImageType::PointType outputOrigin;
+  outputOrigin[0] = originProjection[0];
+  outputOrigin[1] = originProjection[1];
+  outputOrigin[2] = m_centerVolume[2] - spacingVolume[2] * (double)(outputSize[2] - 1) / 2.0;
+
+  // Set the output spacing of the volume
+  typename InputCPUImageType::SpacingType outputSpacing;
+  outputSpacing[0] = spacingProjections[0];
+  outputSpacing[1] = spacingProjections[1];
+  outputSpacing[2] = spacingVolume[2];
+
+  // We only set the first sub-stack at that point, the rest will be
+  // requested in the GenerateData function
+  typename ExtractImageFilterType::InputImageRegionType projRegion;
+  const unsigned int                                    Dimension = this->InputImageDimension;
+  projRegion = this->GetInput(1)->GetLargestPossibleRegion();
+  m_ExtractImageFilter->SetExtractionRegion(projRegion);
+  m_ExtractImageFilter->SetInput(this->GetInput(1));
+  m_ExtractImageFilter->UpdateOutputInformation();
+
+  m_DiscreteGaussianFilter->SetVariance(pow(m_SigmaZero, 2.0));
+
+  if (!(this->GetInput(2)))
+  {
+    m_DiscreteGaussianFilter->SetInput(m_ExtractImageFilter->GetOutput());
+  }
+  else
+  {
+    m_AttenuationMapExpImageFilter = ExpImageFilterType::New();
+    m_AttenuationMapMultiplyImageFilter = MultiplyImageFilterType::New();
+    m_AttenuationMapRegionOfInterest = RegionOfInterestFilterType::New();
+    m_AttenuationMapResampleImageFilter = ResampleImageFilterType::New();
+    m_AttenuationMapConstantMultiplyImageFilter = MultiplyImageFilterType::New();
+    m_AttenuationMapChangeInformation = ChangeInformationFilterType::New();
+    m_AttenuationMapTransform = TransformType::New();
+    m_AttenuationMapChangeInformation->ChangeOriginOn();
+    m_AttenuationMapChangeInformation->ChangeRegionOn();
+    m_AttenuationMapChangeInformation->SetReferenceImage(m_ExtractImageFilter->GetOutput());
+    m_AttenuationMapChangeInformation->SetUseReferenceImage(true);
+
+    m_AttenuationMapTransform->SetCenter(centerRotation);
+    m_AttenuationMapResampleImageFilter->SetTransform(m_AttenuationMapTransform);
+    m_AttenuationMapResampleImageFilter->SetOutputParametersFromImage(this->GetInput(0));
+
+    m_AttenuationMapResampleImageFilter->SetSize(outputSize);
+    m_AttenuationMapResampleImageFilter->SetOutputOrigin(outputOrigin);
+    m_AttenuationMapResampleImageFilter->SetOutputSpacing(spacingProjections);
+    m_AttenuationMapResampleImageFilter->SetInput(this->GetInput(2));
+    m_AttenuationMapResampleImageFilter->UpdateOutputInformation();
+
+    typename RegionOfInterestFilterType::InputImageRegionType attRegion;
+    attRegion = m_AttenuationMapResampleImageFilter->GetOutput()->GetLargestPossibleRegion();
+    attRegion.SetSize(Dimension - 1, 1);
+    m_AttenuationMapRegionOfInterest->SetRegionOfInterest(attRegion);
+    m_AttenuationMapRegionOfInterest->SetInput(m_AttenuationMapResampleImageFilter->GetOutput());
+    m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+
+    m_AttenuationMapConstantMultiplyImageFilter->SetInput(m_AttenuationMapRegionOfInterest->GetOutput());
+    m_AttenuationMapConstantMultiplyImageFilter->SetConstant(-spacingVolume[2]);
+    m_AttenuationMapExpImageFilter->SetInput(m_AttenuationMapConstantMultiplyImageFilter->GetOutput());
+    m_AttenuationMapChangeInformation->SetInput(m_AttenuationMapExpImageFilter->GetOutput());
+    m_AttenuationMapMultiplyImageFilter->SetInput1(m_ExtractImageFilter->GetOutput());
+    m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapChangeInformation->GetOutput());
+    m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+  }
+
+  m_MultiplyImageFilter->SetConstant(spacingVolume[2]);
+
+  m_ConstantVolumeSource->SetInformationFromImage(const_cast<TInputImage *>(this->GetInput(0)));
+  m_ConstantVolumeSource->SetSpacing(outputSpacing);
+  m_ConstantVolumeSource->SetOrigin(outputOrigin);
+  m_ConstantVolumeSource->SetSize(outputSize);
+  m_ConstantVolumeSource->SetConstant(0);
+
+  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianFilter->GetOutput());
+  m_PasteImageFilter->SetDestinationImage(m_ConstantVolumeSource->GetOutput());
+  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+
+  m_ResampleImageFilter->SetInput(m_PasteImageFilter->GetOutput());
+  m_AddImageFilter->SetInput1(this->GetInput(0));
+
+  // Update output information
+  m_AddImageFilter->UpdateOutputInformation();
+  this->GetOutput()->SetOrigin(m_AddImageFilter->GetOutput()->GetOrigin());
+  this->GetOutput()->SetSpacing(m_AddImageFilter->GetOutput()->GetSpacing());
+  this->GetOutput()->SetDirection(m_AddImageFilter->GetOutput()->GetDirection());
+  this->GetOutput()->SetLargestPossibleRegion(m_AddImageFilter->GetOutput()->GetLargestPossibleRegion());
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
+{
+  const typename Superclass::GeometryType::ConstPointer geometry = this->GetGeometry();
+  const unsigned int                                    Dimension = this->InputImageDimension;
+
+  typename ExtractImageFilterType::InputImageRegionType projRegion;
+  projRegion = this->GetInput(1)->GetLargestPossibleRegion();
+  int                 indexProj = 0;
+  std::vector<double> list_angle;
+  if (geometry->GetGantryAngles().size() != projRegion.GetSize(Dimension - 1))
+  {
+    indexProj = projRegion.GetIndex(Dimension - 1);
+    list_angle.push_back(geometry->GetGantryAngles()[indexProj]);
+  }
+  else
+  {
+    list_angle = geometry->GetGantryAngles();
+  }
+
+  projRegion.SetSize(Dimension - 1, 1);
+
+  typename OuputCPUImageType::Pointer                       currentSlice;
+  typename OuputCPUImageType::Pointer                       pimg;
+  typename OuputCPUImageType::Pointer                       currentVolume;
+  typename OuputCPUImageType::PointType                     pointSlice;
+  typename OuputCPUImageType::IndexType                     indexSlice;
+  typename OuputCPUImageType::Pointer                       rotatedAttenuation;
+  typename RegionOfInterestFilterType::InputImageRegionType desiredRegion;
+  PointType                                                 centerRotatedVolume;
+  PointType                                                 originRotatedVolume;
+
+  indexSlice.Fill(0);
+  float dist, sigmaSlice;
+  float thicknessSlice = this->GetInput(0)->GetSpacing()[2];
+  int   nbProjections = 0;
+  int   startSlice;
+  for (auto & angle : list_angle)
+  {
+    // Get the center of the rotated volume
+    m_Transform->SetRotation(0., angle, 0.);
+    centerRotatedVolume = m_Transform->GetMatrix() * m_centerVolume;
+
+    // Set the new origin of the rotate volume according to the center
+    originRotatedVolume = m_ConstantVolumeSource->GetOrigin();
+    originRotatedVolume[2] = centerRotatedVolume[2] - m_ConstantVolumeSource->GetSpacing()[2] *
+                                                        (double)(m_ConstantVolumeSource->GetSize()[2] - 1) / 2.0;
+    m_ConstantVolumeSource->SetOrigin(originRotatedVolume);
+
+    // Set the rotation angle.
+    m_Transform->SetRotation(0., -angle, 0.);
+
+    // Extract the projection corresponding to the current angle from the projection stack
+    projRegion.SetIndex(Dimension - 1, nbProjections + indexProj);
+    m_ExtractImageFilter->SetExtractionRegion(projRegion);
+    m_ExtractImageFilter->UpdateOutputInformation();
+
+    // Find the first positive distance between the volume and the detector
+    m_ConstantVolumeSource->Update();
+    startSlice = m_ConstantVolumeSource->GetOutput()->GetLargestPossibleRegion().GetSize()[2];
+    dist = -1;
+    while (dist < 0)
+    {
+      startSlice -= 1;
+      indexSlice[Dimension - 1] = startSlice;
+      m_ConstantVolumeSource->GetOutput()->TransformIndexToPhysicalPoint(indexSlice, pointSlice);
+      dist = geometry->GetSourceToIsocenterDistances()[nbProjections] -
+             pointSlice.GetVectorFromOrigin() * m_VectorOrthogonalDetector;
+    }
+    if (this->GetInput(2))
+    {
+      m_AttenuationMapTransform->SetRotation(0., angle, 0.);
+      m_AttenuationMapResampleImageFilter->SetOutputOrigin(originRotatedVolume);
+      m_AttenuationMapResampleImageFilter->Update();
+      rotatedAttenuation = m_AttenuationMapResampleImageFilter->GetOutput();
+      rotatedAttenuation->DisconnectPipeline();
+      desiredRegion = rotatedAttenuation->GetLargestPossibleRegion();
+      desiredRegion.SetSize(Dimension - 1, 1);
+      desiredRegion.SetIndex(Dimension - 1, startSlice);
+      m_AttenuationMapRegionOfInterest->SetInput(rotatedAttenuation);
+      m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
+      m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+    }
+    // Compute the variance of the PSF for the first slice
+    sigmaSlice = pow(m_Alpha * dist + m_SigmaZero, 2.0);
+    m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+    m_DiscreteGaussianFilter->UpdateLargestPossibleRegion();
+    currentSlice = m_DiscreteGaussianFilter->GetOutput();
+    currentSlice->DisconnectPipeline();
+
+    // Paste the blur slice into the output volume
+    m_PasteImageFilter->SetSourceImage(currentSlice);
+    m_PasteImageFilter->SetSourceRegion(currentSlice->GetLargestPossibleRegion());
+    m_PasteImageFilter->SetDestinationIndex(indexSlice);
+    m_PasteImageFilter->Update();
+    currentVolume = m_PasteImageFilter->GetOutput();
+    currentVolume->DisconnectPipeline();
+    m_PasteImageFilter->SetDestinationImage(currentVolume);
+    if (!this->GetInput(2))
+    {
+      m_DiscreteGaussianFilter->SetInput(currentSlice);
+    }
+    else
+    {
+      desiredRegion.SetIndex(Dimension - 1, startSlice - 1);
+      m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
+      m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+      m_AttenuationMapMultiplyImageFilter->SetInput1(currentSlice);
+      m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+    }
+    int index;
+    for (index = startSlice; index > 0; index--)
+    {
+      // Compute the distance between the current slice and the detector
+      indexSlice[Dimension - 1] = index - 1;
+      dist += m_ConstantVolumeSource->GetSpacing()[2];
+      // Compute the variance of the PSF for the current slice
+      sigmaSlice = dist * 2 * thicknessSlice * pow(m_Alpha, 2.0) + 2 * thicknessSlice * m_Alpha * m_SigmaZero -
+                   pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
+      m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+      m_DiscreteGaussianFilter->Update();
+      currentSlice = m_DiscreteGaussianFilter->GetOutput();
+      currentSlice->DisconnectPipeline();
+
+      // Paste the blur slice into the output volume
+      m_PasteImageFilter->SetSourceImage(currentSlice);
+      m_PasteImageFilter->SetSourceRegion(currentSlice->GetLargestPossibleRegion());
+      m_PasteImageFilter->SetDestinationIndex(indexSlice);
+      m_PasteImageFilter->Update();
+      currentVolume = m_PasteImageFilter->GetOutput();
+      currentVolume->DisconnectPipeline();
+      m_PasteImageFilter->SetDestinationImage(currentVolume);
+      if (!this->GetInput(2))
+      {
+        m_DiscreteGaussianFilter->SetInput(currentSlice);
+      }
+      else
+      {
+        desiredRegion.SetIndex(Dimension - 1, index - 1);
+        m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
+        m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+        m_AttenuationMapMultiplyImageFilter->SetInput1(currentSlice);
+        m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+      }
+    }
+    // Rotate the volume
+    m_ResampleImageFilter->SetInput(currentVolume);
+    m_AddImageFilter->Update();
+    pimg = m_AddImageFilter->GetOutput();
+    pimg->DisconnectPipeline();
+    m_AddImageFilter->SetInput1(pimg);
+    if (!this->GetInput(2))
+    {
+      m_DiscreteGaussianFilter->SetInput(m_ExtractImageFilter->GetOutput());
+    }
+    else
+    {
+      m_AttenuationMapMultiplyImageFilter->SetInput1(m_ExtractImageFilter->GetOutput());
+      m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+    }
+    nbProjections++;
+  }
+  this->GetOutput()->SetPixelContainer(pimg->GetPixelContainer());
+  this->GetOutput()->CopyInformation(pimg);
+  this->GetOutput()->SetBufferedRegion(pimg->GetBufferedRegion());
+  this->GetOutput()->SetRequestedRegion(pimg->GetRequestedRegion());
+}
+
+} // end namespace rtk
+
+#endif

--- a/include/rtkZengForwardProjectionImageFilter.h
+++ b/include/rtkZengForwardProjectionImageFilter.h
@@ -1,0 +1,173 @@
+/*=========================================================================
+ *
+ *  Copyright RTK Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef rtkZengForwardProjectionImageFilter_h
+#define rtkZengForwardProjectionImageFilter_h
+
+#include "rtkConfiguration.h"
+#include "rtkForwardProjectionImageFilter.h"
+#include "rtkMacro.h"
+#include <itkPixelTraits.h>
+
+#include <itkMultiplyImageFilter.h>
+#include <itkAddImageFilter.h>
+#include <itkDiscreteGaussianImageFilter.h>
+#include <itkPasteImageFilter.h>
+#include <itkResampleImageFilter.h>
+#include <itkVector.h>
+#include <itkCenteredEuler3DTransform.h>
+#include <itkChangeInformationImageFilter.h>
+#include <itkRegionOfInterestImageFilter.h>
+#include <itkExpImageFilter.h>
+#include <itkConstantBoundaryCondition.h>
+
+#include <itkVectorImage.h>
+namespace rtk
+{
+
+/** \class ZengForwardProjectionImageFilter
+ * \brief Zeng forward projection.
+ *
+ * Performs a rotation based forward projection, i.e. the volume is rotated so that
+ * the face of the image volume is parallel to the detector and the projection is done
+ * by summing the collumn. This projector is used to perform the PSF correction
+ * describe in [Zeng 1996]. The forward projector tests if the detector
+ * has been placed after the source and the volume. If the detector is in the volume
+ * the sum is performed only until that point.
+ *
+ * \test rtkZengforwardprojectiontest.cxx
+ *
+ * \author Antoine Robert
+ *
+ * \ingroup RTK Projector
+ */
+
+template <class TInputImage, class TOutputImage>
+class ITK_EXPORT ZengForwardProjectionImageFilter : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
+{
+public:
+  /** Standard class usings. */
+  using VectorType = itk::Vector<double, 3>;
+  using InputPixelType = typename TInputImage::PixelType;
+  using OutputPixelType = typename TOutputImage::PixelType;
+  using OutputImageRegionType = typename TOutputImage::RegionType;
+  using InputCPUImageType = itk::Image<InputPixelType, 3>;
+  using OuputCPUImageType = itk::Image<OutputPixelType, 3>;
+  using PointType = typename InputCPUImageType::PointType;
+
+  using Self = ZengForwardProjectionImageFilter;
+  using Superclass = ForwardProjectionImageFilter<TInputImage, TOutputImage>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
+  using AddImageFilterType = itk::AddImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using AddImageFilterPointerType = typename AddImageFilterType::Pointer;
+  using PasteImageFilterType = itk::PasteImageFilter<OuputCPUImageType, InputCPUImageType>;
+  using PasteImageFilterPointerType = typename PasteImageFilterType::Pointer;
+  using DiscreteGaussianFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using DiscreteGaussianFilterPointeurType = typename DiscreteGaussianFilterType::Pointer;
+  using ResampleImageFilterType = itk::ResampleImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using ResampleImageFilterPointerType = typename ResampleImageFilterType::Pointer;
+  using TransformType = itk::CenteredEuler3DTransform<double>;
+  using TransformPointerType = typename TransformType::Pointer;
+  using ChangeInformationFilterType = itk::ChangeInformationImageFilter<OuputCPUImageType>;
+  using ChangeInformationPointerType = typename ChangeInformationFilterType::Pointer;
+  using RegionOfInterestFilterType = itk::RegionOfInterestImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using RegionOfInterestPointerType = typename RegionOfInterestFilterType::Pointer;
+  using MultiplyImageFilterType = itk::MultiplyImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using MultpiplyImageFilterPointerType = typename MultiplyImageFilterType::Pointer;
+  using ExpImageFilterType = itk::ExpImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using ExpImageFilterPointerType = typename ExpImageFilterType::Pointer;
+
+  /** ImageDimension constants */
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+
+  /** Typedef for the boundary condition */
+  using BoundaryCondition = itk::ConstantBoundaryCondition<OuputCPUImageType>;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ZengForwardProjectionImageFilter, ForwardProjectionImageFilter);
+
+  /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
+  itkGetMacro(SigmaZero, float);
+  itkSetMacro(SigmaZero, float);
+
+  /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
+  itkGetMacro(Alpha, float);
+  itkSetMacro(Alpha, float);
+
+protected:
+  ZengForwardProjectionImageFilter();
+  virtual ~ZengForwardProjectionImageFilter() ITK_OVERRIDE {}
+
+  void
+  GenerateInputRequestedRegion() ITK_OVERRIDE;
+
+  void
+  GenerateOutputInformation() ITK_OVERRIDE;
+
+  void
+  GenerateData() ITK_OVERRIDE;
+
+  /** The two inputs should not be in the same space so there is nothing
+   * to verify. */
+#if ITK_VERSION_MAJOR < 5
+  void
+  VerifyInputInformation() ITK_OVERRIDE;
+#else
+  void
+  VerifyInputInformation() const ITK_OVERRIDE;
+#endif
+
+  RegionOfInterestPointerType        m_RegionOfInterest;
+  AddImageFilterPointerType          m_AddImageFilter;
+  PasteImageFilterPointerType        m_PasteImageFilter;
+  DiscreteGaussianFilterPointeurType m_DiscreteGaussianFilter;
+  ResampleImageFilterPointerType     m_ResampleImageFilter;
+  TransformPointerType               m_Transform;
+  ChangeInformationPointerType       m_ChangeInformation;
+  MultpiplyImageFilterPointerType    m_MultiplyImageFilter;
+  MultpiplyImageFilterPointerType    m_AttenuationMapMultiplyImageFilter;
+  RegionOfInterestPointerType        m_AttenuationMapRegionOfInterest;
+  ExpImageFilterPointerType          m_AttenuationMapExpImageFilter;
+  ResampleImageFilterPointerType     m_AttenuationMapResampleImageFilter;
+  MultpiplyImageFilterPointerType    m_AttenuationMapConstantMultiplyImageFilter;
+  ChangeInformationPointerType       m_AttenuationMapChangeInformation;
+  BoundaryCondition                  m_BoundsCondition;
+
+
+private:
+  ZengForwardProjectionImageFilter(const Self &); // purposely not implemented
+  void
+  operator=(const Self &); // purposely not implemented
+
+  float      m_SigmaZero;
+  float      m_Alpha;
+  VectorType m_VectorOrthogonalDetector;
+  PointType  m_centerVolume;
+};
+
+} // end namespace rtk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "rtkZengForwardProjectionImageFilter.hxx"
+#endif
+
+#endif

--- a/include/rtkZengForwardProjectionImageFilter.hxx
+++ b/include/rtkZengForwardProjectionImageFilter.hxx
@@ -1,0 +1,442 @@
+/*=========================================================================
+ *
+ *  Copyright RTK Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef rtkZengForwardProjectionImageFilter_hxx
+#define rtkZengForwardProjectionImageFilter_hxx
+
+#include <math.h>
+
+#include "rtkZengForwardProjectionImageFilter.h"
+
+#include "rtkHomogeneousMatrix.h"
+#include "rtkBoxShape.h"
+#include "rtkProjectionsRegionConstIteratorRayBased.h"
+#include "itkImageFileWriter.h"
+
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkInputDataObjectConstIterator.h>
+
+namespace rtk
+{
+
+template <class TInputImage, class TOutputImage>
+ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::ZengForwardProjectionImageFilter()
+{
+  // Set default parameters
+  m_SigmaZero = 1.5417233052142099;
+  m_Alpha = 0.016241189545787734;
+  m_VectorOrthogonalDetector[0] = 0;
+  m_VectorOrthogonalDetector[1] = 0;
+  m_VectorOrthogonalDetector[2] = 1;
+  m_centerVolume.Fill(0);
+
+  // Create each filter of the composite filter
+  m_RegionOfInterest = RegionOfInterestFilterType::New();
+  m_AddImageFilter = AddImageFilterType::New();
+  m_PasteImageFilter = PasteImageFilterType::New();
+  m_DiscreteGaussianFilter = DiscreteGaussianFilterType::New();
+  m_ResampleImageFilter = ResampleImageFilterType::New();
+  m_Transform = TransformType::New();
+  m_ChangeInformation = ChangeInformationFilterType::New();
+  m_MultiplyImageFilter = MultiplyImageFilterType::New();
+  m_AttenuationMapExpImageFilter = nullptr;
+  m_AttenuationMapMultiplyImageFilter = nullptr;
+  m_AttenuationMapRegionOfInterest = nullptr;
+  m_AttenuationMapResampleImageFilter = nullptr;
+  m_AttenuationMapConstantMultiplyImageFilter = nullptr;
+  m_AttenuationMapChangeInformation = nullptr;
+
+  // Permanent internal connections
+  m_AddImageFilter->SetInput1(m_DiscreteGaussianFilter->GetOutput());
+  m_AddImageFilter->SetInput2(m_ChangeInformation->GetOutput());
+  m_MultiplyImageFilter->SetInput(m_PasteImageFilter->GetOutput());
+
+  // Default parameters
+  m_DiscreteGaussianFilter->SetMaximumError(0.00001);
+  m_DiscreteGaussianFilter->SetFilterDimensionality(2);
+#if (ITK_VERSION_MAJOR == 5) && (ITK_VERSION_MINOR >= 1)
+  m_DiscreteGaussianFilter->SetInputBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianFilter->SetRealBoundaryCondition(&m_BoundsCondition);
+#endif
+  m_ChangeInformation->ChangeOriginOn();
+  m_ChangeInformation->SetReferenceImage(m_DiscreteGaussianFilter->GetOutput());
+  m_ChangeInformation->SetUseReferenceImage(true);
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
+{
+  Superclass::GenerateInputRequestedRegion();
+  // Input 2 is the attenuation map relative to the volume
+  typename Superclass::InputImagePointer inputPtr2 = const_cast<TInputImage *>(this->GetInput(2));
+  if (!inputPtr2)
+    return;
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengForwardProjectionImageFilter<TInputImage, TOutputImage>
+#if ITK_VERSION_MAJOR < 5
+  ::VerifyInputInformation()
+#else
+  ::VerifyInputInformation() const
+#endif
+{
+  using ImageBaseType = const itk::ImageBase<InputImageDimension>;
+
+  ImageBaseType * inputPtr1 = nullptr;
+
+  itk::InputDataObjectConstIterator it(this);
+  for (; !it.IsAtEnd(); ++it)
+  {
+    // Check whether the output is an image of the appropriate
+    // dimension (use ProcessObject's version of the GetInput()
+    // method since it returns the input as a pointer to a
+    // DataObject as opposed to the subclass version which
+    // static_casts the input to an TInputImage).
+    if (it.GetName() != "Primary")
+    {
+      inputPtr1 = dynamic_cast<ImageBaseType *>(it.GetInput());
+    }
+    if (inputPtr1)
+    {
+      break;
+    }
+  }
+
+  for (; !it.IsAtEnd(); ++it)
+  {
+    if (it.GetName() != "Primary")
+    {
+      auto * inputPtrN = dynamic_cast<ImageBaseType *>(it.GetInput());
+      // Physical space computation only matters if we're using two
+      // images, and not an image and a constant.
+      if (inputPtrN)
+      {
+        // check that the image occupy the same physical space, and that
+        // each index is at the same physical location
+
+        // tolerance for origin and spacing depends on the size of pixel
+        // tolerance for directions a fraction of the unit cube.
+        const double coordinateTol = itk::Math::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                                    inputPtr1->GetSpacing()[0]); // use first dimension spacing
+
+        if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+        {
+          std::ostringstream originString, spacingString, directionString;
+          if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
+          {
+            originString.setf(std::ios::scientific);
+            originString.precision(7);
+            originString << "InputImage Origin: " << inputPtr1->GetOrigin() << ", InputImage" << it.GetName()
+                         << " Origin: " << inputPtrN->GetOrigin() << std::endl;
+            originString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol))
+          {
+            spacingString.setf(std::ios::scientific);
+            spacingString.precision(7);
+            spacingString << "InputImage Spacing: " << inputPtr1->GetSpacing() << ", InputImage" << it.GetName()
+                          << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
+            spacingString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+                inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+          {
+            directionString.setf(std::ios::scientific);
+            directionString.precision(7);
+            directionString << "InputImage Direction: " << inputPtr1->GetDirection() << ", InputImage" << it.GetName()
+                            << " Direction: " << inputPtrN->GetDirection() << std::endl;
+            directionString << "\tTolerance: " << Self::GetGlobalDefaultDirectionTolerance() << std::endl;
+          }
+          itkExceptionMacro(<< "Inputs do not occupy the same physical space! " << std::endl
+                            << originString.str() << spacingString.str() << directionString.str());
+        }
+      }
+    }
+  }
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
+{
+
+  // Info of the input volume
+  const typename OuputCPUImageType::PointType   originVolume = this->GetInput(1)->GetOrigin();
+  const typename OuputCPUImageType::SpacingType spacingVolume = this->GetInput(1)->GetSpacing();
+  const typename OuputCPUImageType::SizeType    sizeVolume = this->GetInput(1)->GetLargestPossibleRegion().GetSize();
+
+  // Info of the input stack of projections
+  const typename InputCPUImageType::SpacingType spacingProjections = this->GetInput(0)->GetSpacing();
+  const typename InputCPUImageType::SizeType  sizeProjection = this->GetInput(0)->GetLargestPossibleRegion().GetSize();
+  const typename OuputCPUImageType::PointType originProjection = this->GetInput(0)->GetOrigin();
+
+  // Find the center of the volume
+  m_centerVolume[0] = originVolume[0] + spacingVolume[0] * (double)(sizeVolume[0] - 1) / 2.0;
+  m_centerVolume[1] = originVolume[1] + spacingVolume[1] * (double)(sizeVolume[1] - 1) / 2.0;
+  m_centerVolume[2] = originVolume[2] + spacingVolume[2] * (double)(sizeVolume[2] - 1) / 2.0;
+
+  PointType centerRotation;
+  centerRotation.Fill(0);
+  m_Transform->SetCenter(centerRotation);
+  m_ResampleImageFilter->SetTransform(m_Transform);
+  m_ResampleImageFilter->SetOutputParametersFromImage(this->GetInput(1));
+
+  // Set the output size of the rotated volume
+  typename OuputCPUImageType::SizeType outputSize;
+  outputSize[0] = sizeProjection[0];
+  outputSize[1] = sizeProjection[1];
+  outputSize[2] = sizeVolume[2] * std::sqrt(2);
+  m_ResampleImageFilter->SetSize(outputSize);
+
+  // Set the new origin of the rotated volume
+  typename OuputCPUImageType::PointType outputOrigin;
+  outputOrigin[0] = originProjection[0];
+  outputOrigin[1] = originProjection[1];
+  outputOrigin[2] = m_centerVolume[2] - spacingVolume[2] * (double)(outputSize[2] - 1) / 2.0;
+  m_ResampleImageFilter->SetOutputOrigin(outputOrigin);
+
+  // Set the output spacing of the rotated volume
+  typename OuputCPUImageType::SpacingType outputSpacing;
+  outputSpacing[0] = spacingProjections[0];
+  outputSpacing[1] = spacingProjections[1];
+  outputSpacing[2] = spacingVolume[2];
+  m_ResampleImageFilter->SetOutputSpacing(outputSpacing);
+  m_ResampleImageFilter->SetInput(this->GetInput(1));
+  m_ResampleImageFilter->UpdateOutputInformation();
+
+  // We only set the first sub-stack at that point, the rest will be
+  // requested in the GenerateData function
+  typename RegionOfInterestFilterType::InputImageRegionType projRegion;
+  const unsigned int                                        Dimension = this->InputImageDimension;
+  projRegion = m_ResampleImageFilter->GetOutput()->GetLargestPossibleRegion();
+  projRegion.SetSize(Dimension - 1, 1);
+  m_RegionOfInterest->SetRegionOfInterest(projRegion);
+  m_RegionOfInterest->SetInput(m_ResampleImageFilter->GetOutput());
+  m_RegionOfInterest->UpdateOutputInformation();
+
+  m_DiscreteGaussianFilter->SetVariance(pow(m_SigmaZero, 2.0));
+
+  if (!(this->GetInput(2)))
+  {
+    m_DiscreteGaussianFilter->SetInput(m_RegionOfInterest->GetOutput());
+  }
+  else
+  {
+    m_AttenuationMapExpImageFilter = ExpImageFilterType::New();
+    m_AttenuationMapMultiplyImageFilter = MultiplyImageFilterType::New();
+    m_AttenuationMapRegionOfInterest = RegionOfInterestFilterType::New();
+    m_AttenuationMapResampleImageFilter = ResampleImageFilterType::New();
+    m_AttenuationMapConstantMultiplyImageFilter = MultiplyImageFilterType::New();
+    m_AttenuationMapChangeInformation = ChangeInformationFilterType::New();
+    m_AttenuationMapChangeInformation->ChangeOriginOn();
+    m_AttenuationMapChangeInformation->SetReferenceImage(m_DiscreteGaussianFilter->GetOutput());
+    m_AttenuationMapChangeInformation->SetUseReferenceImage(true);
+
+    m_AttenuationMapResampleImageFilter->SetTransform(m_Transform);
+    m_AttenuationMapResampleImageFilter->SetOutputParametersFromImage(this->GetInput(1));
+    m_AttenuationMapResampleImageFilter->SetSize(outputSize);
+    m_AttenuationMapResampleImageFilter->SetOutputOrigin(outputOrigin);
+    m_AttenuationMapResampleImageFilter->SetOutputSpacing(outputSpacing);
+    m_AttenuationMapResampleImageFilter->SetInput(this->GetInput(2));
+    m_AttenuationMapResampleImageFilter->UpdateOutputInformation();
+
+    m_AttenuationMapRegionOfInterest->SetRegionOfInterest(projRegion);
+    m_AttenuationMapRegionOfInterest->SetInput(m_AttenuationMapResampleImageFilter->GetOutput());
+    m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+
+    m_AttenuationMapConstantMultiplyImageFilter->SetInput(m_AttenuationMapRegionOfInterest->GetOutput());
+    m_AttenuationMapConstantMultiplyImageFilter->SetConstant(-spacingVolume[2]);
+    m_AttenuationMapExpImageFilter->SetInput(m_AttenuationMapConstantMultiplyImageFilter->GetOutput());
+    m_AttenuationMapMultiplyImageFilter->SetInput1(m_RegionOfInterest->GetOutput());
+    m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapExpImageFilter->GetOutput());
+    m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+  }
+
+  m_MultiplyImageFilter->SetConstant(spacingVolume[2]);
+
+  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianFilter->GetOutput());
+  m_PasteImageFilter->SetDestinationImage(this->GetInput(0));
+  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+
+  // Update output information
+  m_PasteImageFilter->UpdateOutputInformation();
+  this->GetOutput()->SetOrigin(m_PasteImageFilter->GetOutput()->GetOrigin());
+  this->GetOutput()->SetSpacing(m_PasteImageFilter->GetOutput()->GetSpacing());
+  this->GetOutput()->SetDirection(m_PasteImageFilter->GetOutput()->GetDirection());
+  this->GetOutput()->SetLargestPossibleRegion(m_PasteImageFilter->GetOutput()->GetLargestPossibleRegion());
+
+  m_ResampleImageFilter->ReleaseDataFlagOn();
+}
+
+template <class TInputImage, class TOutputImage>
+void
+ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
+{
+  const unsigned int                                    Dimension = this->InputImageDimension;
+  const typename Superclass::GeometryType::ConstPointer geometry = this->GetGeometry();
+  typename OuputCPUImageType::RegionType                projRegion = this->GetInput(0)->GetLargestPossibleRegion();
+  std::vector<double>                                   list_angle;
+  if (geometry->GetGantryAngles().size() != projRegion.GetSize(Dimension - 1))
+  {
+    list_angle.push_back(geometry->GetGantryAngles()[projRegion.GetIndex(Dimension - 1)]);
+  }
+  else
+  {
+    list_angle = geometry->GetGantryAngles();
+  }
+
+  typename OuputCPUImageType::Pointer   currentSlice;
+  typename OuputCPUImageType::Pointer   pimg;
+  typename OuputCPUImageType::Pointer   rotatedVolume;
+  typename OuputCPUImageType::IndexType indexSlice;
+  typename OuputCPUImageType::IndexType indexProjection;
+  PointType                             pointSlice;
+  PointType                             centerRotatedVolume;
+  PointType                             originRotatedVolume;
+
+  indexSlice.Fill(0);
+  indexProjection.Fill(0);
+  float dist, sigmaSlice, thicknessSlice;
+  int   nbProjections = 0;
+  for (auto & angle : list_angle)
+  {
+    // Set the rotation angle.
+    m_Transform->SetRotation(0., angle, 0.);
+    centerRotatedVolume = m_Transform->GetMatrix() * m_centerVolume;
+
+    // Rotate the input volume
+    this->GetInput(1)->GetBufferPointer();
+    originRotatedVolume = m_ResampleImageFilter->GetOutputOrigin();
+    originRotatedVolume[2] = centerRotatedVolume[2] - m_ResampleImageFilter->GetOutputSpacing()[2] *
+                                                        (double)(m_ResampleImageFilter->GetSize()[2] - 1) / 2.0;
+    m_ResampleImageFilter->SetOutputOrigin(originRotatedVolume);
+    m_ResampleImageFilter->Update();
+    rotatedVolume = m_ResampleImageFilter->GetOutput();
+    rotatedVolume->DisconnectPipeline();
+    thicknessSlice = rotatedVolume->GetSpacing()[2];
+
+    // Extract slice from the volume starting by the farthest from the detector.
+    typename RegionOfInterestFilterType::InputImageRegionType desiredRegion = rotatedVolume->GetLargestPossibleRegion();
+    unsigned int                                              nbSlice = desiredRegion.GetSize(Dimension - 1);
+    desiredRegion.SetSize(Dimension - 1, 1);
+    desiredRegion.SetIndex(Dimension - 1, 0);
+    m_RegionOfInterest->SetInput(rotatedVolume);
+    m_RegionOfInterest->SetRegionOfInterest(desiredRegion);
+    m_RegionOfInterest->UpdateOutputInformation();
+    m_RegionOfInterest->Update();
+    if (!(this->GetInput(2)))
+    {
+      currentSlice = m_RegionOfInterest->GetOutput();
+    }
+    else
+    {
+      typename OuputCPUImageType::Pointer rotatedAttenuation;
+      m_AttenuationMapResampleImageFilter->SetOutputOrigin(originRotatedVolume);
+      m_AttenuationMapResampleImageFilter->Update();
+      rotatedAttenuation = m_AttenuationMapResampleImageFilter->GetOutput();
+      rotatedAttenuation->DisconnectPipeline();
+      m_AttenuationMapRegionOfInterest->SetInput(rotatedAttenuation);
+      m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
+      m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+      m_AttenuationMapMultiplyImageFilter->SetInput1(m_RegionOfInterest->GetOutput());
+      m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapExpImageFilter->GetOutput());
+      m_AttenuationMapMultiplyImageFilter->Update();
+      m_AttenuationMapChangeInformation->SetInput(m_AttenuationMapExpImageFilter->GetOutput());
+      currentSlice = m_AttenuationMapMultiplyImageFilter->GetOutput();
+    }
+    currentSlice->DisconnectPipeline();
+    m_DiscreteGaussianFilter->SetInput(currentSlice);
+    m_ChangeInformation->SetInput(m_RegionOfInterest->GetOutput());
+
+    // Compute the distance between the current slice and the detector
+    rotatedVolume->TransformIndexToPhysicalPoint(indexSlice, pointSlice);
+    dist = geometry->GetSourceToIsocenterDistances()[nbProjections] -
+           pointSlice.GetVectorFromOrigin() * m_VectorOrthogonalDetector;
+
+    unsigned int index;
+    for (index = 1; index < nbSlice; index++)
+    {
+      if (dist - rotatedVolume->GetSpacing()[2] < 0)
+      {
+        break;
+      }
+      // Compute the variance of the PSF for the current slice
+      sigmaSlice = dist * 2 * thicknessSlice * pow(m_Alpha, 2.0) + 2 * thicknessSlice * m_Alpha * m_SigmaZero -
+                   pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
+      m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+
+      // Extract the next slice
+      desiredRegion.SetIndex(Dimension - 1, index);
+      m_RegionOfInterest->SetRegionOfInterest(desiredRegion);
+      m_RegionOfInterest->UpdateOutputInformation();
+
+      // Add the current blur slice with the next
+      m_AddImageFilter->GetOutput()->UpdateOutputInformation();
+      m_AddImageFilter->GetOutput()->PropagateRequestedRegion();
+      m_AddImageFilter->Update();
+      if (!(this->GetInput(2)))
+      {
+        currentSlice = m_AddImageFilter->GetOutput();
+      }
+      else
+      {
+        m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
+        m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
+        m_AttenuationMapMultiplyImageFilter->SetInput1(m_AddImageFilter->GetOutput());
+        m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapChangeInformation->GetOutput());
+        m_AttenuationMapMultiplyImageFilter->Update();
+        currentSlice = m_AttenuationMapMultiplyImageFilter->GetOutput();
+      }
+      currentSlice->DisconnectPipeline();
+      m_DiscreteGaussianFilter->SetInput(currentSlice);
+      dist -= rotatedVolume->GetSpacing()[2];
+    }
+    // Compute the variance of the PSF for the last slice
+    sigmaSlice = pow(m_Alpha * dist + m_SigmaZero, 2.0);
+    m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+
+    // Paste the projection in the output volume
+    indexProjection[Dimension - 1] = nbProjections + projRegion.GetIndex(Dimension - 1);
+    m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+    m_PasteImageFilter->SetDestinationIndex(indexProjection);
+    m_PasteImageFilter->UpdateLargestPossibleRegion();
+    pimg = m_PasteImageFilter->GetOutput();
+
+    pimg->DisconnectPipeline();
+    m_PasteImageFilter->SetDestinationImage(pimg);
+    nbProjections++;
+  }
+  m_MultiplyImageFilter->SetInput(pimg);
+  m_MultiplyImageFilter->UpdateLargestPossibleRegion();
+  pimg = m_MultiplyImageFilter->GetOutput();
+  pimg->DisconnectPipeline();
+  this->GetOutput()->SetPixelContainer(pimg->GetPixelContainer());
+  this->GetOutput()->CopyInformation(pimg);
+  this->GetOutput()->SetBufferedRegion(pimg->GetBufferedRegion());
+  this->GetOutput()->SetRequestedRegion(pimg->GetRequestedRegion());
+}
+
+} // end namespace rtk
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ rtk_add_cuda_test(rtkGainCorrectionCudaTest rtkgaincorrectiontest.cxx)
 rtk_add_test(rtkForwardProjectionTest rtkforwardprojectiontest.cxx)
 rtk_add_cuda_test(rtkForwardProjectionCudaTest rtkforwardprojectiontest.cxx)
 rtk_add_test(rtkForwardAttenuatedProjectionTest rtkforwardattenuatedprojectiontest.cxx)
+rtk_add_test(rtkZengProjectionTest rtkzengforwardprojectiontest.cxx)
 
 rtk_add_test(rtkGeometryFileTest rtkgeometryfiletest.cxx)
 

--- a/test/rtkzengforwardprojectiontest.cxx
+++ b/test/rtkzengforwardprojectiontest.cxx
@@ -1,0 +1,129 @@
+#include "rtkTest.h"
+#include "rtkThreeDCircularProjectionGeometryXMLFile.h"
+#include "rtkRayBoxIntersectionImageFilter.h"
+#include "rtkConstantImageSource.h"
+#include "rtkZengForwardProjectionImageFilter.h"
+#include <itkImageRegionSplitterDirection.h>
+#include <itkImageRegionIterator.h>
+#include <cmath>
+
+
+/**
+ * \file rtkzengforwardprojectiontest.cxx
+ *
+ * \brief Functional test for forward projection
+ *
+ * The test projects a volume filled with ones. The forward projector should
+ * then return the intersection of the ray with the box and it is compared
+ * with the analytical intersection of a box with a ray.
+ *
+ * \author Antoine Robert
+ */
+
+int main(int , char** )
+{
+  constexpr unsigned int Dimension = 3;
+  using OutputPixelType = float;
+
+#ifdef USE_CUDA
+  using OutputImageType = itk::CudaImage< OutputPixelType, Dimension >;
+#else
+  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+#endif
+
+  using VectorType = itk::Vector<double, 3>;
+#if FAST_TESTS_NO_CHECKS
+  constexpr unsigned int NumberOfProjectionImages = 3;
+#else
+  constexpr unsigned int NumberOfProjectionImages = 40;
+#endif
+
+  // Constant image sources
+  using ConstantImageSourceType = rtk::ConstantImageSource< OutputImageType >;
+  ConstantImageSourceType::PointType origin;
+  ConstantImageSourceType::SizeType size;
+  ConstantImageSourceType::SpacingType spacing;
+
+  // Create Joseph Forward Projector volume input.
+  const ConstantImageSourceType::Pointer volInput = ConstantImageSourceType::New();
+  origin[0] = -126;
+  origin[1] = -126;
+  origin[2] = -126;
+#if FAST_TESTS_NO_CHECKS
+  size[0] = 2;
+  size[1] = 2;
+  size[2] = 2;
+  spacing[0] = 252.;
+  spacing[1] = 252.;
+  spacing[2] = 252.;
+#else
+  size[0] = 64;
+  size[1] = 64;
+  size[2] = 64;
+  spacing[0] = 4.;
+  spacing[1] = 4.;
+  spacing[2] = 4.;
+#endif
+  volInput->SetOrigin( origin );
+  volInput->SetSpacing( spacing );
+  volInput->SetSize( size );
+  volInput->SetConstant( 1. );
+  volInput->UpdateOutputInformation();
+
+  // Initialization Volume, it is used in the Zeng Forward Projector and in the
+  // Ray Box Intersection Filter in order to initialize the stack of projections.
+  const ConstantImageSourceType::Pointer projInput = ConstantImageSourceType::New();
+  size[2] = NumberOfProjectionImages;
+  projInput->SetOrigin( origin );
+  projInput->SetSpacing( spacing );
+  projInput->SetSize( size );
+  projInput->SetConstant( 0. );
+  projInput->Update();
+
+  // Zeng Forward Projection filter
+  using JFPType = rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>;
+
+  JFPType::Pointer jfp = JFPType::New();
+  jfp->InPlaceOff();
+  jfp->SetInput( projInput->GetOutput() );
+  jfp->SetInput( 1, volInput->GetOutput() );
+
+  // Ray Box Intersection filter (reference)
+  using RBIType = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>;
+  RBIType::Pointer rbi = RBIType::New();
+  rbi->InPlaceOff();
+  rbi->SetInput( projInput->GetOutput() );
+  VectorType boxMin, boxMax;
+  boxMin[0] = -128;
+  boxMin[1] = -128;
+  boxMin[2] = -128;
+  boxMax[0] =  128;
+  boxMax[1] =  128;
+  boxMax[2] =  128;
+  rbi->SetBoxMin(boxMin);
+  rbi->SetBoxMax(boxMax);
+
+  std::cout << "\n\n****** Case 1: inner ray source ******" << std::endl;
+
+  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
+  GeometryType::Pointer geometry = GeometryType::New();
+  for(unsigned int i=0; i<NumberOfProjectionImages;i++)
+  {
+    geometry->AddProjection(500, 0, i*360./NumberOfProjectionImages);
+  }
+
+  rbi->SetGeometry( geometry );
+  rbi->Update();
+
+  jfp->SetGeometry(geometry);
+  jfp->SetAlpha(0.);
+  jfp->SetSigmaZero(0.);
+
+  jfp->Update();
+
+  CheckImageQuality<OutputImageType>(jfp->GetOutput(), rbi->GetOutput(), 1.28, 44.0, 255.0);
+  std::cout << "\n\nTest PASSED! " << std::endl;
+
+
+  return EXIT_SUCCESS;
+}

--- a/wrapping/rtkZengBackProjectionImageFilter.wrap
+++ b/wrapping/rtkZengBackProjectionImageFilter.wrap
@@ -1,0 +1,6 @@
+itk_wrap_class("rtk::ZengBackProjectionImageFilter" POINTER)
+  foreach(t ${WRAP_ITK_REAL})
+    itk_wrap_template("I${ITKM_${t}}3I${ITKM_${t}}3SWM${ITKM_${t}}D${ITKM_${t}}"
+      "itk::Image<${ITKT_${t}}, 3>, itk::Image< ${ITKT_${t}}, 3>")
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/rtkZengForwardProjectionImageFilter.wrap
+++ b/wrapping/rtkZengForwardProjectionImageFilter.wrap
@@ -1,0 +1,5 @@
+itk_wrap_class("rtk::ZengForwardProjectionImageFilter" POINTER)
+  foreach(t ${WRAP_ITK_REAL})
+    itk_wrap_template("I${ITKM_${t}}3I${ITKM_${t}}3" "itk::Image<${ITKT_${t}}, 3>, itk::Image<${ITKT_${t}}, 3>")
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
https://github.com/SimonRit/RTK/commit/a1197a4263027c8912531712161fc1ff3fc32bf2#diff-f7bf5a300284e77d96c7534c0e999a2bR72-R73

https://github.com/SimonRit/RTK/commit/a1197a4263027c8912531712161fc1ff3fc32bf2#diff-5d6e9b168f0d0e40db55971e064e0b4dR72-R73

The setters and getters for boundary condition of the itkDiscreteGaussianFilter are only available since this commit https://github.com/InsightSoftwareConsortium/ITK/commit/a48512e7bd0b6a440211da629d5b581165f4591f.

I will add a condition on the ITK version in the code when the commit will be added in a tag. 
