### PR TITLE
ENH: filters check whether their geometry is set

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -214,6 +214,10 @@ protected:
   ADMMTotalVariationConeBeamReconstructionFilter();
   ~ADMMTotalVariationConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
@@ -163,6 +163,16 @@ ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImag
   inputPtr1->SetRequestedRegion(inputPtr1->GetLargestPossibleRegion());
 }
 
+template <class TInputImage, class TOutputImage>
+void
+ADMMTotalVariationConeBeamReconstructionFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
 template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::GenerateOutputInformation()

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -162,6 +162,10 @@ protected:
   ADMMTotalVariationConjugateGradientOperator();
   ~ADMMTotalVariationConjugateGradientOperator() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
@@ -94,6 +94,16 @@ ADMMTotalVariationConjugateGradientOperator<TOutputImage, TGradientOutputImage>:
   this->Modified();
 }
 
+template <class TInputImage, class TOutputImage>
+void
+ADMMTotalVariationConjugateGradientOperator<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
 template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConjugateGradientOperator<TOutputImage, TGradientOutputImage>::GenerateInputRequestedRegion()

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -214,6 +214,10 @@ protected:
   ADMMWaveletsConeBeamReconstructionFilter();
   ~ADMMWaveletsConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
@@ -97,6 +97,16 @@ ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::SetBackProjectionFilter(
   }
 }
 
+template <class TOutputImage>
+void
+ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
 template <typename TOutputImage>
 void
 ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::GenerateInputRequestedRegion()

--- a/include/rtkBackProjectionImageFilter.h
+++ b/include/rtkBackProjectionImageFilter.h
@@ -90,6 +90,10 @@ protected:
   };
   ~BackProjectionImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Apply changes to the input image requested region. */
   void
   GenerateInputRequestedRegion() override;

--- a/include/rtkBackProjectionImageFilter.hxx
+++ b/include/rtkBackProjectionImageFilter.hxx
@@ -148,6 +148,16 @@ BackProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegi
 
 template <class TInputImage, class TOutputImage>
 void
+BackProjectionImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 BackProjectionImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
   this->SetTranspose(true);

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -217,6 +217,10 @@ protected:
   ConjugateGradientConeBeamReconstructionFilter();
   ~ConjugateGradientConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -152,6 +152,17 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
+ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::VerifyPreconditions()
+  ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
+void
 ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::
   GenerateInputRequestedRegion()
 {

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -117,6 +117,10 @@ protected:
   itkGetMacro(InferiorCorner, double);
   itkGetMacro(SuperiorCorner, double);
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -51,6 +51,16 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::SetOffsets(double minOf
   }
 }
 
+template <class TInputImage, class TOutputImage>
+void
+DisplacedDetectorImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
 /**
  * Account for the padding computed in GenerateOutputInformation to propagate the
  * requested region.

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -122,6 +122,10 @@ protected:
   FDKConeBeamReconstructionFilter();
   ~FDKConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkFDKConeBeamReconstructionFilter.hxx
@@ -56,6 +56,16 @@ FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::FDKCo
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
+FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage, class TFFTPrecision>
+void
 FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::GenerateInputRequestedRegion()
 {
   typename Superclass::InputImagePointer inputPtr = const_cast<TInputImage *>(this->GetInput());

--- a/include/rtkFDKWeightProjectionFilter.h
+++ b/include/rtkFDKWeightProjectionFilter.h
@@ -78,6 +78,10 @@ protected:
   FDKWeightProjectionFilter() = default;
   ~FDKWeightProjectionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void
+  VerifyPreconditions() ITKv5_CONST override;
+
   void
   BeforeThreadedGenerateData() override;
 

--- a/include/rtkFDKWeightProjectionFilter.hxx
+++ b/include/rtkFDKWeightProjectionFilter.hxx
@@ -25,6 +25,17 @@
 
 namespace rtk
 {
+
+template <class TInputImage, class TOutputImage>
+void
+FDKWeightProjectionFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
 template <class TInputImage, class TOutputImage>
 void
 FDKWeightProjectionFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()

--- a/include/rtkFieldOfViewImageFilter.h
+++ b/include/rtkFieldOfViewImageFilter.h
@@ -114,6 +114,9 @@ protected:
   FieldOfViewImageFilter();
   ~FieldOfViewImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   BeforeThreadedGenerateData() override;
 

--- a/include/rtkFieldOfViewImageFilter.hxx
+++ b/include/rtkFieldOfViewImageFilter.hxx
@@ -190,6 +190,16 @@ FieldOfViewImageFilter<TInputImage, TOutputImage>::ComputeFOVRadius(const FOVRad
 
 template <class TInputImage, class TOutputImage>
 void
+FieldOfViewImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 FieldOfViewImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
   // The radius of the FOV is computed with linear programming.

--- a/include/rtkForwardProjectionImageFilter.h
+++ b/include/rtkForwardProjectionImageFilter.h
@@ -65,6 +65,9 @@ protected:
 
   ~ForwardProjectionImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Apply changes to the input image requested region. */
   void
   GenerateInputRequestedRegion() override;

--- a/include/rtkForwardProjectionImageFilter.hxx
+++ b/include/rtkForwardProjectionImageFilter.hxx
@@ -32,6 +32,16 @@ namespace rtk
 
 template <class TInputImage, class TOutputImage>
 void
+ForwardProjectionImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 ForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
   // Input 0 is the stack of projections in which we project

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -187,6 +187,9 @@ protected:
   FourDConjugateGradientConeBeamReconstructionFilter();
   ~FourDConjugateGradientConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateOutputInformation() override;
 

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
@@ -154,6 +154,17 @@ FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionS
 
 template <class VolumeSeriesType, class ProjectionStackType>
 void
+FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::VerifyPreconditions()
+  ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class VolumeSeriesType, class ProjectionStackType>
+void
 FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::GenerateOutputInformation()
 {
   // Set the Conjugate Gradient filter (either on CPU or GPU depending on user's choice)

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -398,6 +398,9 @@ protected:
   FourDROOSTERConeBeamReconstructionFilter();
   ~FourDROOSTERConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -202,6 +202,16 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>:
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
 void
+FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename VolumeSeriesType, typename ProjectionStackType>
+void
 FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::GenerateInputRequestedRegion()
 {
   // Call the superclass' implementation of this method

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -228,6 +228,9 @@ protected:
   FourDReconstructionConjugateGradientOperator();
   ~FourDReconstructionConjugateGradientOperator() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Builds the pipeline and computes output information */
   void
   GenerateOutputInformation() override;

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -156,6 +156,16 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
 void
+FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename VolumeSeriesType, typename ProjectionStackType>
+void
 FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>::GenerateOutputInformation()
 {
   // Set runtime parameters

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -220,6 +220,9 @@ protected:
   FourDSARTConeBeamReconstructionFilter();
   ~FourDSARTConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
@@ -159,6 +159,16 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Se
 
 template <class VolumeSeriesType, class ProjectionStackType>
 void
+FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class VolumeSeriesType, class ProjectionStackType>
+void
 FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::GenerateInputRequestedRegion()
 {
   typename Superclass::InputImagePointer inputPtr = const_cast<VolumeSeriesType *>(this->GetInput());
@@ -234,12 +244,6 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Ge
   m_SubtractFilter->SetInput2(m_FourDToProjectionStackFilter->GetOutput());
   m_SubtractFilter->SetInput1(m_ExtractFilter->GetOutput());
 
-  // For the same reason, set geometry now
-  // Check and set geometry
-  if (this->GetGeometry() == nullptr)
-  {
-    itkGenericExceptionMacro(<< "The geometry of the reconstruction has not been set");
-  }
   m_FourDToProjectionStackFilter->SetGeometry(this->m_Geometry);
   m_ProjectionStackToFourDFilter->SetGeometry(this->m_Geometry);
   m_DisplacedDetectorFilter->SetGeometry(this->m_Geometry);

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -191,6 +191,9 @@ protected:
   IterativeFDKConeBeamReconstructionFilter();
   ~IterativeFDKConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
@@ -71,6 +71,16 @@ IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecisio
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
+IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage, class TFFTPrecision>
+void
 IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::GenerateInputRequestedRegion()
 {
   typename Superclass::InputImagePointer inputPtr = const_cast<TInputImage *>(this->GetInput());
@@ -133,11 +143,6 @@ IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecisio
   m_DivideFilter->SetInput1(m_MultiplyFilter->GetOutput());
   m_DivideFilter->SetInput2(m_RayBoxFilter->GetOutput());
 
-  // Check and set geometry
-  if (this->GetGeometry() == nullptr)
-  {
-    itkGenericExceptionMacro(<< "The geometry of the reconstruction has not been set");
-  }
   m_DisplacedDetectorFilter->SetGeometry(m_Geometry);
   m_ParkerFilter->SetGeometry(m_Geometry);
   m_FDKFilter->SetGeometry(m_Geometry);

--- a/include/rtkMaskCollimationImageFilter.h
+++ b/include/rtkMaskCollimationImageFilter.h
@@ -67,6 +67,9 @@ protected:
   MaskCollimationImageFilter();
   ~MaskCollimationImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   BeforeThreadedGenerateData() override;
 

--- a/include/rtkMaskCollimationImageFilter.hxx
+++ b/include/rtkMaskCollimationImageFilter.hxx
@@ -37,6 +37,16 @@ MaskCollimationImageFilter<TInputImage, TOutputImage>::MaskCollimationImageFilte
 
 template <class TInputImage, class TOutputImage>
 void
+MaskCollimationImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 MaskCollimationImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
   if (this->GetGeometry()->GetGantryAngles().size() != this->GetOutput()->GetLargestPossibleRegion().GetSize()[2])

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -291,6 +291,9 @@ protected:
   MechlemOneStepSpectralReconstructionFilter();
   ~MechlemOneStepSpectralReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -279,6 +279,16 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectru
 
 template <class TOutputImage, class TPhotonCounts, class TSpectrum>
 void
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TOutputImage, class TPhotonCounts, class TSpectrum>
+void
 MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::GenerateInputRequestedRegion()
 {
   // Input 0 is the material volumes we update

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -176,6 +176,9 @@ protected:
   OSEMConeBeamReconstructionFilter();
   ~OSEMConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -87,6 +87,16 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetBackProject
 
 template <class TVolumeImage, class TProjectionImage>
 void
+OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TVolumeImage, class TProjectionImage>
+void
 OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateInputRequestedRegion()
 {
   typename Superclass::InputImagePointer inputPtr = const_cast<TVolumeImage *>(this->GetInput());
@@ -230,12 +240,6 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
   m_DivideProjectionFilter->SetInput2(m_ForwardProjectionFilter->GetOutput());
   m_DivideProjectionFilter->SetConstant(0);
 
-  // For the same reason, set geometry now
-  // Check and set geometry
-  if (this->GetGeometry() == nullptr)
-  {
-    itkGenericExceptionMacro(<< "The geometry of the reconstruction has not been set");
-  }
   m_ForwardProjectionFilter->SetGeometry(this->m_Geometry);
   m_BackProjectionFilter->SetGeometry(this->m_Geometry);
   m_BackProjectionNormalizationFilter->SetGeometry(this->m_Geometry);

--- a/include/rtkParkerShortScanImageFilter.h
+++ b/include/rtkParkerShortScanImageFilter.h
@@ -83,6 +83,9 @@ protected:
   ParkerShortScanImageFilter();
   ~ParkerShortScanImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 

--- a/include/rtkParkerShortScanImageFilter.hxx
+++ b/include/rtkParkerShortScanImageFilter.hxx
@@ -37,6 +37,16 @@ ParkerShortScanImageFilter<TInputImage, TOutputImage>::ParkerShortScanImageFilte
 
 template <class TInputImage, class TOutputImage>
 void
+ParkerShortScanImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 ParkerShortScanImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -105,6 +105,9 @@ protected:
   ProjectGeometricPhantomImageFilter();
   ~ProjectGeometricPhantomImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateData() override;
 

--- a/include/rtkProjectGeometricPhantomImageFilter.hxx
+++ b/include/rtkProjectGeometricPhantomImageFilter.hxx
@@ -40,6 +40,16 @@ ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>::ProjectGeometricP
 
 template <class TInputImage, class TOutputImage>
 void
+ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   // Reading figure config file

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -185,6 +185,9 @@ protected:
   ProjectionStackToFourDImageFilter();
   ~ProjectionStackToFourDImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -126,6 +126,17 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
 
 template <typename VolumeSeriesType, typename ProjectionStackType, typename TFFTPrecision>
 void
+ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPrecision>::VerifyPreconditions()
+  ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename VolumeSeriesType, typename ProjectionStackType, typename TFFTPrecision>
+void
 ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPrecision>::GenerateOutputInformation()
 {
   // Create and set the splat filter

--- a/include/rtkRayConvexIntersectionImageFilter.h
+++ b/include/rtkRayConvexIntersectionImageFilter.h
@@ -95,6 +95,9 @@ protected:
   void
   BeforeThreadedGenerateData() override;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Apply changes to the input image requested region. */
   void
   DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;

--- a/include/rtkRayConvexIntersectionImageFilter.hxx
+++ b/include/rtkRayConvexIntersectionImageFilter.hxx
@@ -45,6 +45,16 @@ RayConvexIntersectionImageFilter<TInputImage, TOutputImage>::BeforeThreadedGener
 
 template <class TInputImage, class TOutputImage>
 void
+RayConvexIntersectionImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 RayConvexIntersectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread)
 {

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -197,6 +197,9 @@ protected:
   ReconstructionConjugateGradientOperator();
   ~ReconstructionConjugateGradientOperator() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -135,6 +135,17 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
 
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
+ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWeightsImage>::VerifyPreconditions()
+  ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
+void
 ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWeightsImage>::
   GenerateInputRequestedRegion()
 {

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -233,6 +233,9 @@ protected:
   RegularizedConjugateGradientConeBeamReconstructionFilter();
   ~RegularizedConjugateGradientConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   /** Does the real work. */
   void
   GenerateData() override;

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
@@ -147,6 +147,16 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::SetBackProject
 
 template <typename TImage>
 void
+RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <typename TImage>
+void
 RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::GenerateInputRequestedRegion()
 {
   // Call the superclass' implementation of this method

--- a/include/rtkReorderProjectionsImageFilter.h
+++ b/include/rtkReorderProjectionsImageFilter.h
@@ -88,6 +88,9 @@ protected:
 
   ~ReorderProjectionsImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateData() override;
 

--- a/include/rtkReorderProjectionsImageFilter.hxx
+++ b/include/rtkReorderProjectionsImageFilter.hxx
@@ -56,6 +56,16 @@ ReorderProjectionsImageFilter<TInputImage, TOutputImage>::GetOutputSignal()
 
 template <class TInputImage, class TOutputImage>
 void
+ReorderProjectionsImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_InputGeometry.IsNull() || this->m_OutputGeometry.IsNull())
+    itkExceptionMacro(<< "Geometries have not been set.");
+}
+
+template <class TInputImage, class TOutputImage>
+void
 ReorderProjectionsImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   unsigned int NumberOfProjections =

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -213,6 +213,9 @@ protected:
   SARTConeBeamReconstructionFilter();
   ~SARTConeBeamReconstructionFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -121,6 +121,16 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetGatingWeigh
 
 template <class TVolumeImage, class TProjectionImage>
 void
+SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_Geometry.IsNull())
+    itkExceptionMacro(<< "Geometry has not been set.");
+}
+
+template <class TVolumeImage, class TProjectionImage>
+void
 SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateInputRequestedRegion()
 {
   typename Superclass::InputImagePointer inputPtr = const_cast<TVolumeImage *>(this->GetInput());
@@ -183,12 +193,6 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
   m_ExtractFilter->SetInput(this->GetInput(1));
   m_SubtractFilter->SetInput(1, m_ForwardProjectionFilter->GetOutput());
 
-  // For the same reason, set geometry now
-  // Check and set geometry
-  if (this->GetGeometry() == nullptr)
-  {
-    itkGenericExceptionMacro(<< "The geometry of the reconstruction has not been set");
-  }
   m_ForwardProjectionFilter->SetGeometry(this->m_Geometry);
   m_BackProjectionFilter->SetGeometry(this->m_Geometry);
   m_BackProjectionNormalizationFilter->SetGeometry(this->m_Geometry);

--- a/include/rtkSubSelectImageFilter.h
+++ b/include/rtkSubSelectImageFilter.h
@@ -97,6 +97,9 @@ protected:
   SubSelectImageFilter();
   ~SubSelectImageFilter() override = default;
 
+  /** Checks that inputs are correctly set. */
+  void VerifyPreconditions() ITKv5_CONST override;
+
   void
   GenerateInputRequestedRegion() override;
 

--- a/include/rtkSubSelectImageFilter.hxx
+++ b/include/rtkSubSelectImageFilter.hxx
@@ -47,6 +47,16 @@ SubSelectImageFilter<ProjectionStackType>::GetInputProjectionStack()
 
 template <typename ProjectionStackType>
 void
+SubSelectImageFilter<ProjectionStackType>::VerifyPreconditions() ITKv5_CONST
+{
+  this->Superclass::VerifyPreconditions();
+
+  if (this->m_InputGeometry.IsNull() || this->m_OutputGeometry.IsNull())
+    itkExceptionMacro(<< "Geometries have not been set.");
+}
+
+template <typename ProjectionStackType>
+void
 SubSelectImageFilter<ProjectionStackType>::GenerateInputRequestedRegion()
 {
   const unsigned int Dimension = this->InputImageDimension;


### PR DESCRIPTION
Attempt at solving #270.

As suggested, this affects all filters returned by `grep Geometry include/*.h | grep itkSet | sed "s/:.*$//g"` as of 72878637c67c55a709c3841bfd51cf0cdce8f035. I suspect that some already existing checks are to be moved in `VerifyPreconditions` but I guess that's something we can leave for future pull requests.

With this version, `rtkAmsterdamShroudTest` fails because of [those lines](https://github.com/acoussat/RTK/blob/check-geometry/test/rtkamsterdamshroudtest.cxx#L230-L231). I don't really know what this filter does and if it is supposed to work without geometry. Can someone explain if this test should be left as it currently is? If yes, I can remove the geometry check.