### PR TITLE
BUG: Change member type from float to double in Zeng projectors

### DIFF
--- a/include/rtkDePierroRegularizationImageFilter.h
+++ b/include/rtkDePierroRegularizationImageFilter.h
@@ -33,7 +33,7 @@ namespace rtk
 /** \class DePierroRegularizationImageFilter
  * \brief Implements a regularization for MLEM/OSEM reconstruction.
  *
- * Perform the quadratic penalization describe in [De Pierro, IEEE TMI, 1995] for
+ * Perform the quadratic penalization described in [De Pierro, IEEE TMI, 1995] for
  * MLEM/OSEM reconstruction.
  *
  * This filter takes the k and k+1 updates of the classic MLEM/OSEM algorithm as
@@ -115,8 +115,8 @@ public:
   itkTypeMacro(DePierroRegularizationFilter, itk::ImageToImageFilter);
 
   /** Get / Set the hyper parameter for the regularization */
-  itkGetMacro(Beta, float);
-  itkSetMacro(Beta, float);
+  itkGetMacro(Beta, double);
+  itkSetMacro(Beta, double);
 
 protected:
   DePierroRegularizationImageFilter();
@@ -142,7 +142,7 @@ protected:
   CustomBinaryFilterPointerType   m_CustomBinaryFilter;
 
 private:
-  float m_Beta{ 0.01 };
+  double m_Beta{ 0.01 };
 
 }; // end of class
 

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -52,8 +52,8 @@ namespace rtk
  * - each voxel of the back projection must be divided by the value it would take if
  * a projection filled with ones was being reprojected.
  *
- * By default the quadratic penalization describe in [De Pierro, IEEE TMI, 1995] is applied
- * during the iterative process. The hyperparameter for the regularization can be change
+ * By default the quadratic penalization described in [De Pierro, IEEE TMI, 1995] is applied
+ * during the iterative process. The hyperparameter for the regularization can be changed
  * using the SetBetaRegularization method. If the hyperparameter is set to 0 the
  * filter behaves like the classic MLEM/OSEM algorithm.
  *
@@ -164,16 +164,16 @@ public:
   itkSetMacro(NumberOfProjectionsPerSubset, unsigned int);
 
   /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
-  itkGetMacro(SigmaZero, float);
-  itkSetMacro(SigmaZero, float);
+  itkGetMacro(SigmaZero, double);
+  itkSetMacro(SigmaZero, double);
 
   /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
-  itkGetMacro(Alpha, float);
-  itkSetMacro(Alpha, float);
+  itkGetMacro(Alpha, double);
+  itkSetMacro(Alpha, double);
 
   /** Get / Set the hyperparameter for the regularization. Default is 0.01 */
-  itkGetMacro(BetaRegularization, float);
-  itkSetMacro(BetaRegularization, float);
+  itkGetMacro(BetaRegularization, double);
+  itkSetMacro(BetaRegularization, double);
 
 protected:
   OSEMConeBeamReconstructionFilter();
@@ -222,11 +222,11 @@ private:
   unsigned int m_NumberOfIterations{ 3 };
 
   /** PSF correction coefficients */
-  float m_SigmaZero{ -1 };
-  float m_Alpha{ -1 };
+  double m_SigmaZero{ -1. };
+  double m_Alpha{ -1. };
 
   /** Hyperparameter for the regularization */
-  float m_BetaRegularization{ 0.01 };
+  double m_BetaRegularization{ 0.01 };
 
 }; // end of class
 

--- a/include/rtkZengBackProjectionImageFilter.h
+++ b/include/rtkZengBackProjectionImageFilter.h
@@ -113,12 +113,12 @@ public:
   itkTypeMacro(ZengBackProjectionImageFilter, BackProjectionImageFilter);
 
   /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
-  itkGetMacro(SigmaZero, float);
-  itkSetMacro(SigmaZero, float);
+  itkGetMacro(SigmaZero, double);
+  itkSetMacro(SigmaZero, double);
 
   /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
-  itkGetMacro(Alpha, float);
-  itkSetMacro(Alpha, float);
+  itkGetMacro(Alpha, double);
+  itkSetMacro(Alpha, double);
 
 
 protected:
@@ -162,8 +162,8 @@ private:
   void
   operator=(const Self &) = delete; // purposely not implemented
 
-  float      m_SigmaZero{ 1.5417233052142099 };
-  float      m_Alpha{ 0.016241189545787734 };
+  double     m_SigmaZero{ 1.5417233052142099 };
+  double     m_Alpha{ 0.016241189545787734 };
   VectorType m_VectorOrthogonalDetector{ 0. };
   PointType  m_centerVolume{ 0 };
 };

--- a/include/rtkZengBackProjectionImageFilter.hxx
+++ b/include/rtkZengBackProjectionImageFilter.hxx
@@ -321,10 +321,10 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
   PointType                                                 originRotatedVolume;
 
   indexSlice.Fill(0);
-  float dist = NAN, sigmaSlice = NAN;
-  float thicknessSlice = this->GetInput(0)->GetSpacing()[2];
-  int   nbProjections = 0;
-  int   startSlice = 0;
+  double dist = NAN, sigmaSlice = NAN;
+  double thicknessSlice = this->GetInput(0)->GetSpacing()[2];
+  int    nbProjections = 0;
+  int    startSlice = 0;
   for (auto & angle : list_angle)
   {
     // Get the center of the rotated volume
@@ -405,7 +405,7 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
       indexSlice[Dimension - 1] = index - 1;
       dist += m_ConstantVolumeSource->GetSpacing()[2];
       // Compute the variance of the PSF for the current slice
-      sigmaSlice = dist * 2 * thicknessSlice * pow(m_Alpha, 2.0) + 2 * thicknessSlice * m_Alpha * m_SigmaZero -
+      sigmaSlice = dist * 2. * thicknessSlice * pow(m_Alpha, 2.0) + 2. * thicknessSlice * m_Alpha * m_SigmaZero -
                    pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
       m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
       m_DiscreteGaussianFilter->Update();

--- a/include/rtkZengForwardProjectionImageFilter.h
+++ b/include/rtkZengForwardProjectionImageFilter.h
@@ -106,12 +106,12 @@ public:
   itkTypeMacro(ZengForwardProjectionImageFilter, ForwardProjectionImageFilter);
 
   /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
-  itkGetMacro(SigmaZero, float);
-  itkSetMacro(SigmaZero, float);
+  itkGetMacro(SigmaZero, double);
+  itkSetMacro(SigmaZero, double);
 
   /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
-  itkGetMacro(Alpha, float);
-  itkSetMacro(Alpha, float);
+  itkGetMacro(Alpha, double);
+  itkSetMacro(Alpha, double);
 
 protected:
   ZengForwardProjectionImageFilter();
@@ -153,8 +153,8 @@ private:
   void
   operator=(const Self &) = delete; // purposely not implemented
 
-  float      m_SigmaZero{ 1.5417233052142099 };
-  float      m_Alpha{ 0.016241189545787734 };
+  double     m_SigmaZero{ 1.5417233052142099 };
+  double     m_Alpha{ 0.016241189545787734 };
   VectorType m_VectorOrthogonalDetector{ 0. };
   PointType  m_centerVolume{ 0 };
 };

--- a/include/rtkZengForwardProjectionImageFilter.hxx
+++ b/include/rtkZengForwardProjectionImageFilter.hxx
@@ -309,8 +309,9 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   indexSlice.Fill(0);
   indexProjection.Fill(0);
-  float dist = NAN, sigmaSlice = NAN, thicknessSlice = NAN;
-  int   nbProjections = 0;
+  double dist = NAN, sigmaSlice = NAN;
+  double thicknessSlice = NAN;
+  int    nbProjections = 0;
   for (auto & angle : list_angle)
   {
     // Set the rotation angle.
@@ -374,7 +375,7 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
         break;
       }
       // Compute the variance of the PSF for the current slice
-      sigmaSlice = dist * 2 * thicknessSlice * pow(m_Alpha, 2.0) + 2 * thicknessSlice * m_Alpha * m_SigmaZero -
+      sigmaSlice = dist * 2. * thicknessSlice * pow(m_Alpha, 2.0) + 2. * thicknessSlice * m_Alpha * m_SigmaZero -
                    pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
       m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
 


### PR DESCRIPTION
This should fix the bug introduced by 9ec2bc5d53307e47ffd60f8fa5d8102d3315a5f8.