### PR TITLE
COMP: Fix hardcoded path in RTK install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,14 +186,9 @@ list(APPEND RTK_INCLUDE_DIRS
 list(APPEND RTK_INCLUDE_DIRS
   ${RTK_BINARY_DIR})
 
-# Export library linking directories (used by LIBPATH)
-set(RTK_SYSTEM_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-set(RTK_SYSTEM_INCLUDE_DIRS ${RTK_INCLUDE_DIRS})
-
 #=========================================================
 # Generate RTKConfig.cmake for the build tree.
 set(RTK_MODULE_PATH_CONFIG ${CMAKE_MODULE_PATH})
-set(RTK_LIBRARY_DIRS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 set(RTK_EXPORT_CODE_BUILD "
 # The RTK version number
@@ -233,6 +228,11 @@ if(NOT ITK_SOURCE_DIR)
 
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
+
+  # Add third party to RTK build targets.
+  # This must be done after RTK has been loaded by ITK to make sure
+  # ${itk-module} variables are defined for RTK.
+  itk_module_target_export(lpsolve55)
 else()
   itk_module_impl()
 endif()

--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -1,7 +1,7 @@
 #
 # Find the packages required by this module
 #
-list(APPEND CMAKE_MODULE_PATH ${RTK_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 include(CheckLanguage)
 check_language(CUDA)

--- a/utilities/lp_solve/CMakeLists.txt
+++ b/utilities/lp_solve/CMakeLists.txt
@@ -98,7 +98,9 @@ set_target_properties(lpsolve55 PROPERTIES VERSION ${LPSOLVE_VERSION}
                                            SOVERSION ${LPSOLVE_VERSION_MAJOR})
 
 if (NOT ITK_SOURCE_DIR)
-  # TODO: export target to find_package(RTK) on build directory ?
+  # Export to RTK build targets must be done after RTK has been loaded by ITK.
+  # When building externally we must do this after including ITKModuleExternal.
+  # See RTK/CMakeLists.txt.
 else()
   itk_module_target_export(lpsolve55)
 endif()
@@ -106,13 +108,15 @@ endif()
 #=========================================================
 if(NOT RTK_INSTALL_NO_LIBRARIES)
   target_include_directories(lpsolve55 PUBLIC $<INSTALL_INTERFACE:${RTK_INSTALL_INCLUDE_DIR}/lpsolve>)
-  install(TARGETS lpsolve55 EXPORT RTK
-    RUNTIME DESTINATION ${RTK_INSTALL_RUNTIME_DIR} COMPONENT Runtime
-    LIBRARY DESTINATION ${RTK_INSTALL_LIB_DIR} COMPONENT RuntimeLibraries
-    ARCHIVE DESTINATION ${RTK_INSTALL_ARCHIVE_DIR} COMPONENT Development
-    PUBLIC_HEADER DESTINATION "${RTK_INSTALL_INCLUDE_DIR}/lpsolve"
-  )
-  install(TARGETS lpsolve55 EXPORT ITKTargets
+
+  # External modules use their own targets.
+  set(_install_targets RTKTargets)
+  if(ITK_SOURCE_DIR)
+    # Remote modules use ITKTargets.cmake
+    set(_install_targets ITKTargets)
+  endif()
+
+  install(TARGETS lpsolve55 EXPORT ${_install_targets}
     RUNTIME DESTINATION ${RTK_INSTALL_RUNTIME_DIR} COMPONENT Runtime
     LIBRARY DESTINATION ${RTK_INSTALL_LIB_DIR} COMPONENT RuntimeLibraries
     ARCHIVE DESTINATION ${RTK_INSTALL_ARCHIVE_DIR} COMPONENT Development


### PR DESCRIPTION
@SimonRit This should be enough to fix #399.

Supersedes #415. lpsolve install is ok, ITKCudaCommon install will be handled in #427.

When [installing external modules](https://discourse.itk.org/t/external-module-bypass-itkdata/4202/8?u=lucasgandel) will be fixed in ITK, we can remove the RTK check preventing to install when building externally, because it should work great after this MR and #427 are integrated.