### PR TITLE
ENH: Compute the backprojection of ones only once in OSEM

### DIFF
--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -175,6 +175,14 @@ public:
   itkGetMacro(BetaRegularization, double);
   itkSetMacro(BetaRegularization, double);
 
+  /** Get / Set StoreNormalizationImages. If true, the normalizations images
+   * are only computed once during the first iteration and stored to be reused
+   * for the next iterations. This speed up the computation time but it is
+   * more memory consuming than if the normalizations images were computed at
+   * each iteration (false). Default is true */
+  itkGetMacro(StoreNormalizationImages, bool);
+  itkSetMacro(StoreNormalizationImages, bool);
+
 protected:
   OSEMConeBeamReconstructionFilter();
   ~OSEMConeBeamReconstructionFilter() override = default;
@@ -227,6 +235,8 @@ private:
 
   /** Hyperparameter for the regularization */
   double m_BetaRegularization{ 0.01 };
+
+  bool m_StoreNormalizationImages{ true };
 
 }; // end of class
 


### PR DESCRIPTION
A backprojection of a volume filled with ones is needed for the OSEM algorithm.
Until now, this backprojection was computed at every iteration. However,
the result is independent of the iterations. Thus, computing this
backprojection only during the first iteration and reused the result for
the next is enough and should reduce the computation time of the OSEM
algorithm.