### PR TITLE
ENH: set division threshold for SART

### DIFF
--- a/applications/rtksart/rtksart.cxx
+++ b/applications/rtksart/rtksart.cxx
@@ -119,6 +119,11 @@ main(int argc, char * argv[])
     sart->SetEnforcePositivity(true);
   }
 
+  if (args_info.divisionthreshold_given)
+  {
+    sart->SetDivisionThreshold(args_info.divisionthreshold_arg);
+  }
+
   REPORT_ITERATIONS(sart, rtk::SARTConeBeamReconstructionFilter<OutputImageType>, OutputImageType)
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(sart->Update())

--- a/applications/rtksart/rtksart.ggo
+++ b/applications/rtksart/rtksart.ggo
@@ -11,6 +11,7 @@ option "positivity"  - "Enforces positivity during the reconstruction"         f
 option "input"     i "Input volume"              string          no
 option "nprojpersubset" - "Number of projections processed between each update of the reconstructed volume (1 for SART, several for OSSART, all for SIRT)" int no default="1"
 option "nodisplaced"    - "Disable the displaced detector filter"              flag   off
+option "divisionthreshold"  - "Threshold below which pixels in the denominator in the projection space are considered zero" double  no
 
 section "Phase gating"
 option "signal"       - "File containing the phase of each projection"                                              string              no

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -147,6 +147,7 @@ public:
   /** Some convenient type alias. */
   using VolumeType = TVolumeImage;
   using ProjectionType = TProjectionImage;
+  using ProjectionPixelType = typename ProjectionType::PixelType;
 
   /** Typedefs of each subfilter of this composite filter */
   using ExtractFilterType = itk::ExtractImageFilter<ProjectionType, ProjectionType>;
@@ -209,6 +210,13 @@ public:
   itkSetMacro(DisableDisplacedDetectorFilter, bool);
   itkGetMacro(DisableDisplacedDetectorFilter, bool);
 
+  /** Set the threshold below which pixels in the denominator in the projection space are considered zero. The division
+   * by zero will then be evaluated at zero. Avoid noise magnification from low projections values when working with
+   * noisy and/or simulated data.
+   */
+  itkSetMacro(DivisionThreshold, ProjectionPixelType);
+  itkGetMacro(DivisionThreshold, ProjectionPixelType);
+
 protected:
   SARTConeBeamReconstructionFilter();
   ~SARTConeBeamReconstructionFilter() override = default;
@@ -250,6 +258,8 @@ protected:
   typename ThresholdFilterType::Pointer          m_ThresholdFilter;
   typename DisplacedDetectorFilterType::Pointer  m_DisplacedDetectorFilter;
   typename GatingWeightsFilterType::Pointer      m_GatingWeightsFilter;
+
+  ProjectionPixelType m_DivisionThreshold;
 
   bool m_EnforcePositivity;
   bool m_DisableDisplacedDetectorFilter;

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -155,6 +155,7 @@ void
 SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutputInformation()
 {
   m_DisplacedDetectorFilter->SetDisable(m_DisableDisplacedDetectorFilter);
+  m_DivideProjectionFilter->SetThreshold(m_DivisionThreshold);
 
   // We only set the first sub-stack at that point, the rest will be
   // requested in the GenerateData function


### PR DESCRIPTION
My attempt at fixing #151. From what I understood of the problem, this should suffice, but I might be missing something. I guess the modifications are automatically propagated to the Python wrappings.
One remark though: the current implementation allows setting a negative threshold. Is that a problem? [ITK seems to allow this behavior.](https://github.com/InsightSoftwareConsortium/ITK/blob/master/Modules/Filtering/ImageIntensity/include/itkDivideOrZeroOutImageFilter.h#L74-L84)