### PR TITLE
COMP: include CMake ITK_USE_FILE to set ITK_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ include(cmake/rtkCompilerFlags.cmake)
 # Find ITK (required)
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK 5.1 REQUIRED)
+  include(${ITK_USE_FILE})
 endif()
 
 # --------------------------------------------------------


### PR DESCRIPTION
Fixes a link error with FFTW on Windows using a system FFTW and RTK built externally, see [here](https://my.cdash.org/viewBuildError.php?buildid=1986321).
For me, it fixes InsightSoftwareConsortium/ITK#1922
@LucasGandel what do you think? Should we remove other `include(${ITK_USE_FILE})` ([here](https://github.com/SimonRit/RTK/blob/master/applications/CMakeLists.txt#L33) and [here](https://github.com/SimonRit/RTK/blob/master/test/CMakeLists.txt#L13))?