### PR TITLE
STYLE: Replace itkStaticConstMacro with static constexpr

### DIFF
--- a/include/rtkAdditiveGaussianNoiseImageFilter.h
+++ b/include/rtkAdditiveGaussianNoiseImageFilter.h
@@ -198,7 +198,7 @@ public:
   using InputPixelType = typename InputImageType::PixelType;
 
   /** ImageDimension constants */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
   // virtual void GenerateOutputInformation();
 

--- a/include/rtkAmsterdamShroudImageFilter.h
+++ b/include/rtkAmsterdamShroudImageFilter.h
@@ -97,9 +97,9 @@ public:
   using GeometryPointer = typename GeometryType::Pointer;
 
   /** ImageDimension constants */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/include/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/include/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -44,7 +44,7 @@ public:
   ITK_DISALLOW_COPY_AND_MOVE(BackwardDifferenceDivergenceImageFilter);
 
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
   /** Convenient type alias for simplifying declarations. */
   using InputImageType = TInputImage;

--- a/include/rtkDPExtractShroudSignalImageFilter.h
+++ b/include/rtkDPExtractShroudSignalImageFilter.h
@@ -50,9 +50,9 @@ public:
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** ImageDimension constants */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/include/rtkDivergenceOfGradientConjugateGradientOperator.h
+++ b/include/rtkDivergenceOfGradientConjugateGradientOperator.h
@@ -41,7 +41,7 @@ public:
   ITK_DISALLOW_COPY_AND_MOVE(DivergenceOfGradientConjugateGradientOperator);
 
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 
   /** Convenient type alias for simplifying declarations. */
   using InputImageType = TInputImage;

--- a/include/rtkDownsampleImageFilter.h
+++ b/include/rtkDownsampleImageFilter.h
@@ -63,7 +63,7 @@ public:
   using OutputImageRegionType = typename TOutputImage::RegionType;
 
   /** ImageDimension enumeration. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Set the downsample factors. Values are clamped to
    * a minimum value of 1.*/

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -68,7 +68,7 @@ public:
   using ZeroPadFactorsType = itk::Vector<int, 2>;
 
   /** ImageDimension constants */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Runtime information support. */
   itkTypeMacro(FFTProjectionsConvolutionImageFilter, ImageToImageFilter);

--- a/include/rtkForwardDifferenceGradientImageFilter.h
+++ b/include/rtkForwardDifferenceGradientImageFilter.h
@@ -59,8 +59,8 @@ public:
   ITK_DISALLOW_COPY_AND_MOVE(ForwardDifferenceGradientImageFilter);
 
   /** Extract dimension from input image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOuputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOuputImage::ImageDimension;
 
   /** Standard class type alias. */
   using Self = ForwardDifferenceGradientImageFilter;

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -66,10 +66,10 @@ public:
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Length of the vector pixel type of the input image. */
-  itkStaticConstMacro(VectorDimension, unsigned int, InputPixelType::Dimension);
+  static constexpr unsigned int VectorDimension = InputPixelType::Dimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   using RealType = TRealType;

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -159,7 +159,7 @@ public:
   using StreamingType = itk::StreamingImageFilter<TOutputImage, TOutputImage>;
 
   /** ImageDimension constant */
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Set the vector of strings that contains the file names. Files
    * are processed in sequential order. */

--- a/include/rtkReg1DExtractShroudSignalImageFilter.h
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.h
@@ -50,9 +50,9 @@ public:
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** ImageDimension constants */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/include/rtkSingularValueThresholdImageFilter.h
+++ b/include/rtkSingularValueThresholdImageFilter.h
@@ -76,10 +76,10 @@ public:
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Length of the vector pixel type of the input image. */
-  itkStaticConstMacro(VectorDimension, unsigned int, InputPixelType::Dimension);
+  static constexpr unsigned int VectorDimension = InputPixelType::Dimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   using RealType = TRealType;

--- a/include/rtkSoftThresholdTVImageFilter.h
+++ b/include/rtkSoftThresholdTVImageFilter.h
@@ -71,10 +71,10 @@ public:
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Length of the vector pixel type of the input image. */
-  itkStaticConstMacro(VectorDimension, unsigned int, InputPixelType::Dimension);
+  static constexpr unsigned int VectorDimension = InputPixelType::Dimension;
 
   /** Superclass type alias. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;

--- a/include/rtkTotalVariationImageFilter.h
+++ b/include/rtkTotalVariationImageFilter.h
@@ -73,7 +73,7 @@ public:
   using PixelType = typename TInputImage::PixelType;
 
   /** Image related type alias. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Type to use for computations. */
   using RealType = typename itk::NumericTraits<PixelType>::RealType;

--- a/include/rtkUpsampleImageFilter.h
+++ b/include/rtkUpsampleImageFilter.h
@@ -64,7 +64,7 @@ public:
   using OutputImageRegionType = typename TOutputImage::RegionType;
 
   /** ImageDimension enumeration. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Set the shrink factors. Values are clamped to
    * a minimum value of 1.*/


### PR DESCRIPTION
Required following InsightSoftwareConsortium/ITK#2767
Done with the following bash scripts:
for i in include/*
do
    sed -i "s/itkStaticConstMacro(\(.*\), \(.*\),
    \(.*\));/static constexpr \2 \1 = \3;/g" $i
done