### PR TITLE
ENH: default projectors for all iterative filters

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -174,15 +174,6 @@ public:
   using DisplacedDetectorFilterType = rtk::DisplacedDetectorImageFilter<TOutputImage>;
   using GatingWeightsFilterType = rtk::MultiplyByVectorImageFilter<TOutputImage>;
 
-  /** Pass the ForwardProjection filter to the conjugate gradient operator */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
-   * B of AX=B */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the geometry to all filters needing it */
   itkSetObjectMacro(Geometry, ThreeDCircularProjectionGeometry);
 

--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
@@ -97,33 +97,6 @@ ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage,
 
 template <typename TOutputImage, typename TGradientOutputImage>
 void
-ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::SetForwardProjectionFilter(
-  ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-    m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilter);
-  }
-}
-
-template <typename TOutputImage, typename TGradientOutputImage>
-void
-ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::SetBackProjectionFilter(
-  BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_BackProjectionFilterForConjugateGradient = this->InstantiateBackProjectionFilter(_arg);
-    m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilterForConjugateGradient);
-  }
-}
-
-template <typename TOutputImage, typename TGradientOutputImage>
-void
 ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::SetBetaForCurrentIteration(int iter)
 {
   float currentBeta = m_Beta * (iter + 1) / (float)m_AL_iterations;
@@ -177,6 +150,19 @@ template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConeBeamReconstructionFilter<TOutputImage, TGradientOutputImage>::GenerateOutputInformation()
 {
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  // Pass the ForwardProjection filter to the conjugate gradient operator
+  m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilter);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  // Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
+  // B of AX=B
+  m_BackProjectionFilterForConjugateGradient =
+    this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilterForConjugateGradient);
+
   // Set runtime connections
   m_GradientFilter1->SetInput(this->GetInput(0));
   m_ZeroMultiplyVolumeFilter->SetInput1(this->GetInput(0));

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -176,15 +176,6 @@ public:
   using ForwardProjectionType = typename Superclass::ForwardProjectionType;
   using BackProjectionType = typename Superclass::BackProjectionType;
 
-  /** Pass the ForwardProjection filter to the conjugate gradient operator */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
-   * B of AX=B */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the geometry to all filters needing it */
   itkSetObjectMacro(Geometry, ThreeDCircularProjectionGeometry);
 

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
@@ -72,31 +72,6 @@ ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::ADMMWaveletsConeBeamReco
   m_DisplacedDetectorFilter->ReleaseDataFlagOn();
 }
 
-template <typename TOutputImage>
-void
-ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::SetForwardProjectionFilter(ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilterForConjugateGradient = this->InstantiateForwardProjectionFilter(_arg);
-    m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilterForConjugateGradient);
-  }
-}
-
-template <typename TOutputImage>
-void
-ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::SetBackProjectionFilter(BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_BackProjectionFilterForConjugateGradient = this->InstantiateBackProjectionFilter(_arg);
-    m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilterForConjugateGradient);
-  }
-}
-
 template <class TOutputImage>
 void
 ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::VerifyPreconditions() ITKv5_CONST
@@ -132,6 +107,20 @@ template <typename TOutputImage>
 void
 ADMMWaveletsConeBeamReconstructionFilter<TOutputImage>::GenerateOutputInformation()
 {
+  // Set forward projection filter
+  m_ForwardProjectionFilterForConjugateGradient =
+    this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  // Pass the ForwardProjection filter to the conjugate gradient operator
+  m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilterForConjugateGradient);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  // Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
+  // B of AX=B
+  m_BackProjectionFilterForConjugateGradient =
+    this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilterForConjugateGradient);
+
   // Set runtime connections
   m_ZeroMultiplyFilter->SetInput1(this->GetInput(0));
   m_CGOperator->SetInput(1, this->GetInput(1)); // The projections (the conjugate gradient operator needs them)

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -170,15 +170,6 @@ public:
   using ConstantImageSourceType = ConstantImageSource<TOutputImage>;
 #endif
 
-  /** Pass the ForwardProjection filter to the conjugate gradient operator */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
-   * B of AX=B */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Set the support mask, if any, for support constraint in reconstruction */
   void
   SetSupportMask(const TSingleComponentImage * SupportMask);

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -125,33 +125,6 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
-ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::
-  SetForwardProjectionFilter(ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-    m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilter);
-  }
-}
-
-template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
-void
-ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::
-  SetBackProjectionFilter(BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_BackProjectionFilterForB = this->InstantiateBackProjectionFilter(_arg);
-    m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilter);
-  }
-}
-
-template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
-void
 ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::VerifyPreconditions()
   ITKv5_CONST
 {
@@ -208,6 +181,18 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 #endif
   m_ConjugateGradientFilter->SetA(m_CGOperator.GetPointer());
   m_ConjugateGradientFilter->SetIterationCosts(m_IterationCosts);
+
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  // Pass the ForwardProjection filter to the conjugate gradient operator
+  m_CGOperator->SetForwardProjectionFilter(m_ForwardProjectionFilter);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  // Pass the backprojection filter to the conjugate gradient operator and to the back projection filter generating the
+  // B of AX=B
+  m_BackProjectionFilterForB = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilter);
 
   // Set runtime connections
   m_ConstantVolumeSource->SetInformationFromImage(this->GetInputVolume());

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -163,14 +163,6 @@ public:
   typename ProjectionStackType::ConstPointer
   GetInputProjectionStack();
 
-  /** Pass the ForwardProjection filter to the conjugate gradient operator */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to the conjugate gradient operator and to the filter generating the B of AX=B */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the interpolation weights to subfilters */
   void
   SetWeights(const itk::Array2D<float> _arg);

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -310,14 +310,6 @@ public:
   using ForwardProjectionType = typename Superclass::ForwardProjectionType;
   using BackProjectionType = typename Superclass::BackProjectionType;
 
-  /** Pass the ForwardProjection filter to SingleProjectionToFourDFilter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to ProjectionStackToFourD*/
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the interpolation weights to SingleProjectionToFourDFilter */
   virtual void
   SetWeights(const itk::Array2D<float> _arg);

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -160,30 +160,6 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>:
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
 void
-FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetForwardProjectionFilter(
-  ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_FourDCGFilter->SetForwardProjectionFilter(_arg);
-  }
-}
-
-template <typename VolumeSeriesType, typename ProjectionStackType>
-void
-FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetBackProjectionFilter(
-  BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_FourDCGFilter->SetBackProjectionFilter(_arg);
-  }
-}
-
-template <typename VolumeSeriesType, typename ProjectionStackType>
-void
 FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetWeights(
   const itk::Array2D<float> _arg)
 {
@@ -265,6 +241,10 @@ void
 FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::GenerateOutputInformation()
 {
   const int Dimension = VolumeType::ImageDimension;
+
+  // Set projection filters
+  m_FourDCGFilter->SetForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  m_FourDCGFilter->SetBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
 
   // The 4D conjugate gradient filter is the only part that must be in the pipeline
   // whatever was the user wants

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -196,14 +196,6 @@ public:
   itkGetMacro(EnforcePositivity, bool);
   itkSetMacro(EnforcePositivity, bool);
 
-  /** Select the ForwardProjection filter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Select the backprojection filter */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the interpolation weights to subfilters */
   void
   SetWeights(const itk::Array2D<float> _arg);

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
@@ -113,32 +113,6 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Ge
 
 template <class VolumeSeriesType, class ProjectionStackType>
 void
-FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetForwardProjectionFilter(
-  ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-    m_FourDToProjectionStackFilter->SetForwardProjectionFilter(m_ForwardProjectionFilter);
-  }
-}
-
-template <class VolumeSeriesType, class ProjectionStackType>
-void
-FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetBackProjectionFilter(
-  BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_ProjectionStackToFourDFilter->SetBackProjectionFilter(m_BackProjectionFilter);
-  }
-}
-
-template <class VolumeSeriesType, class ProjectionStackType>
-void
 FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::SetWeights(const itk::Array2D<float> _arg)
 {
   m_ProjectionStackToFourDFilter->SetWeights(_arg);
@@ -194,6 +168,14 @@ FourDSARTConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::Ge
 {
   const unsigned int Dimension = ProjectionStackType::ImageDimension;
   unsigned int numberOfProjections = this->GetInputProjectionStack()->GetLargestPossibleRegion().GetSize(Dimension - 1);
+
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  m_FourDToProjectionStackFilter->SetForwardProjectionFilter(m_ForwardProjectionFilter);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_ProjectionStackToFourDFilter->SetBackProjectionFilter(m_BackProjectionFilter);
 
   m_DisplacedDetectorFilter->SetDisable(m_DisableDisplacedDetectorFilter);
 

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -287,9 +287,6 @@ SetBackProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructionFi
 {
   switch (args_info.bp_arg)
   {
-    case (-1): // bp__NULL
-      recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_UNKNOWN);
-      break;
     case (0): // bp_arg_VoxelBasedBackProjection
       recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_VOXELBASED);
       break;
@@ -325,9 +322,6 @@ SetForwardProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructio
 {
   switch (args_info.fp_arg)
   {
-    case (-1): // fp__NULL
-      recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_UNKNOWN);
-      break;
     case (0): // fp_arg_Joseph
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_JOSEPH);
       break;

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -69,7 +69,6 @@ public:
   using VolumeType = ProjectionStackType;
   typedef enum
   {
-    FP_UNKNOWN = -1,
     FP_JOSEPH = 0,
     FP_CUDARAYCAST = 2,
     FP_JOSEPHATTENUATED = 3,
@@ -77,7 +76,6 @@ public:
   } ForwardProjectionType;
   typedef enum
   {
-    BP_UNKNOWN = -1,
     BP_VOXELBASED = 0,
     BP_JOSEPH = 1,
     BP_CUDAVOXELBASED = 2,

--- a/include/rtkIterativeConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeConeBeamReconstructionFilter.hxx
@@ -27,8 +27,8 @@ namespace rtk
 template <class TOutputImage, class ProjectionStackType>
 IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::IterativeConeBeamReconstructionFilter()
 {
-  m_CurrentForwardProjectionConfiguration = FP_UNKNOWN;
-  m_CurrentBackProjectionConfiguration = BP_UNKNOWN;
+  m_CurrentForwardProjectionConfiguration = FP_JOSEPH;
+  m_CurrentBackProjectionConfiguration = BP_VOXELBASED;
 }
 
 template <class TOutputImage, class ProjectionStackType>

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -156,10 +156,6 @@ public:
   itkGetMacro(EnforcePositivity, bool);
   itkSetMacro(EnforcePositivity, bool);
 
-  /** Select the ForwardProjection filter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
   /** Select the backprojection filter */
   void
   SetBackProjectionFilter(BackProjectionType itkNotUsed(_arg)) override

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
@@ -59,18 +59,6 @@ IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecisio
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
-IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::SetForwardProjectionFilter(
-  ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-  }
-}
-
-template <class TInputImage, class TOutputImage, class TFFTPrecision>
-void
 IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
@@ -96,6 +84,9 @@ template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
 IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::GenerateOutputInformation()
 {
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+
   // Set FDK parameters
   m_FDKFilter->GetRampFilter()->SetTruncationCorrection(m_TruncationCorrection);
   m_FDKFilter->GetRampFilter()->SetHannCutFrequency(m_HannCutFrequency);

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -229,14 +229,6 @@ public:
   using MultiplyGradientFilterType = itk::MultiplyImageFilter<TGradientsImage, SingleComponentImageType>;
 #endif
 
-  /** Instantiate the forward projection filters */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Instantiate the back projection filters */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** Pass the geometry to all filters needing it */
   itkSetConstObjectMacro(Geometry, ThreeDCircularProjectionGeometry);
 

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -166,33 +166,6 @@ typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts,
 }
 
 template <class TOutputImage, class TPhotonCounts, class TSpectrum>
-void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::SetForwardProjectionFilter(
-  ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg); // The multi-component one
-    m_SingleComponentForwardProjectionFilter =
-      InstantiateSingleComponentForwardProjectionFilter(_arg); // The single-component one
-  }
-}
-
-template <class TOutputImage, class TPhotonCounts, class TSpectrum>
-void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::SetBackProjectionFilter(
-  BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_GradientsBackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_HessiansBackProjectionFilter = this->InstantiateHessiansBackProjectionFilter(_arg);
-  }
-}
-
-template <class TOutputImage, class TPhotonCounts, class TSpectrum>
 typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::
   SingleComponentForwardProjectionFilterType::Pointer
   MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectrum>::
@@ -334,6 +307,17 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TPhotonCounts, TSpectru
 {
   typename TPhotonCounts::RegionType largest = this->GetInputPhotonCounts()->GetLargestPossibleRegion();
   m_NumberOfProjections = largest.GetSize()[TPhotonCounts::ImageDimension - 1];
+
+  // Set forward projection filter
+  m_ForwardProjectionFilter =
+    this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration); // The multi-component one
+  m_SingleComponentForwardProjectionFilter = InstantiateSingleComponentForwardProjectionFilter(
+    this->m_CurrentForwardProjectionConfiguration); // The single-component one
+
+  // Set back projection filter
+  m_GradientsBackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_HessiansBackProjectionFilter =
+    this->InstantiateHessiansBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
 
   // Pre-compute the number of projections in each subset
   m_NumberOfProjectionsInSubset.clear();

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -164,14 +164,6 @@ public:
   itkGetMacro(Alpha, float);
   itkSetMacro(Alpha, float);
 
-  /** Select the ForwardProjection filter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Select the backprojection filter */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
 protected:
   OSEMConeBeamReconstructionFilter();
   ~OSEMConeBeamReconstructionFilter() override = default;

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -64,29 +64,6 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::OSEMConeBeamRe
 
 template <class TVolumeImage, class TProjectionImage>
 void
-OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetForwardProjectionFilter(ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-  }
-}
-
-template <class TVolumeImage, class TProjectionImage>
-void
-OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetBackProjectionFilter(BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_BackProjectionNormalizationFilter = this->InstantiateBackProjectionFilter(_arg);
-  }
-}
-
-template <class TVolumeImage, class TProjectionImage>
-void
 OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
@@ -116,6 +93,14 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
   // We only set the first sub-stack at that point, the rest will be
   // requested in the GenerateData function
   typename ExtractFilterType::InputImageRegionType projRegion;
+
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_BackProjectionNormalizationFilter =
+    this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
 
   projRegion = this->GetInput(1)->GetLargestPossibleRegion();
   m_ExtractFilter->SetExtractionRegion(projRegion);

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -161,14 +161,6 @@ public:
   using WaveletsDenoisingFilterType = rtk::DeconstructSoftThresholdReconstructImageFilter<TImage>;
   using SoftThresholdFilterType = rtk::SoftThresholdImageFilter<TImage, TImage>;
 
-  /** Pass the ForwardProjection filter to SingleProjectionToFourDFilter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Pass the backprojection filter to ProjectionStackToFourD*/
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   // Regularization steps to perform
   itkSetMacro(PerformPositivity, bool);
   itkGetMacro(PerformPositivity, bool);

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
@@ -125,28 +125,6 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TOutputImage>::GetSuppo
 
 template <typename TImage>
 void
-RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::SetForwardProjectionFilter(ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_CGFilter->SetForwardProjectionFilter(_arg);
-  }
-}
-
-template <typename TImage>
-void
-RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::SetBackProjectionFilter(BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_CGFilter->SetBackProjectionFilter(_arg);
-  }
-}
-
-template <typename TImage>
-void
 RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::VerifyPreconditions() ITKv5_CONST
 {
   this->Superclass::VerifyPreconditions();
@@ -174,6 +152,10 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::GenerateOutput
   // Construct the pipeline, adding regularization filters if the user wants them
   // Connect the last filter's output to the next filter's input using the currentDownstreamFilter pointer
   typename itk::ImageToImageFilter<TImage, TImage>::Pointer currentDownstreamFilter;
+
+  // Set projection filters
+  m_CGFilter->SetForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+  m_CGFilter->SetBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
 
   // The conjugate gradient filter is the only part that must be in the pipeline
   // whatever was the user wants

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -193,14 +193,6 @@ public:
   itkGetMacro(EnforcePositivity, bool);
   itkSetMacro(EnforcePositivity, bool);
 
-  /** Select the ForwardProjection filter */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType _arg) override;
-
-  /** Select the backprojection filter */
-  void
-  SetBackProjectionFilter(BackProjectionType _arg) override;
-
   /** In the case of a gated SART, set the gating weights */
   void
   SetGatingWeights(std::vector<float> weights);

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -90,29 +90,6 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SARTConeBeamRe
 
 template <class TVolumeImage, class TProjectionImage>
 void
-SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetForwardProjectionFilter(ForwardProjectionType _arg)
-{
-  if (_arg != this->GetForwardProjectionFilter())
-  {
-    Superclass::SetForwardProjectionFilter(_arg);
-    m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(_arg);
-  }
-}
-
-template <class TVolumeImage, class TProjectionImage>
-void
-SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetBackProjectionFilter(BackProjectionType _arg)
-{
-  if (_arg != this->GetBackProjectionFilter())
-  {
-    Superclass::SetBackProjectionFilter(_arg);
-    m_BackProjectionFilter = this->InstantiateBackProjectionFilter(_arg);
-    m_BackProjectionNormalizationFilter = this->InstantiateBackProjectionFilter(_arg);
-  }
-}
-
-template <class TVolumeImage, class TProjectionImage>
-void
 SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SetGatingWeights(std::vector<float> weights)
 {
   m_GatingWeights = weights;
@@ -163,6 +140,14 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
   projRegion = this->GetInput(1)->GetLargestPossibleRegion();
   m_ExtractFilter->SetExtractionRegion(projRegion);
   m_ExtractFilterRayBox->SetExtractionRegion(projRegion);
+
+  // Set forward projection filter
+  m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);
+
+  // Set back projection filter
+  m_BackProjectionFilter = this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
+  m_BackProjectionNormalizationFilter =
+    this->InstantiateBackProjectionFilter(this->m_CurrentBackProjectionConfiguration);
 
   // Links with the forward and back projection filters should be set here
   // and not in the constructor, as these filters are set at runtime

--- a/src/rtkCudaIterativeFDKConeBeamReconstructionFilter.cxx
+++ b/src/rtkCudaIterativeFDKConeBeamReconstructionFilter.cxx
@@ -28,6 +28,9 @@ rtk::CudaIterativeFDKConeBeamReconstructionFilter ::CudaIterativeFDKConeBeamReco
 
   // Filter parameters
   m_DisplacedDetectorFilter->SetPadOnTruncatedSide(false);
+
+  // Set default projector
+  this->m_CurrentForwardProjectionConfiguration = ForwardProjectionType::FP_CUDARAYCAST;
 }
 
 void


### PR DESCRIPTION
After a lot of trials and errors, my attempt at solving #253.

All filters inheriting from [`rtk::IterativeConeBeamReconstructionFilter`](http://www.openrtk.org/Doxygen/classrtk_1_1IterativeConeBeamReconstructionFilter.html) now have default forward- and back-projectors and won't produce segmentation faults anymore.

This has not been thoroughly tested, I hope it is alright!