### PR TITLE
ENH: progress reporting for ramp filter

### DIFF
--- a/applications/rtkramp/rtkramp.cxx
+++ b/applications/rtkramp/rtkramp.cxx
@@ -27,6 +27,7 @@
 
 #include <itkImageFileWriter.h>
 #include <itkStreamingImageFilter.h>
+#include "rtkProgressCommands.h"
 
 int
 main(int argc, char * argv[])
@@ -95,6 +96,13 @@ main(int argc, char * argv[])
     streamer->SetInput(rampFilter->GetOutput());
   streamer->SetNumberOfStreamDivisions(1 + reader->GetOutput()->GetLargestPossibleRegion().GetSize(2) /
                                              args_info.subsetsize_arg);
+
+  if (args_info.verbose_flag)
+  {
+    using PercentageProgressCommandType = rtk::PercentageProgressCommand<CPURampFilterType>;
+    PercentageProgressCommandType::Pointer progressCommand = PercentageProgressCommandType::New();
+    rampFilter->AddObserver(itk::ProgressEvent(), progressCommand);
+  }
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(streamer->Update())
 

--- a/include/rtkFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.hxx
@@ -121,10 +121,13 @@ template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
 FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::ThreadedGenerateData(
   const RegionType & outputRegionForThread,
-  ThreadIdType       itkNotUsed(threadId))
+  ThreadIdType       threadId)
 {
   auto nproj = outputRegionForThread.GetNumberOfPixels() /
                (outputRegionForThread.GetSize()[0] * outputRegionForThread.GetSize()[1]);
+
+  itk::ProgressReporter progress(this, threadId, outputRegionForThread.GetNumberOfPixels(), 100);
+
   for (unsigned int i = 0; i < nproj; i++)
   {
     auto outputRegion = outputRegionForThread;
@@ -192,6 +195,7 @@ FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::
       itD.Set(itS.Get());
       ++itS;
       ++itD;
+      progress.CompletedPixel();
     }
   }
 }


### PR DESCRIPTION
While running some tests using `rtkfdk -v`, I noticed that the reported progress ended at 66%. After some investigation, it turned out that the ramp filter didn't report its progress anymore, probably because of a719d8913 which removed the use of `DynamicThreadedGenerateData`. This pull request brings back progress reporting for ramp filter, along with reported progress using `rtkramp -v`.

I don't know if the code is correct, since the exact working of `itk::ProgressAccumulator` is somewhat still blurry to me, so please do tell me if anything is wrong!