### PR TITLE
ENH: fix export macros usage to match ITK rules

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -134,7 +134,7 @@ template <typename TOutputImage,
           typename TGradientOutputImage =
             itk::Image<itk::CovariantVector<typename TOutputImage::ValueType, TOutputImage::ImageDimension>,
                        TOutputImage::ImageDimension>>
-class ADMMTotalVariationConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT ADMMTotalVariationConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -104,7 +104,7 @@ template <typename TOutputImage,
           typename TGradientOutputImage =
             itk::Image<itk::CovariantVector<typename TOutputImage::ValueType, TOutputImage::ImageDimension>,
                        TOutputImage::ImageDimension>>
-class ADMMTotalVariationConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
+class ITK_TEMPLATE_EXPORT ADMMTotalVariationConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -140,7 +140,7 @@ namespace rtk
  */
 
 template <typename TOutputImage>
-class ADMMWaveletsConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT ADMMWaveletsConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:

--- a/include/rtkADMMWaveletsConjugateGradientOperator.h
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.h
@@ -95,7 +95,7 @@ namespace rtk
  */
 
 template <typename TOutputImage>
-class ADMMWaveletsConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
+class ITK_TEMPLATE_EXPORT ADMMWaveletsConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkAddMatrixAndDiagonalImageFilter.h
+++ b/include/rtkAddMatrixAndDiagonalImageFilter.h
@@ -41,7 +41,7 @@ template <class TDiagonal,
           class TMatrix = itk::Image<itk::Vector<typename TDiagonal::PixelType::ValueType,
                                                  TDiagonal::PixelType::Dimension * TDiagonal::PixelType::Dimension>,
                                      TDiagonal::ImageDimension>>
-class AddMatrixAndDiagonalImageFilter : public itk::ImageToImageFilter<TMatrix, TMatrix>
+class ITK_TEMPLATE_EXPORT AddMatrixAndDiagonalImageFilter : public itk::ImageToImageFilter<TMatrix, TMatrix>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkAdditiveGaussianNoiseImageFilter.h
+++ b/include/rtkAdditiveGaussianNoiseImageFilter.h
@@ -54,7 +54,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TPixel>
-class NormalVariateNoiseFunctor
+class ITK_TEMPLATE_EXPORT NormalVariateNoiseFunctor
 {
 public:
   NormalVariateNoiseFunctor()
@@ -168,7 +168,7 @@ private:
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage>
-class ITK_EXPORT AdditiveGaussianNoiseImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT AdditiveGaussianNoiseImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkAmsterdamShroudImageFilter.h
+++ b/include/rtkAmsterdamShroudImageFilter.h
@@ -78,7 +78,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage>
-class ITK_EXPORT AmsterdamShroudImageFilter
+class ITK_TEMPLATE_EXPORT AmsterdamShroudImageFilter
   : public itk::ImageToImageFilter<TInputImage, itk::Image<double, TInputImage::ImageDimension - 1>>
 {
 public:

--- a/include/rtkAverageOutOfROIImageFilter.h
+++ b/include/rtkAverageOutOfROIImageFilter.h
@@ -49,7 +49,7 @@ namespace rtk
  */
 template <class TInputImage, class TROI = itk::Image<typename TInputImage::PixelType, TInputImage::ImageDimension - 1>>
 
-class AverageOutOfROIImageFilter : public itk::InPlaceImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT AverageOutOfROIImageFilter : public itk::InPlaceImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkBackProjectionImageFilter.h
+++ b/include/rtkBackProjectionImageFilter.h
@@ -47,7 +47,7 @@ namespace rtk
  * \ingroup RTK Projector
  */
 template <class TInputImage, class TOutputImage>
-class BackProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT BackProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/include/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -37,7 +37,8 @@ namespace rtk
  */
 
 template <typename TInputImage, typename TOutputImage = itk::Image<float, TInputImage::ImageDimension>>
-class BackwardDifferenceDivergenceImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT BackwardDifferenceDivergenceImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
+++ b/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
@@ -36,7 +36,8 @@ template <class TVectorImage,
             itk::Image<itk::Vector<typename TVectorImage::PixelType::ValueType,
                                    TVectorImage::PixelType::Dimension * TVectorImage::PixelType::Dimension>,
                        TVectorImage::ImageDimension>>
-class BlockDiagonalMatrixVectorMultiplyImageFilter : public itk::ImageToImageFilter<TVectorImage, TVectorImage>
+class ITK_TEMPLATE_EXPORT BlockDiagonalMatrixVectorMultiplyImageFilter
+  : public itk::ImageToImageFilter<TVectorImage, TVectorImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkBoellaardScatterCorrectionImageFilter.h
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.h
@@ -37,7 +37,8 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT BoellaardScatterCorrectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT BoellaardScatterCorrectionImageFilter
+  : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConditionalMedianImageFilter.h
+++ b/include/rtkConditionalMedianImageFilter.h
@@ -46,7 +46,7 @@ namespace rtk
  *
  */
 template <typename TInputImage>
-class ConditionalMedianImageFilter : public itk::InPlaceImageFilter<TInputImage>
+class ITK_TEMPLATE_EXPORT ConditionalMedianImageFilter : public itk::InPlaceImageFilter<TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -107,7 +107,8 @@ namespace rtk
  */
 
 template <typename TOutputImage, typename TSingleComponentImage = TOutputImage, typename TWeightsImage = TOutputImage>
-class ConjugateGradientConeBeamReconstructionFilter : public IterativeConeBeamReconstructionFilter<TOutputImage>
+class ITK_TEMPLATE_EXPORT ConjugateGradientConeBeamReconstructionFilter
+  : public IterativeConeBeamReconstructionFilter<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
@@ -32,7 +32,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TInputImage>
-class ConjugateGradientGetP_kPlusOneImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT ConjugateGradientGetP_kPlusOneImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
@@ -34,7 +34,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TInputImage>
-class ConjugateGradientGetR_kPlusOneImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT ConjugateGradientGetR_kPlusOneImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
@@ -32,7 +32,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TInputImage>
-class ConjugateGradientGetX_kPlusOneImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT ConjugateGradientGetX_kPlusOneImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientImageFilter.h
+++ b/include/rtkConjugateGradientImageFilter.h
@@ -43,7 +43,8 @@ namespace rtk
  */
 
 template <typename OutputImageType>
-class ConjugateGradientImageFilter : public itk::InPlaceImageFilter<OutputImageType, OutputImageType>
+class ITK_TEMPLATE_EXPORT ConjugateGradientImageFilter
+  : public itk::InPlaceImageFilter<OutputImageType, OutputImageType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConjugateGradientOperator.h
+++ b/include/rtkConjugateGradientOperator.h
@@ -29,7 +29,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename OutputImageType>
-class ConjugateGradientOperator : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
+class ITK_TEMPLATE_EXPORT ConjugateGradientOperator : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkConstantImageSource.h
+++ b/include/rtkConstantImageSource.h
@@ -48,7 +48,7 @@ namespace rtk
  * \ingroup RTK ImageSource
  */
 template <typename TOutputImage>
-class ITK_EXPORT ConstantImageSource : public itk::ImageSource<TOutputImage>
+class ITK_TEMPLATE_EXPORT ConstantImageSource : public itk::ImageSource<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkCudaBackProjectionImageFilter.h
+++ b/include/rtkCudaBackProjectionImageFilter.h
@@ -47,7 +47,7 @@ namespace rtk
  */
 
 template <class ImageType = itk::CudaImage<float, 3>>
-class ITK_EXPORT CudaBackProjectionImageFilter
+class ITK_TEMPLATE_EXPORT CudaBackProjectionImageFilter
   : public itk::CudaInPlaceImageFilter<ImageType, ImageType, BackProjectionImageFilter<ImageType, ImageType>>
 {
 public:

--- a/include/rtkCudaConjugateGradientImageFilter.h
+++ b/include/rtkCudaConjugateGradientImageFilter.h
@@ -41,7 +41,7 @@ namespace rtk
  */
 
 template <class TImage>
-class CudaConjugateGradientImageFilter
+class ITK_TEMPLATE_EXPORT CudaConjugateGradientImageFilter
   : public itk::CudaImageToImageFilter<TImage, TImage, ConjugateGradientImageFilter<TImage>>
 {
 public:

--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
@@ -46,7 +46,7 @@ namespace rtk
  * \ingroup RTK CudaImageToImageFilter
  */
 template <class TParentImageFilter>
-class CudaFFTProjectionsConvolutionImageFilter
+class ITK_TEMPLATE_EXPORT CudaFFTProjectionsConvolutionImageFilter
   : public itk::CudaImageToImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, TParentImageFilter>
 {
 public:

--- a/include/rtkCudaFFTRampImageFilter.h
+++ b/include/rtkCudaFFTRampImageFilter.h
@@ -25,6 +25,7 @@
 
 #  include "rtkCudaFFTProjectionsConvolutionImageFilter.h"
 #  include "rtkFFTRampImageFilter.h"
+#  include "RTKExport.h"
 
 namespace rtk
 {
@@ -38,7 +39,7 @@ namespace rtk
  *
  * \ingroup RTK CudaImageToImageFilter
  */
-class CudaFFTRampImageFilter
+class RTK_EXPORT CudaFFTRampImageFilter
   : public CudaFFTProjectionsConvolutionImageFilter<
       FFTRampImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, float>>
 {

--- a/include/rtkCudaForwardProjectionImageFilter.h
+++ b/include/rtkCudaForwardProjectionImageFilter.h
@@ -49,7 +49,7 @@ namespace rtk
 {
 
 template <class TInputImage = itk::CudaImage<float, 3>, class TOutputImage = TInputImage>
-class ITK_EXPORT CudaForwardProjectionImageFilter
+class ITK_TEMPLATE_EXPORT CudaForwardProjectionImageFilter
   : public itk::
       CudaInPlaceImageFilter<TInputImage, TOutputImage, ForwardProjectionImageFilter<TInputImage, TOutputImage>>
 {

--- a/include/rtkCudaWeidingerForwardModelImageFilter.h
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.h
@@ -43,7 +43,7 @@ template <class TMaterialProjections,
           class TSpectrum,
           class TProjections =
             itk::CudaImage<typename TMaterialProjections::PixelType::ValueType, TMaterialProjections::ImageDimension>>
-class ITK_EXPORT CudaWeidingerForwardModelImageFilter
+class ITK_TEMPLATE_EXPORT CudaWeidingerForwardModelImageFilter
   : public itk::CudaImageToImageFilter<
       TMaterialProjections,
       TMaterialProjections,

--- a/include/rtkCyclicDeformationImageFilter.h
+++ b/include/rtkCyclicDeformationImageFilter.h
@@ -47,7 +47,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT CyclicDeformationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT CyclicDeformationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDCMImagXImageIO.h
+++ b/include/rtkDCMImagXImageIO.h
@@ -21,6 +21,7 @@
 
 #include <itkGDCMImageIO.h>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -32,7 +33,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class DCMImagXImageIO : public itk::GDCMImageIO
+class RTK_EXPORT DCMImagXImageIO : public itk::GDCMImageIO
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDPExtractShroudSignalImageFilter.h
+++ b/include/rtkDPExtractShroudSignalImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  */
 
 template <class TInputPixel, class TOutputPixel>
-class ITK_EXPORT DPExtractShroudSignalImageFilter
+class ITK_TEMPLATE_EXPORT DPExtractShroudSignalImageFilter
   : public itk::ImageToImageFilter<itk::Image<TInputPixel, 2>, itk::Image<TOutputPixel, 1>>
 {
 public:

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
@@ -42,7 +42,7 @@ namespace rtk
  *
  */
 template <typename TImage>
-class DaubechiesWaveletsConvolutionImageFilter : public itk::ImageToImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT DaubechiesWaveletsConvolutionImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
@@ -71,7 +71,8 @@ namespace rtk
  */
 
 template <typename TImageSequence>
-class DaubechiesWaveletsDenoiseSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
+class ITK_TEMPLATE_EXPORT DaubechiesWaveletsDenoiseSequenceImageFilter
+  : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDbf.h
+++ b/include/rtkDbf.h
@@ -20,6 +20,7 @@
 #define rtkDbf_h
 
 #include "RTKExport.h"
+#include "itkWin32Header.h"
 #include <string>
 #include <fstream>
 #include <vector>

--- a/include/rtkDbf.h
+++ b/include/rtkDbf.h
@@ -19,6 +19,7 @@
 #ifndef rtkDbf_h
 #define rtkDbf_h
 
+#include "RTKExport.h"
 #include <string>
 #include <fstream>
 #include <vector>
@@ -36,7 +37,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class DbfField
+class RTK_EXPORT DbfField
 {
 public:
   /** Constructor */
@@ -83,7 +84,7 @@ private:
  *
  * \ingroup RTK
  */
-class DbfFile
+class RTK_EXPORT DbfFile
 {
 public:
   /** Constructor initializes the structure and goes to first record */

--- a/include/rtkDePierroRegularizationImageFilter.h
+++ b/include/rtkDePierroRegularizationImageFilter.h
@@ -72,7 +72,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT DePierroRegularizationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DePierroRegularizationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDeconstructImageFilter.h
+++ b/include/rtkDeconstructImageFilter.h
@@ -125,7 +125,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TImage>
-class DeconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT DeconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
+++ b/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
@@ -44,7 +44,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TImage>
-class DeconstructSoftThresholdReconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT DeconstructSoftThresholdReconstructImageFilter
+  : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDenoisingBPDQImageFilter.h
+++ b/include/rtkDenoisingBPDQImageFilter.h
@@ -38,7 +38,7 @@ namespace rtk
  */
 
 template <typename TOutputImage, typename TGradientImage>
-class DenoisingBPDQImageFilter : public itk::InPlaceImageFilter<TOutputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DenoisingBPDQImageFilter : public itk::InPlaceImageFilter<TOutputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDigisensGeometryXMLFileReader.h
+++ b/include/rtkDigisensGeometryXMLFileReader.h
@@ -19,6 +19,7 @@
 #ifndef rtkDigisensGeometryXMLFileReader_h
 #define rtkDigisensGeometryXMLFileReader_h
 
+#include "RTKExport.h"
 #include <itkXMLFile.h>
 #include <itkMetaDataDictionary.h>
 
@@ -38,7 +39,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class DigisensGeometryXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
+class RTK_EXPORT DigisensGeometryXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
@@ -38,7 +38,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT DisplacedDetectorForOffsetFieldOfViewImageFilter
+class ITK_TEMPLATE_EXPORT DisplacedDetectorForOffsetFieldOfViewImageFilter
   : public rtk::DisplacedDetectorImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -57,7 +57,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT DisplacedDetectorImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DisplacedDetectorImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDivergenceOfGradientConjugateGradientOperator.h
+++ b/include/rtkDivergenceOfGradientConjugateGradientOperator.h
@@ -35,7 +35,7 @@ namespace rtk
  * \ingroup RTK IntensityImageFilters
  */
 template <class TInputImage>
-class DivergenceOfGradientConjugateGradientOperator : public ConjugateGradientOperator<TInputImage>
+class ITK_TEMPLATE_EXPORT DivergenceOfGradientConjugateGradientOperator : public ConjugateGradientOperator<TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDownsampleImageFilter.h
+++ b/include/rtkDownsampleImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT DownsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DownsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawBoxImageFilter.h
+++ b/include/rtkDrawBoxImageFilter.h
@@ -36,7 +36,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawBoxImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawBoxImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawConeImageFilter.h
+++ b/include/rtkDrawConeImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawConeImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawConeImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawConvexImageFilter.h
+++ b/include/rtkDrawConvexImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage>
-class DrawConvexImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawConvexImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawCylinderImageFilter.h
+++ b/include/rtkDrawCylinderImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawCylinderImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawCylinderImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawEllipsoidImageFilter.h
+++ b/include/rtkDrawEllipsoidImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawEllipsoidImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawEllipsoidImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawGeometricPhantomImageFilter.h
+++ b/include/rtkDrawGeometricPhantomImageFilter.h
@@ -36,7 +36,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawQuadricImageFilter.h
+++ b/include/rtkDrawQuadricImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class DrawQuadricImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawQuadricImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkDrawSheppLoganFilter.h
+++ b/include/rtkDrawSheppLoganFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT DrawSheppLoganFilter : public DrawGeometricPhantomImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT DrawSheppLoganFilter : public DrawGeometricPhantomImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkEdfImageIO.h
+++ b/include/rtkEdfImageIO.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <cstring>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -36,7 +37,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class EdfImageIO : public itk::ImageIOBase
+class RTK_EXPORT EdfImageIO : public itk::ImageIOBase
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkElektaSynergyLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyLookupTableImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TOutputImage>
-class ITK_EXPORT ElektaSynergyLookupTableImageFilter
+class ITK_TEMPLATE_EXPORT ElektaSynergyLookupTableImageFilter
   : public LookupTableImageFilter<itk::Image<unsigned short, TOutputImage::ImageDimension>, TOutputImage>
 {
 public:

--- a/include/rtkElektaSynergyRawLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyRawLookupTableImageFilter.h
@@ -39,7 +39,8 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage = itk::Image<unsigned short, 2>, class TOutputImage = itk::Image<unsigned short, 2>>
-class ITK_EXPORT ElektaSynergyRawLookupTableImageFilter : public LookupTableImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ElektaSynergyRawLookupTableImageFilter
+  : public LookupTableImageFilter<TInputImage, TOutputImage>
 {
 
 public:

--- a/include/rtkExtractPhaseImageFilter.h
+++ b/include/rtkExtractPhaseImageFilter.h
@@ -44,7 +44,7 @@ namespace rtk
  */
 
 template <class TImage>
-class ITK_EXPORT ExtractPhaseImageFilter : public itk::InPlaceImageFilter<TImage>
+class ITK_TEMPLATE_EXPORT ExtractPhaseImageFilter : public itk::InPlaceImageFilter<TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFDKBackProjectionImageFilter.h
+++ b/include/rtkFDKBackProjectionImageFilter.h
@@ -36,7 +36,7 @@ namespace rtk
  * \ingroup RTK Projector
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT FDKBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FDKBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -60,7 +60,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecision = double>
-class ITK_EXPORT FDKConeBeamReconstructionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FDKConeBeamReconstructionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFDKWarpBackProjectionImageFilter.h
+++ b/include/rtkFDKWarpBackProjectionImageFilter.h
@@ -43,7 +43,8 @@ namespace rtk
  * \ingroup RTK Projector
  */
 template <class TInputImage, class TOutputImage, class TDeformation>
-class ITK_EXPORT FDKWarpBackProjectionImageFilter : public FDKBackProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FDKWarpBackProjectionImageFilter
+  : public FDKBackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFDKWeightProjectionFilter.h
+++ b/include/rtkFDKWeightProjectionFilter.h
@@ -48,7 +48,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT FDKWeightProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FDKWeightProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -42,7 +42,8 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
-class ITK_EXPORT FFTProjectionsConvolutionImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FFTProjectionsConvolutionImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFFTRampImageFilter.h
+++ b/include/rtkFFTRampImageFilter.h
@@ -58,7 +58,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecision = double>
-class ITK_EXPORT FFTRampImageFilter
+class ITK_TEMPLATE_EXPORT FFTRampImageFilter
   : public rtk::FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 public:

--- a/include/rtkFieldOfViewImageFilter.h
+++ b/include/rtkFieldOfViewImageFilter.h
@@ -45,7 +45,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT FieldOfViewImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT FieldOfViewImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkForbildPhantomFileReader.h
+++ b/include/rtkForbildPhantomFileReader.h
@@ -19,6 +19,7 @@
 #ifndef rtkForbildPhantomFileReader_h
 #define rtkForbildPhantomFileReader_h
 
+#include "RTKExport.h"
 #include <itkLightProcessObject.h>
 #include "rtkGeometricPhantom.h"
 

--- a/include/rtkForwardDifferenceGradientImageFilter.h
+++ b/include/rtkForwardDifferenceGradientImageFilter.h
@@ -52,7 +52,8 @@ template <typename TInputImage,
           typename TOuputValue = float,
           typename TOuputImage =
             itk::Image<itk::CovariantVector<TOuputValue, TInputImage::ImageDimension>, TInputImage::ImageDimension>>
-class ForwardDifferenceGradientImageFilter : public itk::ImageToImageFilter<TInputImage, TOuputImage>
+class ITK_TEMPLATE_EXPORT ForwardDifferenceGradientImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TOuputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkForwardProjectionImageFilter.h
+++ b/include/rtkForwardProjectionImageFilter.h
@@ -34,7 +34,7 @@ namespace rtk
  * \ingroup RTK Projector
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ForwardProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ForwardProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkForwardWarpImageFilter.h
+++ b/include/rtkForwardWarpImageFilter.h
@@ -42,7 +42,7 @@ template <class TInputImage,
           class TOutputImage = TInputImage,
           class TDVF = itk::Image<itk::CovariantVector<typename TInputImage::PixelType, TInputImage::ImageDimension>,
                                   TInputImage::ImageDimension>>
-class ForwardWarpImageFilter : public itk::WarpImageFilter<TInputImage, TOutputImage, TDVF>
+class ITK_TEMPLATE_EXPORT ForwardWarpImageFilter : public itk::WarpImageFilter<TInputImage, TOutputImage, TDVF>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -93,7 +93,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class ITK_EXPORT FourDConjugateGradientConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT FourDConjugateGradientConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -204,7 +204,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class FourDROOSTERConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT FourDROOSTERConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -127,7 +127,8 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class FourDReconstructionConjugateGradientOperator : public ConjugateGradientOperator<VolumeSeriesType>
+class ITK_TEMPLATE_EXPORT FourDReconstructionConjugateGradientOperator
+  : public ConjugateGradientOperator<VolumeSeriesType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -119,7 +119,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class VolumeSeriesType, class ProjectionStackType>
-class ITK_EXPORT FourDSARTConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT FourDSARTConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkFourDToProjectionStackImageFilter.h
+++ b/include/rtkFourDToProjectionStackImageFilter.h
@@ -97,7 +97,8 @@ namespace rtk
  */
 
 template <typename ProjectionStackType, typename VolumeSeriesType>
-class FourDToProjectionStackImageFilter : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
+class ITK_TEMPLATE_EXPORT FourDToProjectionStackImageFilter
+  : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkGeometricPhantom.h
+++ b/include/rtkGeometricPhantom.h
@@ -19,6 +19,7 @@
 #ifndef rtkGeometricPhantom_h
 #define rtkGeometricPhantom_h
 
+#include "RTKExport.h"
 #include "rtkConvexShape.h"
 
 namespace rtk

--- a/include/rtkGeometricPhantomFileReader.h
+++ b/include/rtkGeometricPhantomFileReader.h
@@ -19,6 +19,7 @@
 #ifndef rtkGeometricPhantomFileReader_h
 #define rtkGeometricPhantomFileReader_h
 
+#include "RTKExport.h"
 #include <itkLightProcessObject.h>
 #include "rtkGeometricPhantom.h"
 

--- a/include/rtkGetNewtonUpdateImageFilter.h
+++ b/include/rtkGetNewtonUpdateImageFilter.h
@@ -42,7 +42,7 @@ template <class TGradient,
           class THessian = itk::Image<itk::Vector<typename TGradient::PixelType::ValueType,
                                                   TGradient::PixelType::Dimension * TGradient::PixelType::Dimension>,
                                       TGradient::ImageDimension>>
-class GetNewtonUpdateImageFilter : public itk::ImageToImageFilter<TGradient, TGradient>
+class ITK_TEMPLATE_EXPORT GetNewtonUpdateImageFilter : public itk::ImageToImageFilter<TGradient, TGradient>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkGgoArgsInfoManager.h
+++ b/include/rtkGgoArgsInfoManager.h
@@ -32,7 +32,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TArgsInfo, class TCleanupFunction = void (*)(TArgsInfo *)>
-class args_info_manager
+class ITK_TEMPLATE_EXPORT args_info_manager
 {
 public:
   args_info_manager(TArgsInfo & args_info, TCleanupFunction cf)

--- a/include/rtkHilbertImageFilter.h
+++ b/include/rtkHilbertImageFilter.h
@@ -41,7 +41,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT HilbertImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT HilbertImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkHisImageIO.h
+++ b/include/rtkHisImageIO.h
@@ -21,6 +21,7 @@
 
 // itk include
 #include <itkImageIOBase.h>
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -35,7 +36,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class HisImageIO : public itk::ImageIOBase
+class RTK_EXPORT HisImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkHncImageIO.h
+++ b/include/rtkHncImageIO.h
@@ -30,6 +30,7 @@
 #  include <cstdint>
 #endif
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -43,7 +44,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class HncImageIO : public itk::ImageIOBase
+class RTK_EXPORT HncImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkHncImageIOFactory.h
+++ b/include/rtkHncImageIOFactory.h
@@ -38,7 +38,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class HncImageIOFactory : public itk::ObjectFactoryBase
+class RTK_EXPORT HncImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkHndImageIO.h
+++ b/include/rtkHndImageIO.h
@@ -29,8 +29,8 @@
 #  include <cstdint>
 #endif
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
-
 namespace rtk
 {
 
@@ -43,7 +43,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class HndImageIO : public itk::ImageIOBase
+class RTK_EXPORT HndImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkI0EstimationProjectionFilter.h
+++ b/include/rtkI0EstimationProjectionFilter.h
@@ -43,7 +43,7 @@ namespace rtk
 template <class TInputImage = itk::Image<unsigned short, 3>,
           class TOutputImage = TInputImage,
           unsigned char bitShift = 2>
-class ITK_EXPORT I0EstimationProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT I0EstimationProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkImagXGeometryReader.h
+++ b/include/rtkImagXGeometryReader.h
@@ -38,7 +38,7 @@ namespace rtk
  * \ingroup RTK IOFilters
  */
 template <typename TInputImage>
-class ImagXGeometryReader : public itk::LightProcessObject
+class ITK_TEMPLATE_EXPORT ImagXGeometryReader : public itk::LightProcessObject
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkImagXImageIO.h
+++ b/include/rtkImagXImageIO.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <cstring>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -34,7 +35,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class ImagXImageIO : public itk::ImageIOBase
+class RTK_EXPORT ImagXImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkImagXXMLFileReader.h
+++ b/include/rtkImagXXMLFileReader.h
@@ -28,6 +28,7 @@
 
 #include <map>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -39,7 +40,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class ImagXXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
+class RTK_EXPORT ImagXXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkImageToVectorImageFilter.h
+++ b/include/rtkImageToVectorImageFilter.h
@@ -44,7 +44,7 @@ namespace rtk
  */
 
 template <typename InputImageType, typename OutputImageType>
-class ImageToVectorImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
+class ITK_TEMPLATE_EXPORT ImageToVectorImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkImportImageFilter.h
+++ b/include/rtkImportImageFilter.h
@@ -41,7 +41,7 @@ namespace rtk
  **/
 
 template <typename TImage>
-class ImportImageFilter : public itk::ImageSource<TImage>
+class ITK_TEMPLATE_EXPORT ImportImageFilter : public itk::ImageSource<TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkInterpolatorWithKnownWeightsImageFilter.h
+++ b/include/rtkInterpolatorWithKnownWeightsImageFilter.h
@@ -61,7 +61,8 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <typename VolumeType, typename VolumeSeriesType>
-class InterpolatorWithKnownWeightsImageFilter : public itk::InPlaceImageFilter<VolumeType, VolumeType>
+class ITK_TEMPLATE_EXPORT InterpolatorWithKnownWeightsImageFilter
+  : public itk::InPlaceImageFilter<VolumeType, VolumeType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkIterationCommands.h
+++ b/include/rtkIterationCommands.h
@@ -35,7 +35,7 @@ namespace rtk
  *
  */
 template <typename TCaller>
-class IterationCommand : public itk::Command
+class ITK_TEMPLATE_EXPORT IterationCommand : public itk::Command
 {
 public:
   /** Standard class typedefs. */
@@ -100,7 +100,7 @@ protected:
  *
  */
 template <typename TCaller>
-class VerboseIterationCommand : public IterationCommand<TCaller>
+class ITK_TEMPLATE_EXPORT VerboseIterationCommand : public IterationCommand<TCaller>
 {
 public:
   /** Standard class typedefs. */
@@ -136,7 +136,7 @@ protected:
  *
  */
 template <typename TCaller, typename TOutputImage>
-class OutputIterationCommand : public IterationCommand<TCaller>
+class ITK_TEMPLATE_EXPORT OutputIterationCommand : public IterationCommand<TCaller>
 {
 public:
   /** Standard class typedefs. */

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -54,7 +54,8 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TOutputImage, class ProjectionStackType = TOutputImage>
-class ITK_EXPORT IterativeConeBeamReconstructionFilter : public itk::ImageToImageFilter<TOutputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT IterativeConeBeamReconstructionFilter
+  : public itk::ImageToImageFilter<TOutputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -104,7 +104,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecision = double>
-class ITK_EXPORT IterativeFDKConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT IterativeFDKConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TInputImage, TOutputImage>
 {
 public:

--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.h
@@ -36,7 +36,7 @@ namespace Functor
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TInput>
-class InterpolationWeightMultiplicationAttenuatedBackProjection
+class ITK_TEMPLATE_EXPORT InterpolationWeightMultiplicationAttenuatedBackProjection
 {
 public:
   InterpolationWeightMultiplicationAttenuatedBackProjection() { m_AttenuationPixel = 0; }
@@ -87,7 +87,7 @@ private:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ComputeAttenuationCorrectionBackProjection
+class ITK_TEMPLATE_EXPORT ComputeAttenuationCorrectionBackProjection
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -151,7 +151,7 @@ private:
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TCoordRepType>
-class SplatWeightMultiplicationAttenuated
+class ITK_TEMPLATE_EXPORT SplatWeightMultiplicationAttenuated
 {
 public:
   SplatWeightMultiplicationAttenuated() = default;
@@ -204,7 +204,7 @@ template <
     SplatWeightMultiplicationAttenuated<typename TInputImage::PixelType, double, typename TOutputImage::PixelType>,
   class TSumAlongRay = Functor::ComputeAttenuationCorrectionBackProjection<typename TInputImage::PixelType,
                                                                            typename TOutputImage::PixelType>>
-class ITK_EXPORT JosephBackAttenuatedProjectionImageFilter
+class ITK_TEMPLATE_EXPORT JosephBackAttenuatedProjectionImageFilter
   : public JosephBackProjectionImageFilter<TInputImage,
                                            TOutputImage,
                                            TInterpolationWeightMultiplication,

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -38,7 +38,7 @@ namespace Functor
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TInput>
-class InterpolationWeightMultiplicationBackProjection
+class ITK_TEMPLATE_EXPORT InterpolationWeightMultiplicationBackProjection
 {
 public:
   InterpolationWeightMultiplicationBackProjection() = default;
@@ -72,7 +72,7 @@ public:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ValueAlongRay
+class ITK_TEMPLATE_EXPORT ValueAlongRay
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -108,7 +108,7 @@ public:
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TCoordRepType>
-class SplatWeightMultiplication
+class ITK_TEMPLATE_EXPORT SplatWeightMultiplication
 {
 public:
   SplatWeightMultiplication() = default;
@@ -161,7 +161,7 @@ template <
   class TSplatWeightMultiplication =
     Functor::SplatWeightMultiplication<typename TInputImage::PixelType, double, typename TOutputImage::PixelType>,
   class TSumAlongRay = Functor::ValueAlongRay<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
-class ITK_EXPORT JosephBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT JosephBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -40,7 +40,7 @@ namespace Functor
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TInput>
-class InterpolationWeightMultiplicationAttenuated
+class ITK_TEMPLATE_EXPORT InterpolationWeightMultiplicationAttenuated
 {
 public:
   InterpolationWeightMultiplicationAttenuated()
@@ -116,7 +116,7 @@ private:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ComputeAttenuationCorrection
+class ITK_TEMPLATE_EXPORT ComputeAttenuationCorrection
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -185,7 +185,7 @@ private:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ProjectedValueAccumulationAttenuated
+class ITK_TEMPLATE_EXPORT ProjectedValueAccumulationAttenuated
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -262,7 +262,7 @@ template <
     Functor::ProjectedValueAccumulationAttenuated<typename TInputImage::PixelType, typename TOutputImage::PixelType>,
   class TSumAlongRay =
     Functor::ComputeAttenuationCorrection<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
-class ITK_EXPORT JosephForwardAttenuatedProjectionImageFilter
+class ITK_TEMPLATE_EXPORT JosephForwardAttenuatedProjectionImageFilter
   : public JosephForwardProjectionImageFilter<TInputImage,
                                               TOutputImage,
                                               TInterpolationWeightMultiplication,

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -40,7 +40,7 @@ namespace Functor
  * \ingroup RTK Functions
  */
 template <class TInput, class TCoordRepType, class TOutput = TInput>
-class InterpolationWeightMultiplication
+class ITK_TEMPLATE_EXPORT InterpolationWeightMultiplication
 {
 public:
   InterpolationWeightMultiplication() = default;
@@ -75,7 +75,7 @@ public:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class SumAlongRay
+class ITK_TEMPLATE_EXPORT SumAlongRay
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -108,7 +108,7 @@ public:
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ProjectedValueAccumulation
+class ITK_TEMPLATE_EXPORT ProjectedValueAccumulation
 {
 public:
   using VectorType = itk::Vector<double, 3>;
@@ -167,7 +167,8 @@ template <class TInputImage,
           class TProjectedValueAccumulation =
             Functor::ProjectedValueAccumulation<typename TInputImage::PixelType, typename TOutputImage::PixelType>,
           class TSumAlongRay = Functor::SumAlongRay<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
-class ITK_EXPORT JosephForwardProjectionImageFilter : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT JosephForwardProjectionImageFilter
+  : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
@@ -75,7 +75,8 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage>
-class LUTbasedVariableI0RawToAttenuationImageFilter : public LookupTableImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT LUTbasedVariableI0RawToAttenuationImageFilter
+  : public LookupTableImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkLagCorrectionImageFilter.h
+++ b/include/rtkLagCorrectionImageFilter.h
@@ -52,7 +52,7 @@ namespace rtk
  */
 
 template <typename TImage, unsigned VModelOrder>
-class LagCorrectionImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT LagCorrectionImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkLaplacianImageFilter.h
+++ b/include/rtkLaplacianImageFilter.h
@@ -38,7 +38,7 @@ namespace rtk
  */
 
 template <typename OutputImageType, typename GradientImageType>
-class LaplacianImageFilter : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
+class ITK_TEMPLATE_EXPORT LaplacianImageFilter : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
+++ b/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
@@ -40,7 +40,8 @@ namespace rtk
  */
 template <class TInputImage>
 
-class LastDimensionL0GradientDenoisingImageFilter : public itk::InPlaceImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT LastDimensionL0GradientDenoisingImageFilter
+  : public itk::InPlaceImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkLookupTableImageFilter.h
+++ b/include/rtkLookupTableImageFilter.h
@@ -44,7 +44,7 @@ namespace Functor
 {
 
 template <class TInput, class TOutput>
-class LUT
+class ITK_TEMPLATE_EXPORT LUT
 {
 public:
   using LookupTableType = itk::Image<TOutput, 1>;
@@ -141,7 +141,7 @@ LUT<double, double>::operator()(const double & val) const
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LookupTableImageFilter
+class ITK_TEMPLATE_EXPORT LookupTableImageFilter
   : public itk::UnaryFunctorImageFilter<TInputImage,
                                         TOutputImage,
                                         Functor::LUT<typename TInputImage::PixelType, typename TOutputImage::PixelType>>

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TInputImage, typename TRealType = float, typename TOutputImage = TInputImage>
-class ITK_EXPORT MagnitudeThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT MagnitudeThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkMaskCollimationImageFilter.h
+++ b/include/rtkMaskCollimationImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT MaskCollimationImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT MaskCollimationImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -143,7 +143,7 @@ namespace rtk
  */
 
 template <typename TOutputImage, typename TPhotonCounts, typename TSpectrum>
-class MechlemOneStepSpectralReconstructionFilter
+class ITK_TEMPLATE_EXPORT MechlemOneStepSpectralReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:

--- a/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -67,7 +67,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class ITK_EXPORT MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter
   : public rtk::FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
@@ -136,7 +136,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class MotionCompensatedFourDROOSTERConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT MotionCompensatedFourDROOSTERConeBeamReconstructionFilter
   : public rtk::FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -97,7 +97,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class MotionCompensatedFourDReconstructionConjugateGradientOperator
+class ITK_TEMPLATE_EXPORT MotionCompensatedFourDReconstructionConjugateGradientOperator
   : public FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkMultiplyByVectorImageFilter.h
+++ b/include/rtkMultiplyByVectorImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  *
  */
 template <class TInputImage>
-class MultiplyByVectorImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT MultiplyByVectorImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkNesterovUpdateImageFilter.h
+++ b/include/rtkNesterovUpdateImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  */
 
 template <typename TImage>
-class NesterovUpdateImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT NesterovUpdateImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -115,7 +115,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TVolumeImage, class TProjectionImage = TVolumeImage>
-class ITK_EXPORT OSEMConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT OSEMConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 {
 public:

--- a/include/rtkOraImageIO.h
+++ b/include/rtkOraImageIO.h
@@ -26,6 +26,7 @@
 
 #include <itkMetaImageIO.h>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -41,7 +42,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class OraImageIO : public itk::MetaImageIO
+class RTK_EXPORT OraImageIO : public itk::MetaImageIO
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkOraLookupTableImageFilter.h
+++ b/include/rtkOraLookupTableImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TOutputImage>
-class ITK_EXPORT OraLookupTableImageFilter
+class ITK_TEMPLATE_EXPORT OraLookupTableImageFilter
   : public LookupTableImageFilter<itk::Image<unsigned short, TOutputImage::ImageDimension>, TOutputImage>
 {
 public:

--- a/include/rtkOraXMLFileReader.h
+++ b/include/rtkOraXMLFileReader.h
@@ -23,6 +23,7 @@
 #include <itkMetaDataDictionary.h>
 #include <itkMetaDataObject.h>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -36,7 +37,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class OraXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
+class RTK_EXPORT OraXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkParkerShortScanImageFilter.h
+++ b/include/rtkParkerShortScanImageFilter.h
@@ -44,7 +44,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT ParkerShortScanImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ParkerShortScanImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkPhaseGatingImageFilter.h
+++ b/include/rtkPhaseGatingImageFilter.h
@@ -31,7 +31,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename ProjectionStackType>
-class PhaseGatingImageFilter : public SubSelectImageFilter<ProjectionStackType>
+class ITK_TEMPLATE_EXPORT PhaseGatingImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkPhaseReader.h
+++ b/include/rtkPhaseReader.h
@@ -18,6 +18,7 @@
 #ifndef rtkPhaseReader_h
 #define rtkPhaseReader_h
 
+#include "RTKExport.h"
 #include <itkCSVFileReaderBase.h>
 
 namespace rtk
@@ -31,7 +32,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class ITK_EXPORT PhaseReader : public itk::CSVFileReaderBase
+class RTK_EXPORT PhaseReader : public itk::CSVFileReaderBase
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
@@ -83,9 +84,5 @@ private:
 };
 
 } // end namespace rtk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "rtkPhaseReader.hxx"
-#endif
 
 #endif

--- a/include/rtkPhasesToInterpolationWeights.h
+++ b/include/rtkPhasesToInterpolationWeights.h
@@ -19,6 +19,7 @@
 #ifndef rtkPhasesToInterpolationWeights_h
 #define rtkPhasesToInterpolationWeights_h
 
+#include "RTKExport.h"
 #include "itkCSVFileReaderBase.h"
 #include "itkArray2D.h"
 
@@ -36,7 +37,7 @@ namespace rtk
  * \ingroup RTK
  */
 
-class ITK_EXPORT PhasesToInterpolationWeights : public itk::CSVFileReaderBase
+class RTK_EXPORT PhasesToInterpolationWeights : public itk::CSVFileReaderBase
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
@@ -111,9 +112,5 @@ private:
 };
 
 } // end namespace rtk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "rtkPhasesToInterpolationWeights.hxx"
-#endif
 
 #endif

--- a/include/rtkPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkPolynomialGainCorrectionImageFilter.h
@@ -41,7 +41,8 @@ namespace rtk
 {
 
 template <class TInputImage, class TOutputImage>
-class PolynomialGainCorrectionImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT PolynomialGainCorrectionImageFilter
+  : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkProgressCommands.h
+++ b/include/rtkProgressCommands.h
@@ -34,7 +34,7 @@ namespace rtk
  *
  */
 template <typename TCaller>
-class ProgressCommand : public itk::Command
+class ITK_TEMPLATE_EXPORT ProgressCommand : public itk::Command
 {
 public:
   /** Standard class typedefs. */
@@ -88,7 +88,7 @@ protected:
  *
  */
 template <typename TCaller>
-class PercentageProgressCommand : public ProgressCommand<TCaller>
+class ITK_TEMPLATE_EXPORT PercentageProgressCommand : public ProgressCommand<TCaller>
 {
 public:
   /** Standard class typedefs. */

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ProjectGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ProjectGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkProjectionGeometry.h
+++ b/include/rtkProjectionGeometry.h
@@ -41,7 +41,7 @@ namespace rtk
  * \ingroup RTK Geometry
  */
 template <unsigned int TDimension = 3>
-class ProjectionGeometry : public itk::DataObject
+class ITK_TEMPLATE_EXPORT ProjectionGeometry : public itk::DataObject
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -102,7 +102,8 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType, typename TFFTPrecision = double>
-class ProjectionStackToFourDImageFilter : public itk::ImageToImageFilter<VolumeSeriesType, VolumeSeriesType>
+class ITK_TEMPLATE_EXPORT ProjectionStackToFourDImageFilter
+  : public itk::ImageToImageFilter<VolumeSeriesType, VolumeSeriesType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -122,7 +122,7 @@ namespace rtk
  * \ingroup RTK ImageSource
  */
 template <class TOutputImage>
-class ITK_EXPORT ProjectionsReader : public itk::ImageSource<TOutputImage>
+class ITK_TEMPLATE_EXPORT ProjectionsReader : public itk::ImageSource<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkProjectionsRegionConstIteratorRayBased.h
+++ b/include/rtkProjectionsRegionConstIteratorRayBased.h
@@ -51,7 +51,7 @@ template <typename TImage>
 class ProjectionsRegionConstIteratorRayBasedParallel;
 
 template <typename TImage>
-class ProjectionsRegionConstIteratorRayBased : public itk::ImageConstIteratorWithIndex<TImage>
+class ITK_TEMPLATE_EXPORT ProjectionsRegionConstIteratorRayBased : public itk::ImageConstIteratorWithIndex<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkProjectionsRegionConstIteratorRayBasedParallel.h
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedParallel.h
@@ -32,7 +32,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TImage>
-class ProjectionsRegionConstIteratorRayBasedParallel : public ProjectionsRegionConstIteratorRayBased<TImage>
+class ITK_TEMPLATE_EXPORT ProjectionsRegionConstIteratorRayBasedParallel
+  : public ProjectionsRegionConstIteratorRayBased<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.h
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.h
@@ -32,7 +32,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TImage>
-class ProjectionsRegionConstIteratorRayBasedWithCylindricalPanel : public ProjectionsRegionConstIteratorRayBased<TImage>
+class ITK_TEMPLATE_EXPORT ProjectionsRegionConstIteratorRayBasedWithCylindricalPanel
+  : public ProjectionsRegionConstIteratorRayBased<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.h
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.h
@@ -32,7 +32,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TImage>
-class ProjectionsRegionConstIteratorRayBasedWithFlatPanel : public ProjectionsRegionConstIteratorRayBased<TImage>
+class ITK_TEMPLATE_EXPORT ProjectionsRegionConstIteratorRayBasedWithFlatPanel
+  : public ProjectionsRegionConstIteratorRayBased<TImage>
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkRayBoxIntersectionImageFilter.h
+++ b/include/rtkRayBoxIntersectionImageFilter.h
@@ -36,7 +36,8 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class RayBoxIntersectionImageFilter : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT RayBoxIntersectionImageFilter
+  : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkRayConvexIntersectionImageFilter.h
+++ b/include/rtkRayConvexIntersectionImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class RayConvexIntersectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT RayConvexIntersectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkRayEllipsoidIntersectionImageFilter.h
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.h
@@ -40,7 +40,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT RayEllipsoidIntersectionImageFilter
+class ITK_TEMPLATE_EXPORT RayEllipsoidIntersectionImageFilter
   : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/include/rtkRayQuadricIntersectionImageFilter.h
+++ b/include/rtkRayQuadricIntersectionImageFilter.h
@@ -35,7 +35,8 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class RayQuadricIntersectionImageFilter : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT RayQuadricIntersectionImageFilter
+  : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkReconstructImageFilter.h
+++ b/include/rtkReconstructImageFilter.h
@@ -120,7 +120,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TImage>
-class ReconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT ReconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -115,7 +115,7 @@ namespace rtk
  */
 
 template <typename TOutputImage, typename TSingleComponentImage = TOutputImage, typename TWeightsImage = TOutputImage>
-class ReconstructionConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
+class ITK_TEMPLATE_EXPORT ReconstructionConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkReg1DExtractShroudSignalImageFilter.h
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.h
@@ -35,7 +35,7 @@ namespace rtk
  */
 
 template <class TInputPixel, class TOutputPixel>
-class ITK_EXPORT Reg1DExtractShroudSignalImageFilter
+class ITK_TEMPLATE_EXPORT Reg1DExtractShroudSignalImageFilter
   : public itk::ImageToImageFilter<itk::Image<TInputPixel, 2>, itk::Image<TOutputPixel, 1>>
 {
 public:

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -104,7 +104,7 @@ namespace rtk
  */
 
 template <typename TImage>
-class RegularizedConjugateGradientConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT RegularizedConjugateGradientConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TImage, TImage>
 {
 public:

--- a/include/rtkReorderProjectionsImageFilter.h
+++ b/include/rtkReorderProjectionsImageFilter.h
@@ -42,7 +42,7 @@ namespace rtk
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT ReorderProjectionsImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ReorderProjectionsImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkResourceProbesCollector.h
+++ b/include/rtkResourceProbesCollector.h
@@ -19,6 +19,7 @@
 #ifndef rtkResourceProbesCollector_h
 #define rtkResourceProbesCollector_h
 
+#include "RTKExport.h"
 #include "rtkConfiguration.h"
 #include <itkTimeProbe.h>
 #include <itkMemoryProbe.h>
@@ -34,7 +35,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class ResourceProbesCollector
+class RTK_EXPORT ResourceProbesCollector
 {
 public:
   using IdType = std::string;

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -132,7 +132,7 @@ namespace rtk
  * \ingroup RTK ReconstructionAlgorithm
  */
 template <class TVolumeImage, class TProjectionImage = TVolumeImage>
-class ITK_EXPORT SARTConeBeamReconstructionFilter
+class ITK_TEMPLATE_EXPORT SARTConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 {
 public:

--- a/include/rtkScatterGlareCorrectionImageFilter.h
+++ b/include/rtkScatterGlareCorrectionImageFilter.h
@@ -39,7 +39,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecision = double>
-class ITK_EXPORT ScatterGlareCorrectionImageFilter
+class ITK_TEMPLATE_EXPORT ScatterGlareCorrectionImageFilter
   : public rtk::FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 public:

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.h
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.h
@@ -36,7 +36,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename ProjectionStackType>
-class SelectOneProjectionPerCycleImageFilter : public SubSelectImageFilter<ProjectionStackType>
+class ITK_TEMPLATE_EXPORT SelectOneProjectionPerCycleImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
+++ b/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
@@ -41,7 +41,8 @@ namespace rtk
  */
 
 template <typename TImage>
-class SeparableQuadraticSurrogateRegularizationImageFilter : public itk::ImageToImageFilter<TImage, TImage>
+class ITK_TEMPLATE_EXPORT SeparableQuadraticSurrogateRegularizationImageFilter
+  : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSheppLoganPhantom.h
+++ b/include/rtkSheppLoganPhantom.h
@@ -19,6 +19,7 @@
 #ifndef rtkSheppLoganPhantom_h
 #define rtkSheppLoganPhantom_h
 
+#include "RTKExport.h"
 #include "rtkGeometricPhantom.h"
 #include "rtkQuadricShape.h"
 

--- a/include/rtkSheppLoganPhantomFilter.h
+++ b/include/rtkSheppLoganPhantomFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  * \ingroup RTK InPlaceImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT SheppLoganPhantomFilter : public ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SheppLoganPhantomFilter : public ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSignalToInterpolationWeights.h
+++ b/include/rtkSignalToInterpolationWeights.h
@@ -19,6 +19,7 @@
 #ifndef rtkSignalToInterpolationWeights_h
 #define rtkSignalToInterpolationWeights_h
 
+#include "RTKExport.h"
 #include "itkCSVFileReaderBase.h"
 #include "itkArray2D.h"
 
@@ -36,7 +37,7 @@ namespace rtk
  * \ingroup RTK
  */
 
-class ITK_EXPORT SignalToInterpolationWeights : public itk::CSVFileReaderBase
+class RTK_EXPORT SignalToInterpolationWeights : public itk::CSVFileReaderBase
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
@@ -100,9 +101,5 @@ private:
 };
 
 } // end namespace rtk
-
-#ifndef ITK_MANUAL_INSTANTIATION
-#  include "rtkSignalToInterpolationWeights.hxx"
-#endif
 
 #endif

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
@@ -42,7 +42,7 @@ template <typename DecomposedProjectionsType,
           typename IncidentSpectrumImageType = itk::VectorImage<float, 2>,
           typename DetectorResponseImageType = itk::Image<float, 2>,
           typename MaterialAttenuationsImageType = itk::Image<float, 2>>
-class ITK_EXPORT SimplexSpectralProjectionsDecompositionImageFilter
+class ITK_TEMPLATE_EXPORT SimplexSpectralProjectionsDecompositionImageFilter
   : public itk::ImageToImageFilter<DecomposedProjectionsType, DecomposedProjectionsType>
 {
 public:

--- a/include/rtkSingularValueThresholdImageFilter.h
+++ b/include/rtkSingularValueThresholdImageFilter.h
@@ -47,7 +47,7 @@ namespace rtk
  *
  */
 template <typename TInputImage, typename TRealType = float, typename TOutputImage = TInputImage>
-class ITK_EXPORT SingularValueThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SingularValueThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSoftThresholdImageFilter.h
+++ b/include/rtkSoftThresholdImageFilter.h
@@ -41,7 +41,7 @@ namespace Functor
 {
 
 template <class TInput, class TOutput>
-class SoftThreshold
+class ITK_TEMPLATE_EXPORT SoftThreshold
 {
 public:
   SoftThreshold() { m_Threshold = itk::NumericTraits<TInput>::Zero; }
@@ -80,7 +80,7 @@ private:
 } // namespace Functor
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT SoftThresholdImageFilter
+class ITK_TEMPLATE_EXPORT SoftThresholdImageFilter
   : public itk::UnaryFunctorImageFilter<
       TInputImage,
       TOutputImage,

--- a/include/rtkSoftThresholdTVImageFilter.h
+++ b/include/rtkSoftThresholdTVImageFilter.h
@@ -42,7 +42,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename TInputImage, typename TOutputImage = TInputImage>
-class ITK_EXPORT SoftThresholdTVImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT SoftThresholdTVImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -44,7 +44,7 @@ template <typename DecomposedProjectionsType,
           typename IncidentSpectrumImageType = itk::VectorImage<float, 2>,
           typename DetectorResponseImageType = itk::Image<float, 2>,
           typename MaterialAttenuationsImageType = itk::Image<float, 2>>
-class ITK_EXPORT SpectralForwardModelImageFilter
+class ITK_TEMPLATE_EXPORT SpectralForwardModelImageFilter
   : public itk::InPlaceImageFilter<MeasuredProjectionsType, MeasuredProjectionsType>
 {
 public:

--- a/include/rtkSplatWithKnownWeightsImageFilter.h
+++ b/include/rtkSplatWithKnownWeightsImageFilter.h
@@ -64,7 +64,8 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename VolumeType>
-class SplatWithKnownWeightsImageFilter : public itk::InPlaceImageFilter<VolumeSeriesType, VolumeSeriesType>
+class ITK_TEMPLATE_EXPORT SplatWithKnownWeightsImageFilter
+  : public itk::InPlaceImageFilter<VolumeSeriesType, VolumeSeriesType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSubSelectFromListImageFilter.h
+++ b/include/rtkSubSelectFromListImageFilter.h
@@ -30,7 +30,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename ProjectionStackType>
-class SubSelectFromListImageFilter : public SubSelectImageFilter<ProjectionStackType>
+class ITK_TEMPLATE_EXPORT SubSelectFromListImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSubSelectImageFilter.h
+++ b/include/rtkSubSelectImageFilter.h
@@ -61,7 +61,8 @@ namespace rtk
  * \ingroup RTK
  */
 template <typename ProjectionStackType>
-class SubSelectImageFilter : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
+class ITK_TEMPLATE_EXPORT SubSelectImageFilter
+  : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkSumOfSquaresImageFilter.h
+++ b/include/rtkSumOfSquaresImageFilter.h
@@ -34,7 +34,7 @@ namespace rtk
 {
 
 template <class TOutputImage>
-class ITK_EXPORT SumOfSquaresImageFilter : public itk::InPlaceImageFilter<TOutputImage>
+class ITK_TEMPLATE_EXPORT SumOfSquaresImageFilter : public itk::InPlaceImageFilter<TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
@@ -114,7 +114,8 @@ template <typename TOutputImage,
           typename TGradientImage =
             itk::Image<itk::CovariantVector<typename TOutputImage::ValueType, TOutputImage::ImageDimension - 1>,
                        TOutputImage::ImageDimension>>
-class TotalNuclearVariationDenoisingBPDQImageFilter : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
+class ITK_TEMPLATE_EXPORT TotalNuclearVariationDenoisingBPDQImageFilter
+  : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.h
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.h
@@ -76,7 +76,8 @@ namespace rtk
  */
 
 template <typename TImageSequence>
-class TotalVariationDenoiseSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
+class ITK_TEMPLATE_EXPORT TotalVariationDenoiseSequenceImageFilter
+  : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkTotalVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalVariationDenoisingBPDQImageFilter.h
@@ -110,7 +110,8 @@ template <typename TOutputImage,
           typename TGradientImage =
             itk::Image<itk::CovariantVector<typename TOutputImage::ValueType, TOutputImage::ImageDimension>,
                        TOutputImage::ImageDimension>>
-class TotalVariationDenoisingBPDQImageFilter : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
+class ITK_TEMPLATE_EXPORT TotalVariationDenoisingBPDQImageFilter
+  : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkTotalVariationImageFilter.h
+++ b/include/rtkTotalVariationImageFilter.h
@@ -47,7 +47,7 @@ namespace rtk
  */
 
 template <typename TInputImage>
-class TotalVariationImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
+class ITK_TEMPLATE_EXPORT TotalVariationImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkUnwarpSequenceConjugateGradientOperator.h
+++ b/include/rtkUnwarpSequenceConjugateGradientOperator.h
@@ -64,7 +64,7 @@ template <typename TImageSequence,
           typename TDVFImage =
             itk::Image<itk::CovariantVector<typename TImageSequence::ValueType, TImageSequence::ImageDimension - 1>,
                        TImageSequence::ImageDimension - 1>>
-class UnwarpSequenceConjugateGradientOperator : public ConjugateGradientOperator<TImageSequence>
+class ITK_TEMPLATE_EXPORT UnwarpSequenceConjugateGradientOperator : public ConjugateGradientOperator<TImageSequence>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkUnwarpSequenceImageFilter.h
+++ b/include/rtkUnwarpSequenceImageFilter.h
@@ -78,7 +78,7 @@ template <typename TImageSequence,
           typename TDVFImage =
             itk::Image<itk::CovariantVector<typename TImageSequence::ValueType, TImageSequence::ImageDimension - 1>,
                        TImageSequence::ImageDimension - 1>>
-class UnwarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
+class ITK_TEMPLATE_EXPORT UnwarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkUpsampleImageFilter.h
+++ b/include/rtkUpsampleImageFilter.h
@@ -36,7 +36,7 @@ namespace rtk
  * \ingroup RTK
  */
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT UpsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT UpsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkVarianObiGeometryReader.h
+++ b/include/rtkVarianObiGeometryReader.h
@@ -19,6 +19,7 @@
 #ifndef rtkVarianObiGeometryReader_h
 #define rtkVarianObiGeometryReader_h
 
+#include "RTKExport.h"
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"
 

--- a/include/rtkVarianObiRawImageFilter.h
+++ b/include/rtkVarianObiRawImageFilter.h
@@ -42,7 +42,7 @@ namespace Function
  * \ingroup RTK Functions
  */
 template <class TInput, class TOutput>
-class ObiAttenuation
+class ITK_TEMPLATE_EXPORT ObiAttenuation
 {
 public:
   ObiAttenuation() = default;
@@ -89,7 +89,7 @@ private:
  * \ingroup RTK ImageToImageFilter
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT VarianObiRawImageFilter
+class ITK_TEMPLATE_EXPORT VarianObiRawImageFilter
   : public itk::UnaryFunctorImageFilter<
       TInputImage,
       TOutputImage,

--- a/include/rtkVarianObiXMLFileReader.h
+++ b/include/rtkVarianObiXMLFileReader.h
@@ -27,6 +27,7 @@
 #include <itkMetaDataDictionary.h>
 #include <itkMetaDataObject.h>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -41,7 +42,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class VarianObiXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
+class RTK_EXPORT VarianObiXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkVarianProBeamGeometryReader.h
+++ b/include/rtkVarianProBeamGeometryReader.h
@@ -19,6 +19,7 @@
 #ifndef rtkVarianProBeamGeometryReader_h
 #define rtkVarianProBeamGeometryReader_h
 
+#include "RTKExport.h"
 #include <itkLightProcessObject.h>
 #include "rtkThreeDCircularProjectionGeometry.h"
 

--- a/include/rtkVarianProBeamXMLFileReader.h
+++ b/include/rtkVarianProBeamXMLFileReader.h
@@ -26,6 +26,7 @@
 #include <itkXMLFile.h>
 #include <itkMetaDataDictionary.h>
 #include <itkMetaDataObject.h>
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -40,7 +41,7 @@ namespace rtk
  *
  * \ingroup RTK
  */
-class VarianProBeamXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
+class RTK_EXPORT VarianProBeamXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkVectorImageToImageFilter.h
+++ b/include/rtkVectorImageToImageFilter.h
@@ -44,7 +44,7 @@ namespace rtk
  */
 
 template <typename InputImageType, typename OutputImageType>
-class VectorImageToImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
+class ITK_TEMPLATE_EXPORT VectorImageToImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.h
@@ -85,7 +85,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class WarpFourDToProjectionStackImageFilter
+class ITK_TEMPLATE_EXPORT WarpFourDToProjectionStackImageFilter
   : public rtk::FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>
 {
 public:

--- a/include/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/include/rtkWarpProjectionStackToFourDImageFilter.h
@@ -82,7 +82,7 @@ namespace rtk
  */
 
 template <typename VolumeSeriesType, typename ProjectionStackType>
-class WarpProjectionStackToFourDImageFilter
+class ITK_TEMPLATE_EXPORT WarpProjectionStackToFourDImageFilter
   : public ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:

--- a/include/rtkWarpSequenceImageFilter.h
+++ b/include/rtkWarpSequenceImageFilter.h
@@ -94,7 +94,7 @@ template <typename TImageSequence,
           typename TDVFImage =
             itk::Image<itk::CovariantVector<typename TImageSequence::ValueType, TImageSequence::ImageDimension - 1>,
                        TImageSequence::ImageDimension - 1>>
-class WarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
+class ITK_TEMPLATE_EXPORT WarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkWatcherForResourceProbe.h
+++ b/include/rtkWatcherForResourceProbe.h
@@ -18,6 +18,7 @@
 #ifndef rtkWatcherForResourceProbe_h
 #define rtkWatcherForResourceProbe_h
 
+#include "RTKExport.h"
 #include <itkCommand.h>
 #include <itkProcessObject.h>
 
@@ -34,7 +35,7 @@ namespace rtk
 
 using namespace itk;
 
-class WatcherForResourceProbe
+class RTK_EXPORT WatcherForResourceProbe
 {
 public:
   /** Constructor. Takes a ProcessObject to monitor and an optional

--- a/include/rtkWaterPrecorrectionImageFilter.h
+++ b/include/rtkWaterPrecorrectionImageFilter.h
@@ -37,7 +37,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT WaterPrecorrectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT WaterPrecorrectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkWeidingerForwardModelImageFilter.h
+++ b/include/rtkWeidingerForwardModelImageFilter.h
@@ -43,7 +43,8 @@ template <class TMaterialProjections,
           class TSpectrum,
           class TProjections =
             itk::Image<typename TMaterialProjections::PixelType::ValueType, TMaterialProjections::ImageDimension>>
-class WeidingerForwardModelImageFilter : public itk::ImageToImageFilter<TMaterialProjections, TMaterialProjections>
+class ITK_TEMPLATE_EXPORT WeidingerForwardModelImageFilter
+  : public itk::ImageToImageFilter<TMaterialProjections, TMaterialProjections>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkXRadImageIO.h
+++ b/include/rtkXRadImageIO.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <cstring>
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 namespace rtk
@@ -37,7 +38,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class XRadImageIO : public itk::ImageIOBase
+class RTK_EXPORT XRadImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkXRadRawToAttenuationImageFilter.h
+++ b/include/rtkXRadRawToAttenuationImageFilter.h
@@ -33,7 +33,7 @@ namespace rtk
 {
 
 template <class TInputImage, class TOutputImage = TInputImage>
-class ITK_EXPORT XRadRawToAttenuationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT XRadRawToAttenuationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
 #if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1

--- a/include/rtkXimImageIO.h
+++ b/include/rtkXimImageIO.h
@@ -19,6 +19,7 @@
 #ifndef rtkXimImageIO_h
 #define rtkXimImageIO_h
 
+#include "RTKExport.h"
 #include "rtkMacro.h"
 
 // itk include
@@ -43,7 +44,7 @@ namespace rtk
  *
  * \ingroup RTK IOFilters
  */
-class XimImageIO : public itk::ImageIOBase
+class RTK_EXPORT XimImageIO : public itk::ImageIOBase
 {
 public:
   /** Standard class type alias. */

--- a/include/rtkZengBackProjectionImageFilter.h
+++ b/include/rtkZengBackProjectionImageFilter.h
@@ -61,7 +61,7 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ZengBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ZengBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class usings. */

--- a/include/rtkZengForwardProjectionImageFilter.h
+++ b/include/rtkZengForwardProjectionImageFilter.h
@@ -58,7 +58,8 @@ namespace rtk
  */
 
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ZengForwardProjectionImageFilter : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
+class ITK_TEMPLATE_EXPORT ZengForwardProjectionImageFilter
+  : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class usings. */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,9 +31,12 @@ set(RTK_SRCS
   rtkOraImageIO.cxx
   rtkOraImageIOFactory.cxx
   rtkOraXMLFileReader.cxx
+  rtkPhaseReader.cxx
+  rtkPhasesToInterpolationWeights.cxx
   rtkQuadricShape.cxx
   rtkReg23ProjectionGeometry.cxx
   rtkSheppLoganPhantom.cxx
+  rtkSignalToInterpolationWeights.cxx
   rtkThreeDCircularProjectionGeometry.cxx
   rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
   rtkThreeDCircularProjectionGeometryXMLFileWriter.cxx

--- a/src/rtkPhaseReader.cxx
+++ b/src/rtkPhaseReader.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef rtkPhaseReader_hxx
-#define rtkPhaseReader_hxx
 
 #include "rtkPhaseReader.h"
 
@@ -84,5 +82,3 @@ PhaseReader::GetOutput()
 }
 
 } // end namespace rtk
-
-#endif

--- a/src/rtkPhasesToInterpolationWeights.cxx
+++ b/src/rtkPhasesToInterpolationWeights.cxx
@@ -15,9 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef rtkPhasesToInterpolationWeights_hxx
-#define rtkPhasesToInterpolationWeights_hxx
-
 #include "rtkPhasesToInterpolationWeights.h"
 
 #include <itksys/SystemTools.hxx>
@@ -191,5 +188,3 @@ PhasesToInterpolationWeights ::GetOutput()
 
 
 } // end namespace rtk
-
-#endif

--- a/src/rtkSignalToInterpolationWeights.cxx
+++ b/src/rtkSignalToInterpolationWeights.cxx
@@ -15,8 +15,6 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef rtkSignalToInterpolationWeights_hxx
-#define rtkSignalToInterpolationWeights_hxx
 
 #include "rtkSignalToInterpolationWeights.h"
 
@@ -101,5 +99,3 @@ SignalToInterpolationWeights ::GetOutput()
 
 
 } // end namespace rtk
-
-#endif

--- a/utilities/ITKCudaCommon/include/itkCudaDataManager.h
+++ b/utilities/ITKCudaCommon/include/itkCudaDataManager.h
@@ -32,7 +32,7 @@
 
 namespace itk
 {
-class GPUMemPointer : public Object
+class ITKCudaCommon_EXPORT GPUMemPointer : public Object
 {
 public:
   using Self = GPUMemPointer;

--- a/utilities/ITKCudaCommon/include/itkCudaImage.h
+++ b/utilities/ITKCudaCommon/include/itkCudaImage.h
@@ -20,6 +20,7 @@
 
 #include "itkImage.h"
 #include "itkCudaImageDataManager.h"
+#include "itkCudaWin32Header.h"
 #include "itkVersion.h"
 #include "itkObjectFactoryBase.h"
 
@@ -36,7 +37,7 @@ namespace itk
  * \ingroup ITKCudaCommon
  */
 template <class TPixel, unsigned int VImageDimension = 2>
-class ITK_EXPORT CudaImage : public Image<TPixel, VImageDimension>
+class ITK_TEMPLATE_EXPORT CudaImage : public Image<TPixel, VImageDimension>
 {
 public:
   using Self = CudaImage;
@@ -220,7 +221,7 @@ private:
   typename CudaImageDataManager<CudaImage>::Pointer m_DataManager;
 };
 
-class CudaImageFactory : public itk::ObjectFactoryBase
+class ITKCudaCommon_EXPORT CudaImageFactory : public itk::ObjectFactoryBase
 {
 public:
   using Self = CudaImageFactory;
@@ -297,7 +298,7 @@ private:
 };
 
 template <class T>
-class CudaTraits
+class ITK_TEMPLATE_EXPORT CudaTraits
 {
 public:
   using Type = T;

--- a/utilities/ITKCudaCommon/include/itkCudaImageDataManager.h
+++ b/utilities/ITKCudaCommon/include/itkCudaImageDataManager.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup ITKCudaCommon
  */
 template <class ImageType>
-class ITK_EXPORT CudaImageDataManager : public CudaDataManager
+class ITK_TEMPLATE_EXPORT CudaImageDataManager : public CudaDataManager
 {
 public:
   using Self = CudaImageDataManager;

--- a/utilities/ITKCudaCommon/include/itkCudaImageToImageFilter.h
+++ b/utilities/ITKCudaCommon/include/itkCudaImageToImageFilter.h
@@ -39,7 +39,7 @@ namespace itk
 template <class TInputImage,
           class TOutputImage,
           class TParentImageFilter = ImageToImageFilter<TInputImage, TOutputImage>>
-class ITK_EXPORT CudaImageToImageFilter : public TParentImageFilter
+class ITK_TEMPLATE_EXPORT CudaImageToImageFilter : public TParentImageFilter
 {
 public:
   /** Standard class type alias. */

--- a/utilities/ITKCudaCommon/include/itkCudaInPlaceImageFilter.h
+++ b/utilities/ITKCudaCommon/include/itkCudaInPlaceImageFilter.h
@@ -35,7 +35,8 @@ namespace itk
 template <class TInputImage,
           class TOutputImage = TInputImage,
           class TParentImageFilter = InPlaceImageFilter<TInputImage, TOutputImage>>
-class ITK_EXPORT CudaInPlaceImageFilter : public CudaImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>
+class ITK_TEMPLATE_EXPORT CudaInPlaceImageFilter
+  : public CudaImageToImageFilter<TInputImage, TOutputImage, TParentImageFilter>
 {
 public:
   /** Standard class type alias. */


### PR DESCRIPTION
- The rules are the following:
    - Use ModuleName_EXPORT for non-templated classes.
    - Use ITK_TEMPLATE_EXPORT for templated classes.
    - Use ITK_FORWARD_EXPORT for forward declarations.