### PR TITLE
COMP: remove warnings due to unused type and lambda capture

### DIFF
--- a/test/rtkforwardattenuatedprojectiontest.cxx
+++ b/test/rtkforwardattenuatedprojectiontest.cxx
@@ -43,7 +43,6 @@ main(int, char **)
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 #endif
 
-  using VectorType = itk::Vector<double, 3>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
 #else
@@ -245,8 +244,8 @@ main(int, char **)
   using CustomBinaryFilterType = itk::BinaryGeneratorImageFilter<OutputImageType, OutputImageType, OutputImageType>;
   typename CustomBinaryFilterType::Pointer customBinaryFilter = CustomBinaryFilterType::New();
   // Set Lambda function
-  auto customLambda = [att](const typename OutputImageType::PixelType & input1,
-                            const typename OutputImageType::PixelType & input2) -> typename OutputImageType::PixelType
+  auto customLambda = [&](const typename OutputImageType::PixelType & input1,
+                          const typename OutputImageType::PixelType & input2) -> typename OutputImageType::PixelType
   {
     return static_cast<typename OutputImageType::PixelType>((1 - std::exp(-input1 * att)) / att *
                                                             std::exp(-input2 * att));


### PR DESCRIPTION
The warnings have been introduced by d13d60b8:

Modules/Remote/RTK/test/rtkforwardattenuatedprojectiontest.cxx:248:24:
warning: lambda capture 'att' is not required to be captured for this
use [-Wunused-lambda-capture]

Modules/Remote/RTK/test/rtkforwardattenuatedprojectiontest.cxx:46:9:
warning: unused type alias 'VectorType' [-Wunused-local-typedef]