### PR TITLE
ENH: allow displaced detector weighting for 4D sinogram

### DIFF
--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -68,15 +68,14 @@ public:
 
   /** Standard class type alias. */
   using Self = DisplacedDetectorImageFilter;
-
   using Superclass = itk::ImageToImageFilter<TInputImage, TOutputImage>;
-
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** Some convenient type alias. */
   using InputImageType = TInputImage;
   using OutputImageType = TOutputImage;
+  static constexpr unsigned int NDimension = TInputImage::ImageDimension;
   using OutputImageRegionType = typename OutputImageType::RegionType;
   using WeightImageType = itk::Image<typename TOutputImage::InternalPixelType, 1>;
 

--- a/wrapping/rtkDisplacedDetectorImageFilter.wrap
+++ b/wrapping/rtkDisplacedDetectorImageFilter.wrap
@@ -3,7 +3,7 @@ if(RTK_USE_CUDA)
 endif()
 
 itk_wrap_class("rtk::DisplacedDetectorImageFilter" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 1 3)
+  itk_wrap_image_filter("${WRAP_ITK_REAL}" 1 3;4)
 
   if(RTK_USE_CUDA)
     foreach(d ${ITK_WRAP_IMAGE_DIMS})


### PR DESCRIPTION
4D sinograms are used in proton CT reconstruction, see
https://doi.org/10.1118/1.4789589.