### PR TITLE
COMP: Prevent RTK from overwriting CMAKE_MODULE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ set(RTK_VERSION_PATCH ${RTK_VERSION_PATCH})
 set(RTK_USE_CUDA ${RTK_USE_CUDA})
 
 if(${RTK_USE_CUDA})
-  set(CMAKE_MODULE_PATH ${RTK_MODULE_PATH_CONFIG} ${CMAKE_MODULE_PATH})
+  list(APPEND CMAKE_MODULE_PATH ${RTK_MODULE_PATH_CONFIG})
   # if we are using CUDA, make sure CUDA libraries are available
   find_package(CUDA_wrap REQUIRED)
   include_directories(${CUDA_INCLUDE_DIRS})


### PR DESCRIPTION
The existing behavior was erasing foo from CMAKE_MODULE_PATH while find_package(ITK) was executed:
```
set(CMAKE_MODULE_PATH foo)
find_package(ITK)
```

This is because _ITKConfig.cmake_ eventually called _lib/cmake/Modules/RTK.cmake_ that had `CMAKE_MODULE_PATH` already expanded when ITK was built.