### PR TITLE
ENH: Wrap NumPy bridge for vector components 2;3;4;5

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,4 +1,5 @@
 itk_wrap_module(RTK)
+
 set(WRAPPER_SUBMODULE_ORDER
   itkFixedArrayRTK
   itkVectorRTK
@@ -17,6 +18,10 @@ set(WRAPPER_SUBMODULE_ORDER
   itkInPlaceImageFilterRTK
   itkCudaInPlaceImageFilter
   rtkForwardProjectionImageFilter
+  itkPyBufferRTK
 )
+
+list(APPEND WRAPPER_SWIG_LIBRARY_FILES "${CMAKE_CURRENT_BINARY_DIR}/PyBufferRTK.i")
+
 itk_auto_load_submodules()
 itk_end_wrap_module()

--- a/wrapping/PyBufferRTK.i.in
+++ b/wrapping/PyBufferRTK.i.in
@@ -1,0 +1,158 @@
+%extend itkPyBuffer@PyBufferTypes@{
+    %pythoncode %{
+
+    import numpy
+    # This is a Mapping from numpy array types to itk pixel types.
+    _np_itk = {"UC":numpy.uint8,
+               "US":numpy.uint16,
+               "UI":numpy.uint32,
+               "UL":numpy.uint64,
+               "SC":numpy.int8,
+               "SS":numpy.int16,
+               "SI":numpy.int32,
+               "SL":numpy.int64,
+               "F":numpy.float32,
+               "D":numpy.float64,
+               }
+    import os
+    if os.name == 'nt':
+        _np_itk['UL'] = numpy.uint32
+        _np_itk['SL'] = numpy.int32
+
+    def GetArrayViewFromImage(image, keep_axes=False, update=True):
+        """Get a NumPy array view of a ITK Image.
+
+        When *keep_axes* is *False*, the NumPy array will have C-order
+        indexing. This is the reverse of how indices are specified in ITK,
+        i.e. k,j,i versus i,j,k. However C-order indexing is expected by most
+        algorithms in NumPy / SciPy.
+
+        Warning: No copy of the data is performed. Using an array
+        view after its source image has been deleted can results in corrupt values
+        or a segfault.
+        """
+        import numpy
+
+        if update:
+            # Ensure the image regions and image pixel buffer have been updated
+            # correctly
+            source = image.GetSource()
+            if source:
+                source.UpdateLargestPossibleRegion()
+
+        itksize = image.GetLargestPossibleRegion().GetSize()
+        dim     = len(itksize)
+        shape   = []
+        for idx in range(dim):
+            shape.append(int(itksize[idx]))
+
+        if(image.GetNumberOfComponentsPerPixel() > 1):
+            shape = [image.GetNumberOfComponentsPerPixel(), ] + shape
+
+        if keep_axes == False:
+            shape = shape[::-1]
+
+        pixelType     = "@PixelType@"
+        numpydatatype = itkPyBuffer@PyBufferTypes@._np_itk[pixelType]
+        memview       = itkPyBuffer@PyBufferTypes@._GetArrayViewFromImage(image)
+        ndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(numpy.ndarray)
+
+        return ndarrview
+
+    GetArrayViewFromImage = staticmethod(GetArrayViewFromImage)
+
+    def GetArrayFromImage(image, keep_axes=False, update=True):
+        """Get a NumPy ndarray from an ITK Image.
+
+        When *keep_axes* is *False*, the NumPy array will have C-order
+        indexing. This is the reverse of how indices are specified in ITK,
+        i.e. k,j,i versus i,j,k. However C-order indexing is expected by most
+        algorithms in NumPy / SciPy.
+
+        This is a deep copy of the image buffer and is completely safe and without potential side effects.
+        """
+        import numpy
+
+        arrayView = itkPyBuffer@PyBufferTypes@.GetArrayViewFromImage(image, keep_axes, update)
+
+        # perform deep copy of the image buffer
+        arr = numpy.array(arrayView, copy=True)
+
+        return arr
+
+
+    GetArrayFromImage = staticmethod(GetArrayFromImage)
+
+    def GetImageViewFromArray(ndarr, is_vector=False):
+        """Get an ITK Image view of a NumPy array.
+
+        If is_vector is True, then a 3D array will be treated as a 2D vector image,
+        otherwise it will be treated as a 3D image.
+
+        If the array uses Fortran-order indexing, i.e. i,j,k, the Image Size
+        will have the same dimensions as the array shape. If the array uses
+        C-order indexing, i.e. k,j,i, the image Size will have the dimensions
+        reversed from the array shape.
+
+        Therefore, since the *numpy.transpose* operator on a 2D array simply
+        inverts the indexing scheme, the Image representation will be the
+        same for an array and its transpose. If flipping is desired, see
+        *numpy.reshape*.
+
+        Warning: No copy of the data is performed. Using an image
+        view after its source array has been deleted can results in corrupt values
+        or a segfault.
+        """
+
+        assert ndarr.ndim in ( 2, 3, 4 ), \
+            "Only arrays of 2, 3 or 4 dimensions are supported."
+        if( not ndarr.flags['C_CONTIGUOUS'] and not ndarr.flags['F_CONTIGUOUS'] ):
+            raise ValueError("Array memory is not contiguous. Try converting your array with "
+                  + "`ascontiguousarray()` or `copy()` or use `GetImageFromArray()`")
+
+        if ( ndarr.ndim == 3 and is_vector ) or (ndarr.ndim == 4):
+            if( ndarr.flags['C_CONTIGUOUS'] ):
+                imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray( ndarr, ndarr.shape[-2::-1], ndarr.shape[-1] )
+            else:
+                imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray( ndarr, ndarr.shape[-1:0:-1], ndarr.shape[0] )
+        elif ndarr.ndim in ( 2, 3 ):
+            imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray( ndarr, ndarr.shape[::-1], 1)
+
+        return imgview
+
+    GetImageViewFromArray = staticmethod(GetImageViewFromArray)
+
+    def GetImageFromArray(ndarr, is_vector=False):
+        """Get an ITK Image of a NumPy array.
+
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
+        side effects.
+
+        If is_vector is True, then a 3D array will be treated as a 2D vector image,
+        otherwise it will be treated as a 3D image.
+
+        If the array uses Fortran-order indexing, i.e. i,j,k, the Image Size
+        will have the same dimensions as the array shape. If the array uses
+        C-order indexing, i.e. k,j,i, the image Size will have the dimensions
+        reversed from the array shape.
+
+        Therefore, since the *numpy.transpose* operator on a 2D array simply
+        inverts the indexing scheme, the Image representation will be the
+        same for an array and its transpose. If flipping is desired, see
+        *numpy.reshape*.
+        """
+        from itkImageDuplicatorPython import itkImageDuplicator@PyBufferTypes@
+
+        # Create a temporary image view of the array
+        imageView = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(ndarr, is_vector)
+
+        # Duplicate the image to let it manage its own memory buffer
+        duplicator = itkImageDuplicator@PyBufferTypes@.New()
+        duplicator.SetInputImage(imageView)
+        duplicator.Update()
+        return duplicator.GetOutput()
+
+    GetImageFromArray = staticmethod(GetImageFromArray)
+
+  %}
+};

--- a/wrapping/itkPyBufferRTK.wrap
+++ b/wrapping/itkPyBufferRTK.wrap
@@ -1,0 +1,31 @@
+itk_wrap_class("itk::PyBuffer")
+
+  UNIQUE(types "${WRAP_ITK_SCALAR};UC;D;US;UI;UL;SC;SS;SI;SL;F")
+  foreach(t ${types})
+    string(REGEX MATCHALL "(V${t}|CV${t})" VectorTypes "${WRAP_ITK_VECTOR}")
+    set(PixelType ${t})
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+      # Image Vector types
+	  set(vectorComponents 2 3 4 5)
+      foreach(vec_dim ${vectorComponents})
+	    list(FIND ITK_WRAP_VECTOR_COMPONENTS "${vec_dim}" _index)
+        if (${_index} EQUAL -1)
+          foreach(vec_type ${VectorTypes})
+
+              set(PyBufferTypes I${vec_type}${vec_dim}${d})
+              configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/PyBufferRTK.i.in
+                         ${CMAKE_CURRENT_BINARY_DIR}/PyBufferRTK.i.temp
+                         @ONLY)
+              file(READ ${CMAKE_CURRENT_BINARY_DIR}/PyBufferRTK.i.temp
+                  PyBufferInterfaceTemp)
+              file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/PyBufferRTK.i
+                  ${PyBufferInterfaceTemp})
+              itk_wrap_template("I${vec_type}${vec_dim}${d}" "itk::Image<${ITKT_${vec_type}${vec_dim}},${d}>")
+
+          endforeach()
+		endif()
+      endforeach()
+    endforeach(d)
+  endforeach(t)
+
+itk_end_wrap_class()


### PR DESCRIPTION
Setup infrastructure to add missing types to the itkBridgeNumPy module.

Unlike ITK, we can not use PyBuffer.i.init to define global function.
This only works when itkPyBuffer is the only submodule in the module being
wrapped, which is not the case when wrapping within RTK module.

WRAPPER_SWIG_LIBRARY_FILES is used to tell swig that additional .i files
should be included in the generated module.i file.
Unfortunately this variable can not operate at a submodule level and will
be used for all submodules when wrapping the current module.

This results in a mix of %include and %import rules which ends up not
replacing the expected chunk in the generated file.

To work around this problem, we put everything in the %extend section, that
will be only replaced for the specified class and won't affect other
submodules.