### PR TITLE
Added DualRotation to displaced detector filters (Cuda and Cpu)

### DIFF
--- a/include/rtkCudaDisplacedDetectorImageFilter.hcu
+++ b/include/rtkCudaDisplacedDetectorImageFilter.hcu
@@ -35,4 +35,22 @@ CUDA_displaced_weight(int     proj_idx_in[3],
                       float   proj_row,
                       float   proj_col);
 
+void
+CUDA_displaced_weight_dual(int     proj_idx_in[3],
+						   int     proj_dim_in[3],
+						   int     proj_dim_in_buf[2],
+						   int     proj_idx_out[3],
+						   int     proj_dim_out[3],
+						   int     proj_dim_out_buf[2],
+						   float * dev_proj_in,
+						   float * dev_proj_out,
+						   float * geometries,
+						   float   theta,
+						   bool    isPositiveCase,
+						   float   proj_orig,
+						   float   proj_row,
+						   float   proj_col,
+						   float   InferiorCorner_2,
+						   float   SuperiorCorner_1);
+
 #endif //__rtkCudaDisplacedDetectorImageFilter_hcu

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -108,6 +108,12 @@ public:
   itkGetMacro(Disable, bool);
   itkSetMacro(Disable, bool);
 
+  /** Get / Set the Dual Rotation parameter
+   */
+  itkGetMacro(DualRotation, bool);
+  itkSetMacro(DualRotation, bool);
+
+
 protected:
   DisplacedDetectorImageFilter();
 
@@ -116,6 +122,13 @@ protected:
   /** Retrieve computed inferior and superior corners */
   itkGetMacro(InferiorCorner, double);
   itkGetMacro(SuperiorCorner, double);
+
+  /** Retrieve computed inferior and superior corners - Dual Rotation positive shift */
+  itkGetMacro(InferiorCorner_1, double);
+  itkGetMacro(SuperiorCorner_1, double);
+  /** Retrieve computed inferior and superior corners - Dual Rotation negative shift*/
+  itkGetMacro(InferiorCorner_2, double);
+  itkGetMacro(SuperiorCorner_2, double);
 
   void
   GenerateInputRequestedRegion() override;
@@ -161,6 +174,22 @@ private:
    * it has to be disabled
    */
   bool m_Disable{ false };
+
+  /** When using a dual rotation geometry that the displaced detector cannot manage,
+   * it must be set true
+   */
+  bool m_DualRotation{ false };
+
+  /** Superior and inferior position of the detector along the weighting
+   *  direction, i.e., the virtual detector described in ToUntiltedCoordinate.
+   *  this variables acoount for two possible detector displacements inside the same geometry.
+   */
+
+  double m_InferiorCorner_1{ 0. };
+  double m_SuperiorCorner_1{ 0. };
+  double m_InferiorCorner_2{ 0. };
+  double m_SuperiorCorner_2{ 0. };
+
 
 }; // end of class
 

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -115,9 +115,9 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::GenerateOutputInformati
   m_InferiorCorner = corner[0];
   m_SuperiorCorner = m_InferiorCorner;
   if (inputPtr->GetSpacing()[0] < 0.)
-    m_InferiorCorner += inputPtr->GetSpacing()[0] * (outputLargestPossibleRegion.GetSize(0) - 1);
+    m_InferiorCorner += inputPtr->GetSpacing()[0] * (outputLargestPossibleRegion.GetSize(0));
   else
-    m_SuperiorCorner += inputPtr->GetSpacing()[0] * (outputLargestPossibleRegion.GetSize(0) - 1);
+    m_SuperiorCorner += inputPtr->GetSpacing()[0] * (outputLargestPossibleRegion.GetSize(0));
 
   if (!m_OffsetsSet)
   {

--- a/src/rtkCudaDisplacedDetectorImageFilter.cu
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cu
@@ -187,3 +187,188 @@ CUDA_displaced_weight(int     proj_idx_in[3],      // overlapping input region i
   cudaFree(dev_geom);
   CUDA_CHECK_ERROR;
 }
+
+/*Dual rotation implementation follows*/
+
+__global__
+void kernel_displaced_weight_dual(
+  int3 proj_idx_in,
+  int3 proj_size_in,
+  int2 proj_size_in_buf,
+  int3 proj_idx_out,
+  int3 proj_size_out,
+  int2 proj_size_out_buf,
+  float *dev_proj_in,
+  float *dev_proj_out,
+  float theta,
+  bool isPositiveCase,
+  float proj_orig,    // projection origin
+  float proj_row,     // projection row direction & spacing
+  float proj_col,     // projection col direction & spacing
+  float InferiorCorner_2,
+  float SuperiorCorner_1
+)
+{
+  // compute thread index
+  int3 tIdx;
+  tIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
+  tIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
+  tIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
+  long int tIdx_comp = tIdx.x + tIdx.y * proj_size_out.x + tIdx.z * proj_size_out_buf.x * proj_size_out_buf.y;
+
+  // check if outside of projection grid
+  if (tIdx.x >= proj_size_out.x || tIdx.y >= proj_size_out.y || tIdx.z >= proj_size_out.z)
+    return;
+
+  // compute projection index from thread index
+  int3 pIdx = make_int3(tIdx.x + proj_idx_out.x,
+                        tIdx.y + proj_idx_out.y,
+                        tIdx.z + proj_idx_out.z);
+  // combined proj. index -> use thread index in z because accessing memory only with this index
+  long int pIdx_comp = (pIdx.x-proj_idx_in.x) + (pIdx.y-proj_idx_in.y) * proj_size_in_buf.x + (pIdx.z-proj_idx_in.z) * proj_size_in_buf.x * proj_size_in_buf.y;
+
+  // check if outside overlapping region
+  if (pIdx.x < proj_idx_in.x || pIdx.x >= (proj_idx_in.x + proj_size_in.x) ||
+      pIdx.y < proj_idx_in.y || pIdx.y >= (proj_idx_in.y + proj_size_in.y) ||
+      pIdx.z < proj_idx_in.z || pIdx.z >= (proj_idx_in.z + proj_size_in.z))
+  {
+    // set areas outside overlapping region to zero
+    dev_proj_out[tIdx_comp] = 0.f;
+    return;
+  }
+  else
+  {
+    float pPoint = TransformIndexToPhysicalPoint(
+          make_int2(pIdx.x, pIdx.y), proj_orig, proj_row, proj_col);
+
+    float sdd = tex1Dfetch(tex_geometry, tIdx.z * 4 + 0);
+    float sx = tex1Dfetch(tex_geometry, tIdx.z * 4 + 1);
+    float px   = tex1Dfetch(tex_geometry, tIdx.z * 4 + 2);
+    float sid = tex1Dfetch(tex_geometry, tIdx.z * 4 + 3);
+
+    float hyp = sqrtf(sid * sid + sx * sx); // to untilted situation
+    float l = ToUntiltedCoordinateAtIsocenter(pPoint, sdd, sid, sx, px, hyp);
+	/*
+	if (tIdx.z)
+	{
+	  if (px != tex1Dfetch(tex_geometry, (tIdx.z-1) * 4 + 2))
+	  {
+		if (px>0)
+		{
+		  theta = -InferiorCorner_2;
+		  isPositiveCase = true;
+		}
+		else
+		{
+		  theta = SuperiorCorner_1;
+		  isPositiveCase = false;
+		}
+	  }
+	}
+	*/
+	if (px>0)
+	{
+		theta = -InferiorCorner_2;
+		isPositiveCase = true;
+	}
+	else
+	{
+		theta = SuperiorCorner_1;
+		isPositiveCase = false;
+	}
+	
+    float invsdd = 0.f;
+    float invden = 0.f;
+    if (hyp != 0.f)
+    {
+      invsdd = 1.f / hyp;
+      invden = 1.f / (2.f * atanf(theta * invsdd));
+    }
+
+    // compute weights here
+    float weight = 0.f;
+    if (isPositiveCase)
+    {
+      if (l <= -1.f * theta)
+        weight = 0.f;
+      else if (l >= theta)
+        weight = 2.f;
+      else
+        weight = sinf(CUDART_PI_F * atanf(l * invsdd) * invden) + 1.f;
+    }
+    else
+    {
+      if (l <= -1.f * theta)
+        weight = 2.f;
+      else if (l >= theta)
+        weight = 0.f;
+      else
+        weight = 1.f - sinf(CUDART_PI_F * atanf(l * invsdd) * invden);
+    }
+
+    dev_proj_out[tIdx_comp] = dev_proj_in[pIdx_comp] * weight;
+  }
+}
+
+void
+CUDA_displaced_weight_dual(int     proj_idx_in[3],		// overlapping input region index
+						   int     proj_dim_in[3],      // overlapping input region size
+						   int     proj_dim_in_buf[2],  // input size of buffered region
+						   int     proj_idx_out[3],     // output region index
+						   int     proj_dim_out[3],     // output region size
+						   int     proj_dim_out_buf[2], // output size of buffered region
+						   float * dev_proj_in,
+						   float * dev_proj_out,
+						   float * geometries,
+						   float   theta,
+						   bool    isPositiveCase,
+						   float   proj_orig,
+						   float   proj_row,
+						   float   proj_col,
+						   float   InferiorCorner_2,
+						   float   SuperiorCorner_1)
+{
+  // copy geometry matrix to device, bind the matrix to the texture
+  float *dev_geom;
+  cudaMalloc((void**)&dev_geom, proj_dim_out[2]*4*sizeof(float));
+  CUDA_CHECK_ERROR;
+  cudaMemcpy(dev_geom, geometries, proj_dim_out[2]*4*sizeof(float), cudaMemcpyHostToDevice);
+  CUDA_CHECK_ERROR;
+  cudaBindTexture(0, tex_geometry, dev_geom, proj_dim_out[2]*4*sizeof(float));
+  CUDA_CHECK_ERROR;
+
+  // Thread Block Dimensions
+  int tBlock_x = 16;
+  int tBlock_y = 16;
+  int tBlock_z = 2;
+
+  // Each element in the volume (each voxel) gets 1 thread
+  unsigned int  blocksInX = (proj_dim_out[0] - 1) / tBlock_x + 1;
+  unsigned int  blocksInY = (proj_dim_out[1] - 1) / tBlock_y + 1;
+  unsigned int  blocksInZ = (proj_dim_out[2] - 1) / tBlock_z + 1;
+
+  dim3 dimGrid  = dim3(blocksInX, blocksInY, blocksInZ);
+  dim3 dimBlock = dim3(tBlock_x, tBlock_y, tBlock_z);
+  kernel_displaced_weight_dual <<< dimGrid, dimBlock >>> (
+      make_int3(proj_idx_in[0], proj_idx_in[1], proj_idx_in[2]),
+      make_int3(proj_dim_in[0], proj_dim_in[1], proj_dim_in[2]),
+      make_int2(proj_dim_in_buf[0], proj_dim_in_buf[1]),
+      make_int3(proj_idx_out[0], proj_idx_out[1], proj_idx_out[2]),
+      make_int3(proj_dim_out[0], proj_dim_out[1], proj_dim_out[2]),
+      make_int2(proj_dim_out_buf[0], proj_dim_out_buf[1]),
+      dev_proj_in,
+      dev_proj_out,
+      theta, isPositiveCase,
+      proj_orig,
+      proj_row,
+      proj_col,
+	  InferiorCorner_2,
+	  SuperiorCorner_1
+      );
+
+  // Unbind matrix texture
+  cudaUnbindTexture(tex_geometry);
+  CUDA_CHECK_ERROR;
+  cudaFree(dev_geom);
+  CUDA_CHECK_ERROR;
+}


### PR DESCRIPTION
Added DualRotation flag to displaced detector filters (can be set using a get/set standard method), additional effort has been made to provide a weighting consistent with the current implementation to projections stacks described by a geometry file generated by two rotations with opposite detector displacements.

The weighting is compatible with Parker Short Scan weighting filters, so it is possible to directly test results, provided a geometry file with a dual rotation (an example of suche file is attached --> 600 projections on a range of 220° limited ROM and +/-140 displacement of isocenter projection on X axis).

[geometry_hf_dual_220_300.zip](https://github.com/SimonRit/RTK/files/4117461/geometry_hf_dual_220_300.zip)

Example of PSSF output is also attached as reference:

![OutputExamplewithPSSF](https://user-images.githubusercontent.com/58032590/73181289-39eb5a00-4117-11ea-9e7a-843dacd47d27.png)

Additional notes : 
- Presence of an artifact in the center of the reconstructed volume which is more intense as the detector displacement increases
- Especially in the cuda implementation code can be reduced, I've tried my best to safely implement without damaging the existing implementation
- Implementation absent of OffsetFOV weighting filters