### PR TITLE
ENH: one-line iteration reporting

### DIFF
--- a/applications/rtkfdk/rtkfdk.cxx
+++ b/applications/rtkfdk/rtkfdk.cxx
@@ -150,7 +150,7 @@ main(int argc, char * argv[])
   f->SetProjectionSubsetSize(args_info.subsetsize_arg);                                                                \
   if (args_info.verbose_flag)                                                                                          \
   {                                                                                                                    \
-    f->AddObserver(itk::ProgressEvent(), progressCommand);                                                             \
+    f->AddObserver(itk::AnyEvent(), progressCommand);                                                                  \
   }
 
   // FDK reconstruction filtering

--- a/include/rtkMacro.h
+++ b/include/rtkMacro.h
@@ -215,7 +215,7 @@
   {                                                                                                                    \
     using VerboseIterationCommandType = rtk::VerboseIterationCommand<filter_type>;                                     \
     typename VerboseIterationCommandType::Pointer verboseIterationCommand = VerboseIterationCommandType::New();        \
-    filter->AddObserver(itk::IterationEvent(), verboseIterationCommand);                                               \
+    filter->AddObserver(itk::AnyEvent(), verboseIterationCommand);                                                     \
   }                                                                                                                    \
   if (args_info.output_every_given)                                                                                    \
   {                                                                                                                    \
@@ -233,6 +233,5 @@
     filter->AddObserver(itk::IterationEvent(), outputIterationCommand);                                                \
   }
 //--------------------------------------------------------------------
-
 
 #endif


### PR DESCRIPTION
Should enhance iteration reporting outputs such that it only occupies a single line.

However this approach has some drawbacks:
- if for some reason the filter outputs something, then this output is going to be erased after iteration completion;
- the character `\r` is output when there is a redirection to a file, which produces a line like
```
^MIteration 1 completed.^MIteration 2 completed.^MIteration 3 completed.
```
- a new line is missing at the very end of the output.

I don't see any potential fix for these issues, tell me if an idea pops to your mind!