### PR TITLE
COMP: remove manual definition of standard for nvcc

### DIFF
--- a/cmake/FindCUDA_wrap.cmake
+++ b/cmake/FindCUDA_wrap.cmake
@@ -64,8 +64,6 @@ else()
      )
 endif()
 
-list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
-
 if(CUDA_FOUND)
   try_run(RUN_RESULT_VAR COMPILE_RESULT_VAR
          ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
The flag -std=c++11 added by 090d8f1 should not be required.