### PR TITLE
BUG: CudaFDKConeBeamReconstructionFilter not using GPU default subset size

### DIFF
--- a/src/rtkCudaFDKConeBeamReconstructionFilter.cxx
+++ b/src/rtkCudaFDKConeBeamReconstructionFilter.cxx
@@ -33,6 +33,9 @@ rtk::CudaFDKConeBeamReconstructionFilter ::CudaFDKConeBeamReconstructionFilter()
   // Default parameters
   m_BackProjectionFilter->InPlaceOn();
   m_BackProjectionFilter->SetTranspose(false);
+
+  // Overwrite subset size of CPU version with GPU default
+  CPUSuperclass::SetProjectionSubsetSize(SLAB_SIZE);
 }
 
 void


### PR DESCRIPTION
Fixes CudaFDKConeBeamReconstructionFilter not using the default number projection subsets as given by RTK_CUDA_PROJECTIONS_SLAB_SIZE (and thus SLAB_SIZE).
See discussion on [mailinglist](https://public.kitware.com/pipermail/rtk-users/2021-November/011117.html)