### PR TITLE
COMP: Fixed unused variable 'caller'

### DIFF
--- a/include/rtkIterationCommands.h
+++ b/include/rtkIterationCommands.h
@@ -100,7 +100,7 @@ public:
 
 protected:
   void
-  Run(const TCaller * caller) override
+  Run(const TCaller * itkNotUsed(caller)) override
   {
     std::cout << "Iteration " << this->m_IterationCount << " completed."
               << std::endl; // TODO allow string personnalization


### PR DESCRIPTION
An `itkNotUsed` macro is missing, causing several warnings during compilation. This pull request fixes that.