### PR TITLE
STYLE: remove backward compatibility with ITK v5.1

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -138,11 +138,7 @@ class ITK_TEMPLATE_EXPORT ADMMTotalVariationConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ADMMTotalVariationConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ADMMTotalVariationConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ADMMTotalVariationConeBeamReconstructionFilter;

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -107,11 +107,7 @@ template <typename TOutputImage,
 class ITK_TEMPLATE_EXPORT ADMMTotalVariationConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ADMMTotalVariationConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ADMMTotalVariationConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = ADMMTotalVariationConjugateGradientOperator;

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -144,11 +144,7 @@ class ITK_TEMPLATE_EXPORT ADMMWaveletsConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ADMMWaveletsConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ADMMWaveletsConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ADMMWaveletsConeBeamReconstructionFilter;

--- a/include/rtkADMMWaveletsConjugateGradientOperator.h
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.h
@@ -98,11 +98,7 @@ template <typename TOutputImage>
 class ITK_TEMPLATE_EXPORT ADMMWaveletsConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ADMMWaveletsConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ADMMWaveletsConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = ADMMWaveletsConjugateGradientOperator;

--- a/include/rtkAddMatrixAndDiagonalImageFilter.h
+++ b/include/rtkAddMatrixAndDiagonalImageFilter.h
@@ -44,11 +44,7 @@ template <class TDiagonal,
 class ITK_TEMPLATE_EXPORT AddMatrixAndDiagonalImageFilter : public itk::ImageToImageFilter<TMatrix, TMatrix>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(AddMatrixAndDiagonalImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(AddMatrixAndDiagonalImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = AddMatrixAndDiagonalImageFilter;

--- a/include/rtkAdditiveGaussianNoiseImageFilter.h
+++ b/include/rtkAdditiveGaussianNoiseImageFilter.h
@@ -171,11 +171,7 @@ template <class TInputImage>
 class ITK_TEMPLATE_EXPORT AdditiveGaussianNoiseImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(AdditiveGaussianNoiseImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(AdditiveGaussianNoiseImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = AdditiveGaussianNoiseImageFilter;

--- a/include/rtkAmsterdamShroudImageFilter.h
+++ b/include/rtkAmsterdamShroudImageFilter.h
@@ -82,11 +82,7 @@ class ITK_TEMPLATE_EXPORT AmsterdamShroudImageFilter
   : public itk::ImageToImageFilter<TInputImage, itk::Image<double, TInputImage::ImageDimension - 1>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(AmsterdamShroudImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(AmsterdamShroudImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = AmsterdamShroudImageFilter;

--- a/include/rtkAverageOutOfROIImageFilter.h
+++ b/include/rtkAverageOutOfROIImageFilter.h
@@ -52,11 +52,7 @@ template <class TInputImage, class TROI = itk::Image<typename TInputImage::Pixel
 class ITK_TEMPLATE_EXPORT AverageOutOfROIImageFilter : public itk::InPlaceImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(AverageOutOfROIImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(AverageOutOfROIImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = AverageOutOfROIImageFilter;

--- a/include/rtkBackProjectionImageFilter.h
+++ b/include/rtkBackProjectionImageFilter.h
@@ -50,11 +50,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT BackProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(BackProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(BackProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = BackProjectionImageFilter;

--- a/include/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/include/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -41,11 +41,7 @@ class ITK_TEMPLATE_EXPORT BackwardDifferenceDivergenceImageFilter
   : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(BackwardDifferenceDivergenceImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(BackwardDifferenceDivergenceImageFilter);
-#endif
 
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/include/rtkBioscanGeometryReader.h
+++ b/include/rtkBioscanGeometryReader.h
@@ -52,11 +52,7 @@ namespace rtk
 class RTK_EXPORT BioscanGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(BioscanGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(BioscanGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = BioscanGeometryReader;

--- a/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
+++ b/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
@@ -40,11 +40,7 @@ class ITK_TEMPLATE_EXPORT BlockDiagonalMatrixVectorMultiplyImageFilter
   : public itk::ImageToImageFilter<TVectorImage, TVectorImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(BlockDiagonalMatrixVectorMultiplyImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(BlockDiagonalMatrixVectorMultiplyImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = BlockDiagonalMatrixVectorMultiplyImageFilter;

--- a/include/rtkBoellaardScatterCorrectionImageFilter.h
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.h
@@ -41,11 +41,7 @@ class ITK_TEMPLATE_EXPORT BoellaardScatterCorrectionImageFilter
   : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(BoellaardScatterCorrectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(BoellaardScatterCorrectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = BoellaardScatterCorrectionImageFilter;

--- a/include/rtkConditionalMedianImageFilter.h
+++ b/include/rtkConditionalMedianImageFilter.h
@@ -49,11 +49,7 @@ template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ConditionalMedianImageFilter : public itk::InPlaceImageFilter<TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConditionalMedianImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConditionalMedianImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConditionalMedianImageFilter;

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -111,11 +111,7 @@ class ITK_TEMPLATE_EXPORT ConjugateGradientConeBeamReconstructionFilter
   : public IterativeConeBeamReconstructionFilter<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientConeBeamReconstructionFilter;

--- a/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
@@ -36,11 +36,7 @@ class ITK_TEMPLATE_EXPORT ConjugateGradientGetP_kPlusOneImageFilter
   : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientGetP_kPlusOneImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientGetP_kPlusOneImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientGetP_kPlusOneImageFilter;

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
@@ -38,11 +38,7 @@ class ITK_TEMPLATE_EXPORT ConjugateGradientGetR_kPlusOneImageFilter
   : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientGetR_kPlusOneImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientGetR_kPlusOneImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientGetR_kPlusOneImageFilter;

--- a/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
@@ -36,11 +36,7 @@ class ITK_TEMPLATE_EXPORT ConjugateGradientGetX_kPlusOneImageFilter
   : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientGetX_kPlusOneImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientGetX_kPlusOneImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientGetX_kPlusOneImageFilter;

--- a/include/rtkConjugateGradientImageFilter.h
+++ b/include/rtkConjugateGradientImageFilter.h
@@ -47,11 +47,7 @@ class ITK_TEMPLATE_EXPORT ConjugateGradientImageFilter
   : public itk::InPlaceImageFilter<OutputImageType, OutputImageType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientImageFilter;

--- a/include/rtkConjugateGradientOperator.h
+++ b/include/rtkConjugateGradientOperator.h
@@ -32,11 +32,7 @@ template <typename OutputImageType>
 class ITK_TEMPLATE_EXPORT ConjugateGradientOperator : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = ConjugateGradientOperator;

--- a/include/rtkConstantImageSource.h
+++ b/include/rtkConstantImageSource.h
@@ -51,11 +51,7 @@ template <typename TOutputImage>
 class ITK_TEMPLATE_EXPORT ConstantImageSource : public itk::ImageSource<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConstantImageSource);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConstantImageSource);
-#endif
 
   /** Standard class type alias. */
   using Self = ConstantImageSource;

--- a/include/rtkConvexShape.h
+++ b/include/rtkConvexShape.h
@@ -46,11 +46,7 @@ namespace rtk
 class RTK_EXPORT ConvexShape : public itk::DataObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ConvexShape);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ConvexShape);
-#endif
 
   /** Standard class type alias. */
   using Self = ConvexShape;

--- a/include/rtkCudaAverageOutOfROIImageFilter.h
+++ b/include/rtkCudaAverageOutOfROIImageFilter.h
@@ -47,11 +47,7 @@ class RTK_EXPORT CudaAverageOutOfROIImageFilter
 
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaAverageOutOfROIImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaAverageOutOfROIImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaAverageOutOfROIImageFilter;

--- a/include/rtkCudaBackProjectionImageFilter.h
+++ b/include/rtkCudaBackProjectionImageFilter.h
@@ -51,11 +51,7 @@ class ITK_TEMPLATE_EXPORT CudaBackProjectionImageFilter
   : public itk::CudaInPlaceImageFilter<ImageType, ImageType, BackProjectionImageFilter<ImageType, ImageType>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaBackProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaBackProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using BackProjectionImageFilterType = BackProjectionImageFilter<ImageType, ImageType>;

--- a/include/rtkCudaConjugateGradientImageFilter.h
+++ b/include/rtkCudaConjugateGradientImageFilter.h
@@ -45,11 +45,7 @@ class ITK_TEMPLATE_EXPORT CudaConjugateGradientImageFilter
   : public itk::CudaImageToImageFilter<TImage, TImage, ConjugateGradientImageFilter<TImage>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaConjugateGradientImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaConjugateGradientImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaConjugateGradientImageFilter<TImage>;

--- a/include/rtkCudaConstantVolumeSeriesSource.h
+++ b/include/rtkCudaConstantVolumeSeriesSource.h
@@ -46,11 +46,7 @@ class RTK_EXPORT CudaConstantVolumeSeriesSource
                                        ConstantImageSource<itk::CudaImage<float, 4>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaConstantVolumeSeriesSource);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaConstantVolumeSeriesSource);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaConstantVolumeSeriesSource;

--- a/include/rtkCudaConstantVolumeSource.h
+++ b/include/rtkCudaConstantVolumeSource.h
@@ -46,11 +46,7 @@ class RTK_EXPORT CudaConstantVolumeSource
                                        ConstantImageSource<itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaConstantVolumeSource);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaConstantVolumeSource);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaConstantVolumeSource;

--- a/include/rtkCudaCropImageFilter.h
+++ b/include/rtkCudaCropImageFilter.h
@@ -51,11 +51,7 @@ class RTK_EXPORT CudaCropImageFilter
                                        itk::CropImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaCropImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaCropImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaCyclicDeformationImageFilter.h
+++ b/include/rtkCudaCyclicDeformationImageFilter.h
@@ -48,11 +48,7 @@ class RTK_EXPORT CudaCyclicDeformationImageFilter
                                                                     itk::CudaImage<itk::CovariantVector<float, 3>, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaCyclicDeformationImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaCyclicDeformationImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaCyclicDeformationImageFilter;

--- a/include/rtkCudaDisplacedDetectorImageFilter.h
+++ b/include/rtkCudaDisplacedDetectorImageFilter.h
@@ -52,11 +52,7 @@ class RTK_EXPORT CudaDisplacedDetectorImageFilter
                                        rtk::DisplacedDetectorImageFilter<itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaDisplacedDetectorImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaDisplacedDetectorImageFilter);
-#  endif
 
   /** Convenience type alias **/
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaFDKBackProjectionImageFilter.h
+++ b/include/rtkCudaFDKBackProjectionImageFilter.h
@@ -49,11 +49,7 @@ class RTK_EXPORT CudaFDKBackProjectionImageFilter
                                        FDKBackProjectionImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaFDKBackProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaFDKBackProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaFDKConeBeamReconstructionFilter.h
+++ b/include/rtkCudaFDKConeBeamReconstructionFilter.h
@@ -53,11 +53,7 @@ class RTK_EXPORT CudaFDKConeBeamReconstructionFilter
       FDKConeBeamReconstructionFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, float>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaFDKConeBeamReconstructionFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaFDKConeBeamReconstructionFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaFDKConeBeamReconstructionFilter;

--- a/include/rtkCudaFDKWeightProjectionFilter.h
+++ b/include/rtkCudaFDKWeightProjectionFilter.h
@@ -53,11 +53,7 @@ class RTK_EXPORT CudaFDKWeightProjectionFilter
                                        rtk::FDKWeightProjectionFilter<itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaFDKWeightProjectionFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaFDKWeightProjectionFilter);
-#  endif
 
   /** Convenience type alias **/
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
@@ -50,11 +50,7 @@ class ITK_TEMPLATE_EXPORT CudaFFTProjectionsConvolutionImageFilter
   : public itk::CudaImageToImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, TParentImageFilter>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaFFTProjectionsConvolutionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaFFTProjectionsConvolutionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaFFTProjectionsConvolutionImageFilter;

--- a/include/rtkCudaFFTRampImageFilter.h
+++ b/include/rtkCudaFFTRampImageFilter.h
@@ -44,11 +44,7 @@ class RTK_EXPORT CudaFFTRampImageFilter
       FFTRampImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, float>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaFFTRampImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaFFTRampImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaFFTRampImageFilter;

--- a/include/rtkCudaForwardProjectionImageFilter.h
+++ b/include/rtkCudaForwardProjectionImageFilter.h
@@ -54,11 +54,7 @@ class ITK_TEMPLATE_EXPORT CudaForwardProjectionImageFilter
       CudaInPlaceImageFilter<TInputImage, TOutputImage, ForwardProjectionImageFilter<TInputImage, TOutputImage>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaForwardProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaForwardProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaForwardProjectionImageFilter;

--- a/include/rtkCudaForwardWarpImageFilter.h
+++ b/include/rtkCudaForwardWarpImageFilter.h
@@ -52,11 +52,7 @@ class RTK_EXPORT CudaForwardWarpImageFilter
                                                                    itk::CudaImage<itk::CovariantVector<float, 3>, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaForwardWarpImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaForwardWarpImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaInterpolateImageFilter.h
+++ b/include/rtkCudaInterpolateImageFilter.h
@@ -47,11 +47,7 @@ class RTK_EXPORT CudaInterpolateImageFilter
       InterpolatorWithKnownWeightsImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 4>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaInterpolateImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaInterpolateImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaInterpolateImageFilter;

--- a/include/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
@@ -55,11 +55,7 @@ class RTK_EXPORT CudaIterativeFDKConeBeamReconstructionFilter
       IterativeFDKConeBeamReconstructionFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, float>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaIterativeFDKConeBeamReconstructionFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaIterativeFDKConeBeamReconstructionFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaIterativeFDKConeBeamReconstructionFilter;

--- a/include/rtkCudaLagCorrectionImageFilter.h
+++ b/include/rtkCudaLagCorrectionImageFilter.h
@@ -51,11 +51,7 @@ class RTK_EXPORT CudaLagCorrectionImageFilter
                                        LagCorrectionImageFilter<itk::CudaImage<unsigned short, 3>, 4>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaLagCorrectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaLagCorrectionImageFilter);
-#  endif
 
   /** Convenience type alias **/
   using ImageType = itk::CudaImage<unsigned short, 3>;

--- a/include/rtkCudaLaplacianImageFilter.h
+++ b/include/rtkCudaLaplacianImageFilter.h
@@ -45,11 +45,7 @@ class RTK_EXPORT CudaLaplacianImageFilter
       LaplacianImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<itk::CovariantVector<float, 3>, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaLaplacianImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaLaplacianImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaLaplacianImageFilter;

--- a/include/rtkCudaLastDimensionTVDenoisingImageFilter.h
+++ b/include/rtkCudaLastDimensionTVDenoisingImageFilter.h
@@ -49,11 +49,7 @@ class RTK_EXPORT CudaLastDimensionTVDenoisingImageFilter
                                              itk::CudaImage<itk::CovariantVector<float, 1>, 4>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaLastDimensionTVDenoisingImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaLastDimensionTVDenoisingImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaLastDimensionTVDenoisingImageFilter;

--- a/include/rtkCudaParkerShortScanImageFilter.h
+++ b/include/rtkCudaParkerShortScanImageFilter.h
@@ -52,11 +52,7 @@ class RTK_EXPORT CudaParkerShortScanImageFilter
                                        rtk::ParkerShortScanImageFilter<itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaParkerShortScanImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaParkerShortScanImageFilter);
-#  endif
 
   /** Convenience type alias **/
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkCudaPolynomialGainCorrectionImageFilter.h
@@ -52,11 +52,7 @@ class RTK_EXPORT CudaPolynomialGainCorrectionImageFilter
       PolynomialGainCorrectionImageFilter<itk::CudaImage<unsigned short, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaPolynomialGainCorrectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaPolynomialGainCorrectionImageFilter);
-#  endif
 
   /** Convenience type alias **/
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaRayCastBackProjectionImageFilter.h
+++ b/include/rtkCudaRayCastBackProjectionImageFilter.h
@@ -52,11 +52,7 @@ class RTK_EXPORT CudaRayCastBackProjectionImageFilter
                                        BackProjectionImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaRayCastBackProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaRayCastBackProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaScatterGlareCorrectionImageFilter.h
+++ b/include/rtkCudaScatterGlareCorrectionImageFilter.h
@@ -45,11 +45,7 @@ class CudaScatterGlareCorrectionImageFilter
       ScatterGlareCorrectionImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>, float>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaScatterGlareCorrectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaScatterGlareCorrectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaScatterGlareCorrectionImageFilter;

--- a/include/rtkCudaSplatImageFilter.h
+++ b/include/rtkCudaSplatImageFilter.h
@@ -48,11 +48,7 @@ class RTK_EXPORT CudaSplatImageFilter
 
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaSplatImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaSplatImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaSplatImageFilter;

--- a/include/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
@@ -48,11 +48,7 @@ class RTK_EXPORT CudaTotalVariationDenoisingBPDQImageFilter
                                              itk::CudaImage<itk::CovariantVector<float, 3>, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaTotalVariationDenoisingBPDQImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaTotalVariationDenoisingBPDQImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = rtk::CudaTotalVariationDenoisingBPDQImageFilter;

--- a/include/rtkCudaWarpBackProjectionImageFilter.h
+++ b/include/rtkCudaWarpBackProjectionImageFilter.h
@@ -50,11 +50,7 @@ class RTK_EXPORT CudaWarpBackProjectionImageFilter
                                        BackProjectionImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaWarpBackProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaWarpBackProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaWarpForwardProjectionImageFilter.h
+++ b/include/rtkCudaWarpForwardProjectionImageFilter.h
@@ -50,11 +50,7 @@ class RTK_EXPORT CudaWarpForwardProjectionImageFilter
                                        ForwardProjectionImageFilter<itk::CudaImage<float, 3>, itk::CudaImage<float, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaWarpForwardProjectionImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaWarpForwardProjectionImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using InputImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaWarpImageFilter.h
+++ b/include/rtkCudaWarpImageFilter.h
@@ -51,11 +51,7 @@ class RTK_EXPORT CudaWarpImageFilter
                                                             itk::CudaImage<itk::CovariantVector<float, 3>, 3>>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaWarpImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaWarpImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using ImageType = itk::CudaImage<float, 3>;

--- a/include/rtkCudaWeidingerForwardModelImageFilter.h
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.h
@@ -50,11 +50,7 @@ class ITK_TEMPLATE_EXPORT CudaWeidingerForwardModelImageFilter
       WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>>
 {
 public:
-#  if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CudaWeidingerForwardModelImageFilter);
-#  else
   ITK_DISALLOW_COPY_AND_MOVE(CudaWeidingerForwardModelImageFilter);
-#  endif
 
   /** Standard class type alias. */
   using Self = CudaWeidingerForwardModelImageFilter;

--- a/include/rtkCyclicDeformationImageFilter.h
+++ b/include/rtkCyclicDeformationImageFilter.h
@@ -50,11 +50,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT CyclicDeformationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(CyclicDeformationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(CyclicDeformationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = CyclicDeformationImageFilter;

--- a/include/rtkDCMImagXImageIO.h
+++ b/include/rtkDCMImagXImageIO.h
@@ -36,11 +36,7 @@ namespace rtk
 class RTK_EXPORT DCMImagXImageIO : public itk::GDCMImageIO
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DCMImagXImageIO);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DCMImagXImageIO);
-#endif
 
   /** Standard class type alias. */
   using Self = DCMImagXImageIO;

--- a/include/rtkDCMImagXImageIOFactory.h
+++ b/include/rtkDCMImagXImageIOFactory.h
@@ -37,11 +37,7 @@ namespace rtk
 class RTK_EXPORT DCMImagXImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DCMImagXImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DCMImagXImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = DCMImagXImageIOFactory;

--- a/include/rtkDPExtractShroudSignalImageFilter.h
+++ b/include/rtkDPExtractShroudSignalImageFilter.h
@@ -39,11 +39,7 @@ class ITK_TEMPLATE_EXPORT DPExtractShroudSignalImageFilter
   : public itk::ImageToImageFilter<itk::Image<TInputPixel, 2>, itk::Image<TOutputPixel, 1>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DPExtractShroudSignalImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DPExtractShroudSignalImageFilter);
-#endif
 
   /** Standard class type alias. */
   using TInputImage = itk::Image<TInputPixel, 2>;

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
@@ -45,11 +45,7 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT DaubechiesWaveletsConvolutionImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DaubechiesWaveletsConvolutionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DaubechiesWaveletsConvolutionImageFilter);
-#endif
 
   enum Pass
   {

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
@@ -75,11 +75,7 @@ class ITK_TEMPLATE_EXPORT DaubechiesWaveletsDenoiseSequenceImageFilter
   : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DaubechiesWaveletsDenoiseSequenceImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DaubechiesWaveletsDenoiseSequenceImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DaubechiesWaveletsDenoiseSequenceImageFilter;

--- a/include/rtkDePierroRegularizationImageFilter.h
+++ b/include/rtkDePierroRegularizationImageFilter.h
@@ -75,11 +75,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT DePierroRegularizationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DePierroRegularizationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DePierroRegularizationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DePierroRegularizationImageFilter;

--- a/include/rtkDeconstructImageFilter.h
+++ b/include/rtkDeconstructImageFilter.h
@@ -128,11 +128,7 @@ template <class TImage>
 class ITK_TEMPLATE_EXPORT DeconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DeconstructImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DeconstructImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DeconstructImageFilter;

--- a/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
+++ b/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
@@ -48,11 +48,7 @@ class ITK_TEMPLATE_EXPORT DeconstructSoftThresholdReconstructImageFilter
   : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DeconstructSoftThresholdReconstructImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DeconstructSoftThresholdReconstructImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DeconstructSoftThresholdReconstructImageFilter;

--- a/include/rtkDenoisingBPDQImageFilter.h
+++ b/include/rtkDenoisingBPDQImageFilter.h
@@ -41,11 +41,7 @@ template <typename TOutputImage, typename TGradientImage>
 class ITK_TEMPLATE_EXPORT DenoisingBPDQImageFilter : public itk::InPlaceImageFilter<TOutputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DenoisingBPDQImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DenoisingBPDQImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DenoisingBPDQImageFilter;

--- a/include/rtkDigisensGeometryReader.h
+++ b/include/rtkDigisensGeometryReader.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT DigisensGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DigisensGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DigisensGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = DigisensGeometryReader;

--- a/include/rtkDigisensGeometryXMLFileReader.h
+++ b/include/rtkDigisensGeometryXMLFileReader.h
@@ -42,11 +42,7 @@ namespace rtk
 class RTK_EXPORT DigisensGeometryXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DigisensGeometryXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DigisensGeometryXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = DigisensGeometryXMLFileReader;

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
@@ -42,11 +42,7 @@ class ITK_TEMPLATE_EXPORT DisplacedDetectorForOffsetFieldOfViewImageFilter
   : public rtk::DisplacedDetectorImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DisplacedDetectorForOffsetFieldOfViewImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DisplacedDetectorForOffsetFieldOfViewImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DisplacedDetectorForOffsetFieldOfViewImageFilter;

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -60,11 +60,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT DisplacedDetectorImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DisplacedDetectorImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DisplacedDetectorImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DisplacedDetectorImageFilter;

--- a/include/rtkDivergenceOfGradientConjugateGradientOperator.h
+++ b/include/rtkDivergenceOfGradientConjugateGradientOperator.h
@@ -38,11 +38,7 @@ template <class TInputImage>
 class ITK_TEMPLATE_EXPORT DivergenceOfGradientConjugateGradientOperator : public ConjugateGradientOperator<TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DivergenceOfGradientConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DivergenceOfGradientConjugateGradientOperator);
-#endif
 
   /** Extract dimension from input and output image. */
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/include/rtkDownsampleImageFilter.h
+++ b/include/rtkDownsampleImageFilter.h
@@ -38,11 +38,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT DownsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DownsampleImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DownsampleImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DownsampleImageFilter;

--- a/include/rtkDrawBoxImageFilter.h
+++ b/include/rtkDrawBoxImageFilter.h
@@ -39,11 +39,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawBoxImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawBoxImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawBoxImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawBoxImageFilter;

--- a/include/rtkDrawConeImageFilter.h
+++ b/include/rtkDrawConeImageFilter.h
@@ -38,11 +38,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawConeImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawConeImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawConeImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawConeImageFilter;

--- a/include/rtkDrawConvexImageFilter.h
+++ b/include/rtkDrawConvexImageFilter.h
@@ -42,11 +42,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawConvexImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawConvexImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawConvexImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawConvexImageFilter;

--- a/include/rtkDrawCylinderImageFilter.h
+++ b/include/rtkDrawCylinderImageFilter.h
@@ -42,11 +42,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawCylinderImageFilter : public DrawEllipsoidImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawCylinderImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawCylinderImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawCylinderImageFilter;

--- a/include/rtkDrawEllipsoidImageFilter.h
+++ b/include/rtkDrawEllipsoidImageFilter.h
@@ -38,11 +38,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawEllipsoidImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawEllipsoidImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawEllipsoidImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawEllipsoidImageFilter;

--- a/include/rtkDrawGeometricPhantomImageFilter.h
+++ b/include/rtkDrawGeometricPhantomImageFilter.h
@@ -39,11 +39,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawGeometricPhantomImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawGeometricPhantomImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawGeometricPhantomImageFilter;

--- a/include/rtkDrawQuadricImageFilter.h
+++ b/include/rtkDrawQuadricImageFilter.h
@@ -38,11 +38,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawQuadricImageFilter : public DrawConvexImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawQuadricImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawQuadricImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawQuadricImageFilter;

--- a/include/rtkDrawSheppLoganFilter.h
+++ b/include/rtkDrawSheppLoganFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT DrawSheppLoganFilter : public DrawGeometricPhantomImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DrawSheppLoganFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DrawSheppLoganFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = DrawSheppLoganFilter;

--- a/include/rtkDualEnergyNegativeLogLikelihood.h
+++ b/include/rtkDualEnergyNegativeLogLikelihood.h
@@ -43,11 +43,7 @@ namespace rtk
 class DualEnergyNegativeLogLikelihood : public rtk::ProjectionsDecompositionNegativeLogLikelihood
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(DualEnergyNegativeLogLikelihood);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(DualEnergyNegativeLogLikelihood);
-#endif
 
   using Self = DualEnergyNegativeLogLikelihood;
   using Superclass = rtk::ProjectionsDecompositionNegativeLogLikelihood;

--- a/include/rtkEdfImageIO.h
+++ b/include/rtkEdfImageIO.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT EdfImageIO : public itk::ImageIOBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(EdfImageIO);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(EdfImageIO);
-#endif
 
   /** Standard class type alias. */
   using Self = EdfImageIO;

--- a/include/rtkEdfImageIOFactory.h
+++ b/include/rtkEdfImageIOFactory.h
@@ -38,11 +38,7 @@ namespace rtk
 class RTK_EXPORT EdfImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(EdfImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(EdfImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = EdfImageIOFactory;

--- a/include/rtkEdfRawToAttenuationImageFilter.h
+++ b/include/rtkEdfRawToAttenuationImageFilter.h
@@ -39,11 +39,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITKIOImageBase_HIDDEN EdfRawToAttenuationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(EdfRawToAttenuationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(EdfRawToAttenuationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = EdfRawToAttenuationImageFilter;

--- a/include/rtkElektaSynergyGeometryReader.h
+++ b/include/rtkElektaSynergyGeometryReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT ElektaSynergyGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ElektaSynergyGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ElektaSynergyGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = ElektaSynergyGeometryReader;

--- a/include/rtkElektaSynergyLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyLookupTableImageFilter.h
@@ -43,11 +43,7 @@ class ITK_TEMPLATE_EXPORT ElektaSynergyLookupTableImageFilter
   : public LookupTableImageFilter<itk::Image<unsigned short, TOutputImage::ImageDimension>, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ElektaSynergyLookupTableImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ElektaSynergyLookupTableImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ElektaSynergyLookupTableImageFilter;

--- a/include/rtkElektaSynergyRawLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyRawLookupTableImageFilter.h
@@ -44,11 +44,7 @@ class ITK_TEMPLATE_EXPORT ElektaSynergyRawLookupTableImageFilter
 {
 
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ElektaSynergyRawLookupTableImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ElektaSynergyRawLookupTableImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ElektaSynergyRawLookupTableImageFilter;

--- a/include/rtkElektaXVI5GeometryXMLFile.h
+++ b/include/rtkElektaXVI5GeometryXMLFile.h
@@ -46,11 +46,7 @@ namespace rtk
 class RTK_EXPORT ElektaXVI5GeometryXMLFileReader : public itk::XMLReader<ThreeDCircularProjectionGeometry>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ElektaXVI5GeometryXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ElektaXVI5GeometryXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = ElektaXVI5GeometryXMLFileReader;

--- a/include/rtkExtractPhaseImageFilter.h
+++ b/include/rtkExtractPhaseImageFilter.h
@@ -47,11 +47,7 @@ template <class TImage>
 class ITK_TEMPLATE_EXPORT ExtractPhaseImageFilter : public itk::InPlaceImageFilter<TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExtractPhaseImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ExtractPhaseImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ExtractPhaseImageFilter;

--- a/include/rtkFDKBackProjectionImageFilter.h
+++ b/include/rtkFDKBackProjectionImageFilter.h
@@ -39,11 +39,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT FDKBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDKBackProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FDKBackProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FDKBackProjectionImageFilter;

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -63,11 +63,7 @@ template <class TInputImage, class TOutputImage = TInputImage, class TFFTPrecisi
 class ITK_TEMPLATE_EXPORT FDKConeBeamReconstructionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDKConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FDKConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FDKConeBeamReconstructionFilter;

--- a/include/rtkFDKWarpBackProjectionImageFilter.h
+++ b/include/rtkFDKWarpBackProjectionImageFilter.h
@@ -47,11 +47,7 @@ class ITK_TEMPLATE_EXPORT FDKWarpBackProjectionImageFilter
   : public FDKBackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDKWarpBackProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FDKWarpBackProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FDKWarpBackProjectionImageFilter;

--- a/include/rtkFDKWeightProjectionFilter.h
+++ b/include/rtkFDKWeightProjectionFilter.h
@@ -51,11 +51,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT FDKWeightProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDKWeightProjectionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FDKWeightProjectionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FDKWeightProjectionFilter;

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -46,11 +46,7 @@ class ITK_TEMPLATE_EXPORT FFTProjectionsConvolutionImageFilter
   : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FFTProjectionsConvolutionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FFTProjectionsConvolutionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FFTProjectionsConvolutionImageFilter;

--- a/include/rtkFFTRampImageFilter.h
+++ b/include/rtkFFTRampImageFilter.h
@@ -62,11 +62,7 @@ class ITK_TEMPLATE_EXPORT FFTRampImageFilter
   : public rtk::FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FFTRampImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FFTRampImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FFTRampImageFilter;

--- a/include/rtkFieldOfViewImageFilter.h
+++ b/include/rtkFieldOfViewImageFilter.h
@@ -48,11 +48,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT FieldOfViewImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FieldOfViewImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FieldOfViewImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FieldOfViewImageFilter;

--- a/include/rtkForbildPhantomFileReader.h
+++ b/include/rtkForbildPhantomFileReader.h
@@ -42,11 +42,7 @@ namespace rtk
 class RTK_EXPORT ForbildPhantomFileReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ForbildPhantomFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ForbildPhantomFileReader);
-#endif
 
   /** Standard class type alias. */
   using Self = ForbildPhantomFileReader;

--- a/include/rtkForwardDifferenceGradientImageFilter.h
+++ b/include/rtkForwardDifferenceGradientImageFilter.h
@@ -56,11 +56,7 @@ class ITK_TEMPLATE_EXPORT ForwardDifferenceGradientImageFilter
   : public itk::ImageToImageFilter<TInputImage, TOuputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ForwardDifferenceGradientImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ForwardDifferenceGradientImageFilter);
-#endif
 
   /** Extract dimension from input image. */
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/include/rtkForwardProjectionImageFilter.h
+++ b/include/rtkForwardProjectionImageFilter.h
@@ -37,11 +37,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ForwardProjectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ForwardProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ForwardProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ForwardProjectionImageFilter;

--- a/include/rtkForwardWarpImageFilter.h
+++ b/include/rtkForwardWarpImageFilter.h
@@ -45,11 +45,7 @@ template <class TInputImage,
 class ITK_TEMPLATE_EXPORT ForwardWarpImageFilter : public itk::WarpImageFilter<TInputImage, TOutputImage, TDVF>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ForwardWarpImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ForwardWarpImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ForwardWarpImageFilter;

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -97,11 +97,7 @@ class ITK_TEMPLATE_EXPORT FourDConjugateGradientConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FourDConjugateGradientConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FourDConjugateGradientConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FourDConjugateGradientConeBeamReconstructionFilter;

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -208,11 +208,7 @@ class ITK_TEMPLATE_EXPORT FourDROOSTERConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FourDROOSTERConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FourDROOSTERConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FourDROOSTERConeBeamReconstructionFilter;

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -131,11 +131,7 @@ class ITK_TEMPLATE_EXPORT FourDReconstructionConjugateGradientOperator
   : public ConjugateGradientOperator<VolumeSeriesType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FourDReconstructionConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FourDReconstructionConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = FourDReconstructionConjugateGradientOperator;

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -123,11 +123,7 @@ class ITK_TEMPLATE_EXPORT FourDSARTConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FourDSARTConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FourDSARTConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FourDSARTConeBeamReconstructionFilter;

--- a/include/rtkFourDToProjectionStackImageFilter.h
+++ b/include/rtkFourDToProjectionStackImageFilter.h
@@ -101,11 +101,7 @@ class ITK_TEMPLATE_EXPORT FourDToProjectionStackImageFilter
   : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(FourDToProjectionStackImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(FourDToProjectionStackImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = FourDToProjectionStackImageFilter;

--- a/include/rtkGeometricPhantom.h
+++ b/include/rtkGeometricPhantom.h
@@ -37,11 +37,7 @@ namespace rtk
 class RTK_EXPORT GeometricPhantom : public itk::DataObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(GeometricPhantom);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(GeometricPhantom);
-#endif
 
   /** Standard class type alias. */
   using Self = GeometricPhantom;

--- a/include/rtkGeometricPhantomFileReader.h
+++ b/include/rtkGeometricPhantomFileReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT GeometricPhantomFileReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(GeometricPhantomFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(GeometricPhantomFileReader);
-#endif
 
   /** Standard class type alias. */
   using Self = GeometricPhantomFileReader;

--- a/include/rtkGetNewtonUpdateImageFilter.h
+++ b/include/rtkGetNewtonUpdateImageFilter.h
@@ -45,11 +45,7 @@ template <class TGradient,
 class ITK_TEMPLATE_EXPORT GetNewtonUpdateImageFilter : public itk::ImageToImageFilter<TGradient, TGradient>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(GetNewtonUpdateImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(GetNewtonUpdateImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = GetNewtonUpdateImageFilter;

--- a/include/rtkGlobalResourceProbe.h
+++ b/include/rtkGlobalResourceProbe.h
@@ -36,11 +36,7 @@ namespace rtk
 class RTK_EXPORT GlobalResourceProbe : public itk::Object
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(GlobalResourceProbe);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(GlobalResourceProbe);
-#endif
 
   /** Standard class type alias. */
   using Self = GlobalResourceProbe;

--- a/include/rtkHilbertImageFilter.h
+++ b/include/rtkHilbertImageFilter.h
@@ -44,11 +44,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT HilbertImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(HilbertImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(HilbertImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = HilbertImageFilter;

--- a/include/rtkHisImageIOFactory.h
+++ b/include/rtkHisImageIOFactory.h
@@ -41,11 +41,7 @@ namespace rtk
 class RTK_EXPORT HisImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(HisImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(HisImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = HisImageIOFactory;

--- a/include/rtkHndImageIOFactory.h
+++ b/include/rtkHndImageIOFactory.h
@@ -43,11 +43,7 @@ namespace rtk
 class RTK_EXPORT HndImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(HndImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(HndImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = HndImageIOFactory;

--- a/include/rtkI0EstimationProjectionFilter.h
+++ b/include/rtkI0EstimationProjectionFilter.h
@@ -46,11 +46,7 @@ template <class TInputImage = itk::Image<unsigned short, 3>,
 class ITK_TEMPLATE_EXPORT I0EstimationProjectionFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(I0EstimationProjectionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(I0EstimationProjectionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = I0EstimationProjectionFilter<TInputImage, TOutputImage, bitShift>;

--- a/include/rtkImagXGeometryReader.h
+++ b/include/rtkImagXGeometryReader.h
@@ -41,11 +41,7 @@ template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT ImagXGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImagXGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ImagXGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = ImagXGeometryReader;

--- a/include/rtkImagXImageIOFactory.h
+++ b/include/rtkImagXImageIOFactory.h
@@ -37,11 +37,7 @@ namespace rtk
 class RTK_EXPORT ImagXImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImagXImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ImagXImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = ImagXImageIOFactory;

--- a/include/rtkImagXXMLFileReader.h
+++ b/include/rtkImagXXMLFileReader.h
@@ -43,11 +43,7 @@ namespace rtk
 class RTK_EXPORT ImagXXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImagXXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ImagXXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = ImagXXMLFileReader;

--- a/include/rtkImageToVectorImageFilter.h
+++ b/include/rtkImageToVectorImageFilter.h
@@ -47,11 +47,7 @@ template <typename InputImageType, typename OutputImageType>
 class ITK_TEMPLATE_EXPORT ImageToVectorImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToVectorImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ImageToVectorImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ImageToVectorImageFilter;

--- a/include/rtkImportImageFilter.h
+++ b/include/rtkImportImageFilter.h
@@ -44,11 +44,7 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT ImportImageFilter : public itk::ImageSource<TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImportImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ImportImageFilter);
-#endif
 
   /** Typedef for the output image.   */
   using OutputImagePointer = typename TImage::Pointer;

--- a/include/rtkInterpolatorWithKnownWeightsImageFilter.h
+++ b/include/rtkInterpolatorWithKnownWeightsImageFilter.h
@@ -65,11 +65,7 @@ class ITK_TEMPLATE_EXPORT InterpolatorWithKnownWeightsImageFilter
   : public itk::InPlaceImageFilter<VolumeType, VolumeType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(InterpolatorWithKnownWeightsImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(InterpolatorWithKnownWeightsImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = InterpolatorWithKnownWeightsImageFilter;

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -58,11 +58,7 @@ class ITK_TEMPLATE_EXPORT IterativeConeBeamReconstructionFilter
   : public itk::ImageToImageFilter<TOutputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(IterativeConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = IterativeConeBeamReconstructionFilter;

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -108,11 +108,7 @@ class ITK_TEMPLATE_EXPORT IterativeFDKConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterativeFDKConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(IterativeFDKConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = IterativeFDKConeBeamReconstructionFilter;

--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.h
@@ -212,11 +212,7 @@ class ITK_TEMPLATE_EXPORT JosephBackAttenuatedProjectionImageFilter
                                            TSumAlongRay>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(JosephBackAttenuatedProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(JosephBackAttenuatedProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = JosephBackAttenuatedProjectionImageFilter;

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -164,11 +164,7 @@ template <
 class ITK_TEMPLATE_EXPORT JosephBackProjectionImageFilter : public BackProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(JosephBackProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(JosephBackProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = JosephBackProjectionImageFilter;

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -270,11 +270,7 @@ class ITK_TEMPLATE_EXPORT JosephForwardAttenuatedProjectionImageFilter
                                               TSumAlongRay>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(JosephForwardAttenuatedProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(JosephForwardAttenuatedProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = JosephForwardAttenuatedProjectionImageFilter;

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -171,11 +171,7 @@ class ITK_TEMPLATE_EXPORT JosephForwardProjectionImageFilter
   : public ForwardProjectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(JosephForwardProjectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(JosephForwardProjectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = JosephForwardProjectionImageFilter;

--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
@@ -79,11 +79,7 @@ class ITK_TEMPLATE_EXPORT LUTbasedVariableI0RawToAttenuationImageFilter
   : public LookupTableImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(LUTbasedVariableI0RawToAttenuationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(LUTbasedVariableI0RawToAttenuationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = LUTbasedVariableI0RawToAttenuationImageFilter;

--- a/include/rtkLagCorrectionImageFilter.h
+++ b/include/rtkLagCorrectionImageFilter.h
@@ -55,11 +55,7 @@ template <typename TImage, unsigned VModelOrder>
 class ITK_TEMPLATE_EXPORT LagCorrectionImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(LagCorrectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(LagCorrectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = LagCorrectionImageFilter;

--- a/include/rtkLaplacianImageFilter.h
+++ b/include/rtkLaplacianImageFilter.h
@@ -41,11 +41,7 @@ template <typename OutputImageType, typename GradientImageType>
 class ITK_TEMPLATE_EXPORT LaplacianImageFilter : public itk::ImageToImageFilter<OutputImageType, OutputImageType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(LaplacianImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(LaplacianImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = LaplacianImageFilter;

--- a/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
+++ b/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
@@ -44,11 +44,7 @@ class ITK_TEMPLATE_EXPORT LastDimensionL0GradientDenoisingImageFilter
   : public itk::InPlaceImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(LastDimensionL0GradientDenoisingImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(LastDimensionL0GradientDenoisingImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = LastDimensionL0GradientDenoisingImageFilter;

--- a/include/rtkLookupTableImageFilter.h
+++ b/include/rtkLookupTableImageFilter.h
@@ -147,11 +147,7 @@ class ITK_TEMPLATE_EXPORT LookupTableImageFilter
                                         Functor::LUT<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(LookupTableImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(LookupTableImageFilter);
-#endif
 
   /** Lookup table type definition. */
   using FunctorType = Functor::LUT<typename TInputImage::PixelType, typename TOutputImage::PixelType>;

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -40,11 +40,7 @@ template <typename TInputImage, typename TRealType = float, typename TOutputImag
 class ITK_TEMPLATE_EXPORT MagnitudeThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MagnitudeThresholdImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MagnitudeThresholdImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MagnitudeThresholdImageFilter;

--- a/include/rtkMaskCollimationImageFilter.h
+++ b/include/rtkMaskCollimationImageFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT MaskCollimationImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MaskCollimationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MaskCollimationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MaskCollimationImageFilter;

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -147,11 +147,7 @@ class ITK_TEMPLATE_EXPORT MechlemOneStepSpectralReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TOutputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MechlemOneStepSpectralReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MechlemOneStepSpectralReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MechlemOneStepSpectralReconstructionFilter;

--- a/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -71,11 +71,7 @@ class ITK_TEMPLATE_EXPORT MotionCompensatedFourDConjugateGradientConeBeamReconst
   : public rtk::FourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter;

--- a/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
@@ -140,11 +140,7 @@ class ITK_TEMPLATE_EXPORT MotionCompensatedFourDROOSTERConeBeamReconstructionFil
   : public rtk::FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MotionCompensatedFourDROOSTERConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MotionCompensatedFourDROOSTERConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MotionCompensatedFourDROOSTERConeBeamReconstructionFilter;

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -101,11 +101,7 @@ class ITK_TEMPLATE_EXPORT MotionCompensatedFourDReconstructionConjugateGradientO
   : public FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MotionCompensatedFourDReconstructionConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MotionCompensatedFourDReconstructionConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = MotionCompensatedFourDReconstructionConjugateGradientOperator;

--- a/include/rtkMultiplyByVectorImageFilter.h
+++ b/include/rtkMultiplyByVectorImageFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage>
 class ITK_TEMPLATE_EXPORT MultiplyByVectorImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(MultiplyByVectorImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(MultiplyByVectorImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = MultiplyByVectorImageFilter;

--- a/include/rtkNesterovUpdateImageFilter.h
+++ b/include/rtkNesterovUpdateImageFilter.h
@@ -42,11 +42,7 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT NesterovUpdateImageFilter : public itk::InPlaceImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(NesterovUpdateImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(NesterovUpdateImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = NesterovUpdateImageFilter;

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -119,11 +119,7 @@ class ITK_TEMPLATE_EXPORT OSEMConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(OSEMConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(OSEMConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = OSEMConeBeamReconstructionFilter;

--- a/include/rtkOraGeometryReader.h
+++ b/include/rtkOraGeometryReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT OraGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(OraGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(OraGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = OraGeometryReader;

--- a/include/rtkOraImageIOFactory.h
+++ b/include/rtkOraImageIOFactory.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT OraImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(OraImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(OraImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = OraImageIOFactory;

--- a/include/rtkOraLookupTableImageFilter.h
+++ b/include/rtkOraLookupTableImageFilter.h
@@ -43,11 +43,7 @@ class ITK_TEMPLATE_EXPORT OraLookupTableImageFilter
   : public LookupTableImageFilter<itk::Image<unsigned short, TOutputImage::ImageDimension>, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(OraLookupTableImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(OraLookupTableImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = OraLookupTableImageFilter;

--- a/include/rtkOraXMLFileReader.h
+++ b/include/rtkOraXMLFileReader.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT OraXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(OraXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(OraXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = OraXMLFileReader;

--- a/include/rtkParkerShortScanImageFilter.h
+++ b/include/rtkParkerShortScanImageFilter.h
@@ -47,11 +47,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ParkerShortScanImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParkerShortScanImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ParkerShortScanImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ParkerShortScanImageFilter;

--- a/include/rtkPhaseGatingImageFilter.h
+++ b/include/rtkPhaseGatingImageFilter.h
@@ -34,11 +34,7 @@ template <typename ProjectionStackType>
 class ITK_TEMPLATE_EXPORT PhaseGatingImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseGatingImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(PhaseGatingImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = PhaseGatingImageFilter;

--- a/include/rtkPhaseReader.h
+++ b/include/rtkPhaseReader.h
@@ -35,11 +35,7 @@ namespace rtk
 class RTK_EXPORT PhaseReader : public itk::CSVFileReaderBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(PhaseReader);
-#endif
 
   /** Standard class type alias */
   using Self = PhaseReader;

--- a/include/rtkPhasesToInterpolationWeights.h
+++ b/include/rtkPhasesToInterpolationWeights.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT PhasesToInterpolationWeights : public itk::CSVFileReaderBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhasesToInterpolationWeights);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(PhasesToInterpolationWeights);
-#endif
 
   /** Standard class type alias */
   using Self = PhasesToInterpolationWeights;

--- a/include/rtkPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkPolynomialGainCorrectionImageFilter.h
@@ -45,11 +45,7 @@ class ITK_TEMPLATE_EXPORT PolynomialGainCorrectionImageFilter
   : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(PolynomialGainCorrectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(PolynomialGainCorrectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = PolynomialGainCorrectionImageFilter;

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT ProjectGeometricPhantomImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectGeometricPhantomImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ProjectGeometricPhantomImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ProjectGeometricPhantomImageFilter;

--- a/include/rtkProjectionGeometry.h
+++ b/include/rtkProjectionGeometry.h
@@ -44,11 +44,7 @@ template <unsigned int TDimension = 3>
 class ITK_TEMPLATE_EXPORT ProjectionGeometry : public itk::DataObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectionGeometry);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ProjectionGeometry);
-#endif
 
   using Self = ProjectionGeometry<TDimension>;
   using Superclass = itk::DataObject;

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -106,11 +106,7 @@ class ITK_TEMPLATE_EXPORT ProjectionStackToFourDImageFilter
   : public itk::ImageToImageFilter<VolumeSeriesType, VolumeSeriesType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectionStackToFourDImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ProjectionStackToFourDImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ProjectionStackToFourDImageFilter;

--- a/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
+++ b/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
@@ -39,11 +39,7 @@ namespace rtk
 class ProjectionsDecompositionNegativeLogLikelihood : public itk::SingleValuedCostFunction
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectionsDecompositionNegativeLogLikelihood);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ProjectionsDecompositionNegativeLogLikelihood);
-#endif
 
   using Self = ProjectionsDecompositionNegativeLogLikelihood;
   using Superclass = itk::SingleValuedCostFunction;

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -125,11 +125,7 @@ template <class TOutputImage>
 class ITK_TEMPLATE_EXPORT ProjectionsReader : public itk::ImageSource<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProjectionsReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ProjectionsReader);
-#endif
 
   /** Standard class type alias. */
   using Self = ProjectionsReader;

--- a/include/rtkRayBoxIntersectionImageFilter.h
+++ b/include/rtkRayBoxIntersectionImageFilter.h
@@ -40,11 +40,7 @@ class ITK_TEMPLATE_EXPORT RayBoxIntersectionImageFilter
   : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(RayBoxIntersectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(RayBoxIntersectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = RayBoxIntersectionImageFilter;

--- a/include/rtkRayConvexIntersectionImageFilter.h
+++ b/include/rtkRayConvexIntersectionImageFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT RayConvexIntersectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(RayConvexIntersectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(RayConvexIntersectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = RayConvexIntersectionImageFilter;

--- a/include/rtkRayEllipsoidIntersectionImageFilter.h
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.h
@@ -44,11 +44,7 @@ class ITK_TEMPLATE_EXPORT RayEllipsoidIntersectionImageFilter
   : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(RayEllipsoidIntersectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(RayEllipsoidIntersectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = RayEllipsoidIntersectionImageFilter;

--- a/include/rtkRayQuadricIntersectionImageFilter.h
+++ b/include/rtkRayQuadricIntersectionImageFilter.h
@@ -39,11 +39,7 @@ class ITK_TEMPLATE_EXPORT RayQuadricIntersectionImageFilter
   : public RayConvexIntersectionImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(RayQuadricIntersectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(RayQuadricIntersectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = RayQuadricIntersectionImageFilter;

--- a/include/rtkReconstructImageFilter.h
+++ b/include/rtkReconstructImageFilter.h
@@ -123,11 +123,7 @@ template <class TImage>
 class ITK_TEMPLATE_EXPORT ReconstructImageFilter : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ReconstructImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ReconstructImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ReconstructImageFilter;

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -118,11 +118,7 @@ template <typename TOutputImage, typename TSingleComponentImage = TOutputImage, 
 class ITK_TEMPLATE_EXPORT ReconstructionConjugateGradientOperator : public ConjugateGradientOperator<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ReconstructionConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ReconstructionConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = ReconstructionConjugateGradientOperator;

--- a/include/rtkReg1DExtractShroudSignalImageFilter.h
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.h
@@ -39,11 +39,7 @@ class ITK_TEMPLATE_EXPORT Reg1DExtractShroudSignalImageFilter
   : public itk::ImageToImageFilter<itk::Image<TInputPixel, 2>, itk::Image<TOutputPixel, 1>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(Reg1DExtractShroudSignalImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(Reg1DExtractShroudSignalImageFilter);
-#endif
 
   /** Standard class type alias. */
   using TInputImage = itk::Image<TInputPixel, 2>;

--- a/include/rtkReg23ProjectionGeometry.h
+++ b/include/rtkReg23ProjectionGeometry.h
@@ -63,11 +63,7 @@ namespace rtk
 class RTK_EXPORT Reg23ProjectionGeometry : public rtk::ThreeDCircularProjectionGeometry
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(Reg23ProjectionGeometry);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(Reg23ProjectionGeometry);
-#endif
 
   /** General type alias **/
   using Self = Reg23ProjectionGeometry;

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -108,11 +108,7 @@ class ITK_TEMPLATE_EXPORT RegularizedConjugateGradientConeBeamReconstructionFilt
   : public rtk::IterativeConeBeamReconstructionFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(RegularizedConjugateGradientConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(RegularizedConjugateGradientConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = RegularizedConjugateGradientConeBeamReconstructionFilter;

--- a/include/rtkReorderProjectionsImageFilter.h
+++ b/include/rtkReorderProjectionsImageFilter.h
@@ -45,11 +45,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ReorderProjectionsImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ReorderProjectionsImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ReorderProjectionsImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ReorderProjectionsImageFilter;

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -136,11 +136,7 @@ class ITK_TEMPLATE_EXPORT SARTConeBeamReconstructionFilter
   : public rtk::IterativeConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SARTConeBeamReconstructionFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SARTConeBeamReconstructionFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SARTConeBeamReconstructionFilter;

--- a/include/rtkScatterGlareCorrectionImageFilter.h
+++ b/include/rtkScatterGlareCorrectionImageFilter.h
@@ -43,11 +43,7 @@ class ITK_TEMPLATE_EXPORT ScatterGlareCorrectionImageFilter
   : public rtk::FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ScatterGlareCorrectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ScatterGlareCorrectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = ScatterGlareCorrectionImageFilter;

--- a/include/rtkSchlomka2008NegativeLogLikelihood.h
+++ b/include/rtkSchlomka2008NegativeLogLikelihood.h
@@ -45,11 +45,7 @@ namespace rtk
 class Schlomka2008NegativeLogLikelihood : public rtk::ProjectionsDecompositionNegativeLogLikelihood
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(Schlomka2008NegativeLogLikelihood);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(Schlomka2008NegativeLogLikelihood);
-#endif
 
   using Self = Schlomka2008NegativeLogLikelihood;
   using Superclass = rtk::ProjectionsDecompositionNegativeLogLikelihood;

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.h
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.h
@@ -39,11 +39,7 @@ template <typename ProjectionStackType>
 class ITK_TEMPLATE_EXPORT SelectOneProjectionPerCycleImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SelectOneProjectionPerCycleImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SelectOneProjectionPerCycleImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SelectOneProjectionPerCycleImageFilter;

--- a/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
+++ b/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
@@ -45,11 +45,7 @@ class ITK_TEMPLATE_EXPORT SeparableQuadraticSurrogateRegularizationImageFilter
   : public itk::ImageToImageFilter<TImage, TImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SeparableQuadraticSurrogateRegularizationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SeparableQuadraticSurrogateRegularizationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SeparableQuadraticSurrogateRegularizationImageFilter;

--- a/include/rtkSheppLoganPhantom.h
+++ b/include/rtkSheppLoganPhantom.h
@@ -41,11 +41,7 @@ namespace rtk
 class RTK_EXPORT SheppLoganPhantom : public GeometricPhantom
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SheppLoganPhantom);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SheppLoganPhantom);
-#endif
 
   /** Standard class type alias. */
   using Self = SheppLoganPhantom;

--- a/include/rtkSheppLoganPhantomFilter.h
+++ b/include/rtkSheppLoganPhantomFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage>
 class ITK_TEMPLATE_EXPORT SheppLoganPhantomFilter : public ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SheppLoganPhantomFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SheppLoganPhantomFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SheppLoganPhantomFilter;

--- a/include/rtkSignalToInterpolationWeights.h
+++ b/include/rtkSignalToInterpolationWeights.h
@@ -40,11 +40,7 @@ namespace rtk
 class RTK_EXPORT SignalToInterpolationWeights : public itk::CSVFileReaderBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SignalToInterpolationWeights);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SignalToInterpolationWeights);
-#endif
 
   /** Standard class type alias */
   using Self = SignalToInterpolationWeights;

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
@@ -46,11 +46,7 @@ class ITK_TEMPLATE_EXPORT SimplexSpectralProjectionsDecompositionImageFilter
   : public itk::ImageToImageFilter<DecomposedProjectionsType, DecomposedProjectionsType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SimplexSpectralProjectionsDecompositionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SimplexSpectralProjectionsDecompositionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SimplexSpectralProjectionsDecompositionImageFilter;

--- a/include/rtkSingularValueThresholdImageFilter.h
+++ b/include/rtkSingularValueThresholdImageFilter.h
@@ -50,11 +50,7 @@ template <typename TInputImage, typename TRealType = float, typename TOutputImag
 class ITK_TEMPLATE_EXPORT SingularValueThresholdImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SingularValueThresholdImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SingularValueThresholdImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SingularValueThresholdImageFilter;

--- a/include/rtkSoftThresholdImageFilter.h
+++ b/include/rtkSoftThresholdImageFilter.h
@@ -87,11 +87,7 @@ class ITK_TEMPLATE_EXPORT SoftThresholdImageFilter
       Functor::SoftThreshold<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SoftThresholdImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SoftThresholdImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SoftThresholdImageFilter;

--- a/include/rtkSoftThresholdTVImageFilter.h
+++ b/include/rtkSoftThresholdTVImageFilter.h
@@ -45,11 +45,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT SoftThresholdTVImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SoftThresholdTVImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SoftThresholdTVImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SoftThresholdTVImageFilter;

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -48,11 +48,7 @@ class ITK_TEMPLATE_EXPORT SpectralForwardModelImageFilter
   : public itk::InPlaceImageFilter<MeasuredProjectionsType, MeasuredProjectionsType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SpectralForwardModelImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SpectralForwardModelImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SpectralForwardModelImageFilter;

--- a/include/rtkSplatWithKnownWeightsImageFilter.h
+++ b/include/rtkSplatWithKnownWeightsImageFilter.h
@@ -68,11 +68,7 @@ class ITK_TEMPLATE_EXPORT SplatWithKnownWeightsImageFilter
   : public itk::InPlaceImageFilter<VolumeSeriesType, VolumeSeriesType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SplatWithKnownWeightsImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SplatWithKnownWeightsImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SplatWithKnownWeightsImageFilter;

--- a/include/rtkSubSelectFromListImageFilter.h
+++ b/include/rtkSubSelectFromListImageFilter.h
@@ -33,11 +33,7 @@ template <typename ProjectionStackType>
 class ITK_TEMPLATE_EXPORT SubSelectFromListImageFilter : public SubSelectImageFilter<ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SubSelectFromListImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SubSelectFromListImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SubSelectFromListImageFilter;

--- a/include/rtkSubSelectImageFilter.h
+++ b/include/rtkSubSelectImageFilter.h
@@ -65,11 +65,7 @@ class ITK_TEMPLATE_EXPORT SubSelectImageFilter
   : public itk::ImageToImageFilter<ProjectionStackType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SubSelectImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SubSelectImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SubSelectImageFilter;

--- a/include/rtkSumOfSquaresImageFilter.h
+++ b/include/rtkSumOfSquaresImageFilter.h
@@ -37,11 +37,7 @@ template <class TOutputImage>
 class ITK_TEMPLATE_EXPORT SumOfSquaresImageFilter : public itk::InPlaceImageFilter<TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(SumOfSquaresImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(SumOfSquaresImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = SumOfSquaresImageFilter;

--- a/include/rtkThreeDCircularProjectionGeometry.h
+++ b/include/rtkThreeDCircularProjectionGeometry.h
@@ -50,11 +50,7 @@ namespace rtk
 class RTK_EXPORT ThreeDCircularProjectionGeometry : public ProjectionGeometry<3>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ThreeDCircularProjectionGeometry);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ThreeDCircularProjectionGeometry);
-#endif
 
   using Self = ThreeDCircularProjectionGeometry;
   using Superclass = ProjectionGeometry<3>;

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
@@ -44,11 +44,7 @@ namespace rtk
 class RTK_EXPORT ThreeDCircularProjectionGeometryXMLFileReader : public itk::XMLReader<ThreeDCircularProjectionGeometry>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ThreeDCircularProjectionGeometryXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ThreeDCircularProjectionGeometryXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = ThreeDCircularProjectionGeometryXMLFileReader;

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
@@ -42,11 +42,7 @@ class RTK_EXPORT ThreeDCircularProjectionGeometryXMLFileWriter
   : public itk::XMLWriterBase<ThreeDCircularProjectionGeometry>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(ThreeDCircularProjectionGeometryXMLFileWriter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(ThreeDCircularProjectionGeometryXMLFileWriter);
-#endif
 
   /** standard type alias */
   using Superclass = itk::XMLWriterBase<ThreeDCircularProjectionGeometry>;

--- a/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
@@ -118,11 +118,7 @@ class ITK_TEMPLATE_EXPORT TotalNuclearVariationDenoisingBPDQImageFilter
   : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(TotalNuclearVariationDenoisingBPDQImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(TotalNuclearVariationDenoisingBPDQImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = TotalNuclearVariationDenoisingBPDQImageFilter;

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.h
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.h
@@ -80,11 +80,7 @@ class ITK_TEMPLATE_EXPORT TotalVariationDenoiseSequenceImageFilter
   : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(TotalVariationDenoiseSequenceImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(TotalVariationDenoiseSequenceImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = TotalVariationDenoiseSequenceImageFilter;

--- a/include/rtkTotalVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalVariationDenoisingBPDQImageFilter.h
@@ -114,11 +114,7 @@ class ITK_TEMPLATE_EXPORT TotalVariationDenoisingBPDQImageFilter
   : public rtk::DenoisingBPDQImageFilter<TOutputImage, TGradientImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(TotalVariationDenoisingBPDQImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(TotalVariationDenoisingBPDQImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = TotalVariationDenoisingBPDQImageFilter;

--- a/include/rtkTotalVariationImageFilter.h
+++ b/include/rtkTotalVariationImageFilter.h
@@ -50,11 +50,7 @@ template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT TotalVariationImageFilter : public itk::ImageToImageFilter<TInputImage, TInputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(TotalVariationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(TotalVariationImageFilter);
-#endif
 
   /** Standard Self type alias */
   using Self = TotalVariationImageFilter;

--- a/include/rtkUnwarpSequenceConjugateGradientOperator.h
+++ b/include/rtkUnwarpSequenceConjugateGradientOperator.h
@@ -67,11 +67,7 @@ template <typename TImageSequence,
 class ITK_TEMPLATE_EXPORT UnwarpSequenceConjugateGradientOperator : public ConjugateGradientOperator<TImageSequence>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(UnwarpSequenceConjugateGradientOperator);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(UnwarpSequenceConjugateGradientOperator);
-#endif
 
   /** Standard class type alias. */
   using Self = UnwarpSequenceConjugateGradientOperator;

--- a/include/rtkUnwarpSequenceImageFilter.h
+++ b/include/rtkUnwarpSequenceImageFilter.h
@@ -81,11 +81,7 @@ template <typename TImageSequence,
 class ITK_TEMPLATE_EXPORT UnwarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(UnwarpSequenceImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(UnwarpSequenceImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = UnwarpSequenceImageFilter;

--- a/include/rtkUpsampleImageFilter.h
+++ b/include/rtkUpsampleImageFilter.h
@@ -39,11 +39,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT UpsampleImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(UpsampleImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(UpsampleImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = UpsampleImageFilter;

--- a/include/rtkVarianObiGeometryReader.h
+++ b/include/rtkVarianObiGeometryReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT VarianObiGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianObiGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VarianObiGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = VarianObiGeometryReader;

--- a/include/rtkVarianObiRawImageFilter.h
+++ b/include/rtkVarianObiRawImageFilter.h
@@ -96,11 +96,7 @@ class ITK_TEMPLATE_EXPORT VarianObiRawImageFilter
       Function::ObiAttenuation<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianObiRawImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VarianObiRawImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = VarianObiRawImageFilter;

--- a/include/rtkVarianObiXMLFileReader.h
+++ b/include/rtkVarianObiXMLFileReader.h
@@ -45,11 +45,7 @@ namespace rtk
 class RTK_EXPORT VarianObiXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianObiXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VarianObiXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = VarianObiXMLFileReader;

--- a/include/rtkVarianProBeamGeometryReader.h
+++ b/include/rtkVarianProBeamGeometryReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT VarianProBeamGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianProBeamGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VarianProBeamGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = VarianProBeamGeometryReader;

--- a/include/rtkVarianProBeamXMLFileReader.h
+++ b/include/rtkVarianProBeamXMLFileReader.h
@@ -44,11 +44,7 @@ namespace rtk
 class RTK_EXPORT VarianProBeamXMLFileReader : public itk::XMLReader<itk::MetaDataDictionary>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VarianProBeamXMLFileReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VarianProBeamXMLFileReader);
-#endif
 
   /** Standard type alias */
   using Self = VarianProBeamXMLFileReader;

--- a/include/rtkVectorImageToImageFilter.h
+++ b/include/rtkVectorImageToImageFilter.h
@@ -47,11 +47,7 @@ template <typename InputImageType, typename OutputImageType>
 class ITK_TEMPLATE_EXPORT VectorImageToImageFilter : public itk::ImageToImageFilter<InputImageType, OutputImageType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(VectorImageToImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(VectorImageToImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = VectorImageToImageFilter;

--- a/include/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.h
@@ -89,11 +89,7 @@ class ITK_TEMPLATE_EXPORT WarpFourDToProjectionStackImageFilter
   : public rtk::FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(WarpFourDToProjectionStackImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(WarpFourDToProjectionStackImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = WarpFourDToProjectionStackImageFilter;

--- a/include/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/include/rtkWarpProjectionStackToFourDImageFilter.h
@@ -86,11 +86,7 @@ class ITK_TEMPLATE_EXPORT WarpProjectionStackToFourDImageFilter
   : public ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(WarpProjectionStackToFourDImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(WarpProjectionStackToFourDImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = WarpProjectionStackToFourDImageFilter;

--- a/include/rtkWarpSequenceImageFilter.h
+++ b/include/rtkWarpSequenceImageFilter.h
@@ -97,11 +97,7 @@ template <typename TImageSequence,
 class ITK_TEMPLATE_EXPORT WarpSequenceImageFilter : public itk::ImageToImageFilter<TImageSequence, TImageSequence>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(WarpSequenceImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(WarpSequenceImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = WarpSequenceImageFilter;

--- a/include/rtkWaterPrecorrectionImageFilter.h
+++ b/include/rtkWaterPrecorrectionImageFilter.h
@@ -40,11 +40,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT WaterPrecorrectionImageFilter : public itk::InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaterPrecorrectionImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(WaterPrecorrectionImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = WaterPrecorrectionImageFilter;

--- a/include/rtkWeidingerForwardModelImageFilter.h
+++ b/include/rtkWeidingerForwardModelImageFilter.h
@@ -47,11 +47,7 @@ class ITK_TEMPLATE_EXPORT WeidingerForwardModelImageFilter
   : public itk::ImageToImageFilter<TMaterialProjections, TMaterialProjections>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(WeidingerForwardModelImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(WeidingerForwardModelImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = WeidingerForwardModelImageFilter;

--- a/include/rtkXRadGeometryReader.h
+++ b/include/rtkXRadGeometryReader.h
@@ -39,11 +39,7 @@ namespace rtk
 class RTK_EXPORT XRadGeometryReader : public itk::LightProcessObject
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(XRadGeometryReader);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(XRadGeometryReader);
-#endif
 
   /** Standard type alias */
   using Self = XRadGeometryReader;

--- a/include/rtkXRadImageIOFactory.h
+++ b/include/rtkXRadImageIOFactory.h
@@ -38,11 +38,7 @@ namespace rtk
 class RTK_EXPORT XRadImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(XRadImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(XRadImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = XRadImageIOFactory;

--- a/include/rtkXRadRawToAttenuationImageFilter.h
+++ b/include/rtkXRadRawToAttenuationImageFilter.h
@@ -36,11 +36,7 @@ template <class TInputImage, class TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT XRadRawToAttenuationImageFilter : public itk::ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(XRadRawToAttenuationImageFilter);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(XRadRawToAttenuationImageFilter);
-#endif
 
   /** Standard class type alias. */
   using Self = XRadRawToAttenuationImageFilter;

--- a/include/rtkXimImageIOFactory.h
+++ b/include/rtkXimImageIOFactory.h
@@ -44,11 +44,7 @@ namespace rtk
 class RTK_EXPORT XimImageIOFactory : public itk::ObjectFactoryBase
 {
 public:
-#if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1
-  ITK_DISALLOW_COPY_AND_ASSIGN(XimImageIOFactory);
-#else
   ITK_DISALLOW_COPY_AND_MOVE(XimImageIOFactory);
-#endif
 
   /** Standard class type alias. */
   using Self = XimImageIOFactory;


### PR DESCRIPTION
RTK is only maintained with the latest ITK release and ITK v5.2 has been
released on April 2021.
The sed command use for this patch is
for i in include/* ; do sed -i ':a;N;$!ba;s/# *if ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 1\n  ITK_DISALLOW_COPY_AND_ASSIGN.*\(ITK_DISALLOW_COPY_AND_MOVE([[:alnum:]_]*);\)\n# *endif/  \1/g' $i ; done