### PR TITLE
COMP: missing definition of ITK_LIBRARY_BUILD_TYPE for external build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,12 @@ mark_as_advanced(RTK_DATA_ROOT)
 # Initialization
 if(NOT ITK_SOURCE_DIR)
   include(itk-module-init.cmake)
+
+  if(RTK_BUILD_SHARED_LIBS)
+    set(ITK_LIBRARY_BUILD_TYPE "SHARED")
+  else()
+    set(ITK_LIBRARY_BUILD_TYPE "STATIC")
+  endif()
 endif()
 
 # Propagate cmake options in a header file


### PR DESCRIPTION
Without the patch, there were errors when compiling with BUILD_SHARED_LIBS ON and CUDA ON with MSVC 2019, see [here](https://my.cdash.org/viewBuildError.php?buildid=1911065). 
@LucasGandel  can you tell me what you think?
@dzenanz, @thewtex, is it intentional that ITK_LIBRARY_BUILD_TYPE is not defined when building a remote module externally? RTK is not the only module to use this, there are a few others (at least IOFDF, IOMeshSTL, IOTransformDCMTK, MGHIO, MinimalPathExtraction).