### PR TITLE
COMP: Support if(... IN_LIST...) with CMake old projects

### DIFF
--- a/cmake/FindCUDA_wrap.cmake
+++ b/cmake/FindCUDA_wrap.cmake
@@ -1,4 +1,5 @@
 # - Wrapper around FindCUDA
+cmake_minimum_required(VERSION 3.3)
 
 if (MINGW)
   # Cuda doesn't work with mingw at all


### PR DESCRIPTION
If a project with cmake_minimum_required(VERSION 3.0) (e.g. CTK)
find_packages ITK that includes RTK built with CUDA, then
if(... IN_LIST ...) in FindCUDA_wrap.cmake is not supported.

We do not want to enforce Foo to have the same miminum version as RTK.
Foo could add policy but find_package(ITK) creates a new policy scope that prevents Foo from
ignores policies added by Foo.