### PR TITLE
Fix compilation error about floor on cu files

### DIFF
--- a/src/rtkCudaForwardWarpImageFilter.cu
+++ b/src/rtkCudaForwardWarpImageFilter.cu
@@ -190,9 +190,9 @@ linearSplat_3Dgrid(float * dev_vol_in, float * dev_vol_out, float * dev_accumula
 
   // Compute the splat weights
   int3 BaseIndexInOutput;
-  BaseIndexInOutput.x = floor(IndexInOutput.x);
-  BaseIndexInOutput.y = floor(IndexInOutput.y);
-  BaseIndexInOutput.z = floor(IndexInOutput.z);
+  BaseIndexInOutput.x = floorf(IndexInOutput.x);
+  BaseIndexInOutput.y = floorf(IndexInOutput.y);
+  BaseIndexInOutput.z = floorf(IndexInOutput.z);
 
   float3 Distance;
   Distance.x = IndexInOutput.x - BaseIndexInOutput.x;

--- a/src/rtkCudaRayCastBackProjectionImageFilter.cu
+++ b/src/rtkCudaRayCastBackProjectionImageFilter.cu
@@ -215,9 +215,9 @@ kernel_ray_cast_back_project(float * dev_accumulate_values, float * dev_proj, fl
     {
       for (t = tnear; t <= tfar; t += vStep)
       {
-        floor_pos.x = floor(pos.x);
-        floor_pos.y = floor(pos.y);
-        floor_pos.z = floor(pos.z);
+        floor_pos.x = floorf(pos.x);
+        floor_pos.y = floorf(pos.y);
+        floor_pos.z = floorf(pos.z);
 
         // Compute the weights and the voxel indices, taking into account border conditions (here clamping)
         splat3D_getWeightsAndIndices(pos, floor_pos, c_volSize, weights, indices);


### PR DESCRIPTION
Hello. Thanks for this great project. I tried to compile RTK independently on ITK. The following modification was necessary.

# summary
Fix compilation error with VS 2019 (16.9.5) and CUDA 11.1

# Errors
The compilation fails on VS 2019 (16.9.5) with the following errors:

```
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(193): error : calling a __host__ function("__floorf") from a __global__ function("linearSplat_3Dgrid") is not allowed
8>
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(193): error : identifier "__floorf" is undefined in device code
8>
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(194): error : calling a __host__ function("__floorf") from a __global__ function("linearSplat_3Dgrid") is not allowed
8>
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(194): error : identifier "__floorf" is undefined in device code
8>
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(195): error : calling a __host__ function("__floorf") from a __global__ function("linearSplat_3Dgrid") is not allowed
8>
8>.../RTK/src/rtkCudaForwardWarpImageFilter.cu(195): error : identifier "__floorf" is undefined in device code
8>
8>6 errors detected in the compilation of ".../RTK/src/rtkCudaForwardWarpImageFilter.cu".
```
and 
```
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(218): error : calling a __host__ function("__floorf") from a __global__ function("kernel_ray_cast_back_project") is not allowed
5>
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(218): error : identifier "__floorf" is undefined in device code
5>
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(219): error : calling a __host__ function("__floorf") from a __global__ function("kernel_ray_cast_back_project") is not allowed
5>
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(219): error : identifier "__floorf" is undefined in device code
5>
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(220): error : calling a __host__ function("__floorf") from a __global__ function("kernel_ray_cast_back_project") is not allowed
5>
5>.../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu(220): error : identifier "__floorf" is undefined in device code
5>
5>6 errors detected in the compilation of ".../RTK/src/rtkCudaRayCastBackProjectionImageFilter.cu".
```
# Change

`floor` => `floorf`

# Comment
This might have been occured since VS2019 16.9.1.
Similar (same?) issue can be found here: https://github.com/CERN/TIGRE/pull/264
