### PR TITLE
BUG: Do use use shallow version of checkout for clang format linting

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -8,6 +8,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master


### PR DESCRIPTION
See InsightSoftwareConsortium/ITKModuleTemplate@e275e844