### PR TITLE
COMP: Future proof enumeration to integer implicit conversion

### DIFF
--- a/src/rtkEdfImageIO.cxx
+++ b/src/rtkEdfImageIO.cxx
@@ -162,11 +162,11 @@ rtk::EdfImageIO::ReadImageInformation()
     }
   }
 
-  static const struct table edf_byteorder_table[] = { { "LowByteFirst", LittleEndian }, /* little endian */
-                                                      { "HighByteFirst", BigEndian },   /* big endian */
+  static const struct table edf_byteorder_table[] = { { "LowByteFirst", static_cast<int>(LittleEndian) }, /* little endian */
+                                                      { "HighByteFirst", static_cast<int>(BigEndian) },   /* big endian */
                                                       { nullptr, -1 } };
 
-  int byteorder = LittleEndian;
+  int byteorder = static_cast<int>(LittleEndian);
   if ((p = edf_findInHeader(header, "ByteOrder")))
   {
     k = lookup_table_nth(edf_byteorder_table, p);
@@ -174,7 +174,7 @@ rtk::EdfImageIO::ReadImageInformation()
     {
 
       byteorder = edf_byteorder_table[k].value;
-      if (byteorder == LittleEndian)
+      if (byteorder == static_cast<int>(LittleEndian))
         this->SetByteOrder(LittleEndian);
       else
         this->SetByteOrder(BigEndian);


### PR DESCRIPTION
ITKv5.1 is enforcing more strict enumeration to integer conversion
checking. The changed code will work both before and after the
proposed change by explicitly casting the enumerations to integer
types.