### PR TITLE
remove recursive header includes

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkADMMTotalVariationConeBeamReconstructionFilter_hxx
 #define rtkADMMTotalVariationConeBeamReconstructionFilter_hxx
 
-#include "rtkADMMTotalVariationConeBeamReconstructionFilter.h"
 
 #include <itkIterationReporter.h>
 

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkADMMTotalVariationConjugateGradientOperator_hxx
 #define rtkADMMTotalVariationConjugateGradientOperator_hxx
 
-#include "rtkADMMTotalVariationConjugateGradientOperator.h"
 
 namespace rtk
 {

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkADMMWaveletsConeBeamReconstructionFilter_hxx
 #define rtkADMMWaveletsConeBeamReconstructionFilter_hxx
 
-#include "rtkADMMWaveletsConeBeamReconstructionFilter.h"
 
 #include <itkIterationReporter.h>
 

--- a/include/rtkADMMWaveletsConjugateGradientOperator.hxx
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkADMMWaveletsConjugateGradientOperator_hxx
 #define rtkADMMWaveletsConjugateGradientOperator_hxx
 
-#include "rtkADMMWaveletsConjugateGradientOperator.h"
 
 namespace rtk
 {

--- a/include/rtkAddMatrixAndDiagonalImageFilter.hxx
+++ b/include/rtkAddMatrixAndDiagonalImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkAddMatrixAndDiagonalImageFilter_hxx
 #define rtkAddMatrixAndDiagonalImageFilter_hxx
 
-#include "rtkAddMatrixAndDiagonalImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "vnl/vnl_inverse.h"

--- a/include/rtkAdditiveGaussianNoiseImageFilter.hxx
+++ b/include/rtkAdditiveGaussianNoiseImageFilter.hxx
@@ -36,7 +36,6 @@
 #ifndef rtkAdditiveGaussianNoiseImageFilter_hxx
 #define rtkAdditiveGaussianNoiseImageFilter_hxx
 
-#include "rtkAdditiveGaussianNoiseImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkAmsterdamShroudImageFilter.hxx
+++ b/include/rtkAmsterdamShroudImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkAmsterdamShroudImageFilter_hxx
 #define rtkAmsterdamShroudImageFilter_hxx
 
-#include "rtkAmsterdamShroudImageFilter.h"
 #include "rtkHomogeneousMatrix.h"
 
 #include <itkImageFileWriter.h>

--- a/include/rtkAverageOutOfROIImageFilter.hxx
+++ b/include/rtkAverageOutOfROIImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkAverageOutOfROIImageFilter_hxx
 #define rtkAverageOutOfROIImageFilter_hxx
 
-#include "rtkAverageOutOfROIImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/rtkBackProjectionImageFilter.hxx
+++ b/include/rtkBackProjectionImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkBackProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 

--- a/include/rtkBackProjectionImageFilter.hxx
+++ b/include/rtkBackProjectionImageFilter.hxx
@@ -236,12 +236,12 @@ BackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
     }
 
     // Optimized version
-    if (fabs(matrix[1][0]) < 1e-10 && fabs(matrix[2][0]) < 1e-10)
+    if (itk::Math::abs(matrix[1][0]) < 1e-10 && itk::Math::abs(matrix[2][0]) < 1e-10)
     {
       OptimizedBackprojectionX(outputRegionForThread, matrix, projection);
       continue;
     }
-    if (fabs(matrix[1][1]) < 1e-10 && fabs(matrix[2][1]) < 1e-10)
+    if (itk::Math::abs(matrix[1][1]) < 1e-10 && itk::Math::abs(matrix[2][1]) < 1e-10)
     {
       OptimizedBackprojectionY(outputRegionForThread, matrix, projection);
       continue;

--- a/include/rtkBackwardDifferenceDivergenceImageFilter.hxx
+++ b/include/rtkBackwardDifferenceDivergenceImageFilter.hxx
@@ -18,7 +18,6 @@
 
 #ifndef rtkBackwardDifferenceDivergenceImageFilter_hxx
 #define rtkBackwardDifferenceDivergenceImageFilter_hxx
-#include "rtkBackwardDifferenceDivergenceImageFilter.h"
 
 #include <itkConstShapedNeighborhoodIterator.h>
 #include <itkNeighborhoodInnerProduct.h>

--- a/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.hxx
+++ b/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkBlockDiagonalMatrixVectorMultiplyImageFilter_hxx
 #define rtkBlockDiagonalMatrixVectorMultiplyImageFilter_hxx
 
-#include "rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "vnl/vnl_inverse.h"

--- a/include/rtkBoellaardScatterCorrectionImageFilter.hxx
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkBoellaardScatterCorrectionImageFilter_hxx
 #define rtkBoellaardScatterCorrectionImageFilter_hxx
 
-#include "rtkBoellaardScatterCorrectionImageFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkConditionalMedianImageFilter.hxx
+++ b/include/rtkConditionalMedianImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkConditionalMedianImageFilter_hxx
 #define rtkConditionalMedianImageFilter_hxx
 
-#include "rtkConditionalMedianImageFilter.h"
 #include <itkImageRegionIterator.h>
 #include <numeric>
 

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientConeBeamReconstructionFilter_hxx
 #define rtkConjugateGradientConeBeamReconstructionFilter_hxx
 
-#include "rtkConjugateGradientConeBeamReconstructionFilter.h"
 #include <itkProgressAccumulator.h>
 
 namespace rtk

--- a/include/rtkConjugateGradientGetP_kPlusOneImageFilter.hxx
+++ b/include/rtkConjugateGradientGetP_kPlusOneImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientGetP_kPlusOneImageFilter_hxx
 #define rtkConjugateGradientGetP_kPlusOneImageFilter_hxx
 
-#include "rtkConjugateGradientGetP_kPlusOneImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.hxx
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientGetR_kPlusOneImageFilter_hxx
 #define rtkConjugateGradientGetR_kPlusOneImageFilter_hxx
 
-#include "rtkConjugateGradientGetR_kPlusOneImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/include/rtkConjugateGradientGetX_kPlusOneImageFilter.hxx
+++ b/include/rtkConjugateGradientGetX_kPlusOneImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientGetX_kPlusOneImageFilter_hxx
 #define rtkConjugateGradientGetX_kPlusOneImageFilter_hxx
 
-#include "rtkConjugateGradientGetX_kPlusOneImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkConjugateGradientImageFilter.hxx
+++ b/include/rtkConjugateGradientImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientImageFilter_hxx
 #define rtkConjugateGradientImageFilter_hxx
 
-#include "rtkConjugateGradientImageFilter.h"
 #include <itkMultiThreaderBase.h>
 #include <mutex>
 #include <itkIterationReporter.h>

--- a/include/rtkConjugateGradientOperator.hxx
+++ b/include/rtkConjugateGradientOperator.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConjugateGradientOperator_hxx
 #define rtkConjugateGradientOperator_hxx
 
-#include "rtkConjugateGradientOperator.h"
 
 namespace rtk
 {

--- a/include/rtkConstantImageSource.hxx
+++ b/include/rtkConstantImageSource.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkConstantImageSource_hxx
 #define rtkConstantImageSource_hxx
 
-#include "rtkConstantImageSource.h"
 
 #include <itkImageRegionIterator.h>
 

--- a/include/rtkCyclicDeformationImageFilter.hxx
+++ b/include/rtkCyclicDeformationImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkCyclicDeformationImageFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkDPExtractShroudSignalImageFilter.hxx
+++ b/include/rtkDPExtractShroudSignalImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDPExtractShroudSignalImageFilter_hxx
 #define rtkDPExtractShroudSignalImageFilter_hxx
 
-#include "rtkDPExtractShroudSignalImageFilter.h"
 
 #include <itkArray.h>
 

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
@@ -20,7 +20,6 @@
 #define rtkDaubechiesWaveletsConvolutionImageFilter_hxx
 
 // Includes
-#include "rtkDaubechiesWaveletsConvolutionImageFilter.h"
 
 #include <vector>
 #include <algorithm>

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDaubechiesWaveletsDenoiseSequenceImageFilter_hxx
 #define rtkDaubechiesWaveletsDenoiseSequenceImageFilter_hxx
 
-#include "rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h"
 #include <itkImageFileWriter.h>
 
 namespace rtk

--- a/include/rtkDeconstructImageFilter.hxx
+++ b/include/rtkDeconstructImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDeconstructImageFilter_hxx
 #define rtkDeconstructImageFilter_hxx
 
-#include "rtkDeconstructImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkDeconstructSoftThresholdReconstructImageFilter.hxx
+++ b/include/rtkDeconstructSoftThresholdReconstructImageFilter.hxx
@@ -20,7 +20,6 @@
 #define rtkDeconstructSoftThresholdReconstructImageFilter_hxx
 
 // rtk Includes
-#include "rtkDeconstructSoftThresholdReconstructImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkDenoisingBPDQImageFilter.hxx
+++ b/include/rtkDenoisingBPDQImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDenoisingBPDQImageFilter_hxx
 #define rtkDenoisingBPDQImageFilter_hxx
 
-#include "rtkDenoisingBPDQImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
@@ -92,7 +92,7 @@ DisplacedDetectorForOffsetFieldOfViewImageFilter<TInputImage, TOutputImage>::Gen
                              << " space must be covered by all projections.");
   }
   // Case 2: Not displaced if less than 10% relative difference between radii
-  else if (200. * fabs(ri - rs) / (ri + rs) < 10.)
+  else if (200. * itk::Math::abs(ri - rs) / (ri + rs) < 10.)
   {
     this->SetInPlace(true);
   }

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDisplacedDetectorImageFilter_hxx
 #define rtkDisplacedDetectorImageFilter_hxx
 
-#include "rtkDisplacedDetectorImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -156,7 +156,7 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::GenerateOutputInformati
                              << " Corner inf=" << m_InferiorCorner << " and corner sup=" << m_SuperiorCorner);
   }
   // Case 2: Not displaced, or explicit request not to pad: default outputLargestPossibleRegion is fine
-  else if ((fabs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * fabs(m_SuperiorCorner - m_InferiorCorner)) ||
+  else if ((itk::Math::abs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * itk::Math::abs(m_SuperiorCorner - m_InferiorCorner)) ||
            !m_PadOnTruncatedSide)
   {
     this->SetInPlace(true);
@@ -204,7 +204,7 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   itk::ImageRegionConstIterator<InputImageType> itIn(this->GetInput(), overlapRegion);
 
   // Not displaced, nothing to do
-  if ((fabs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * fabs(m_SuperiorCorner - m_InferiorCorner)) || m_Disable)
+  if ((itk::Math::abs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * itk::Math::abs(m_SuperiorCorner - m_InferiorCorner)) || m_Disable)
   {
     // If not in place, copy is required
     if (this->GetInput() != this->GetOutput())

--- a/include/rtkDivergenceOfGradientConjugateGradientOperator.hxx
+++ b/include/rtkDivergenceOfGradientConjugateGradientOperator.hxx
@@ -18,7 +18,6 @@
 
 #ifndef rtkDivergenceOfGradientConjugateGradientOperator_hxx
 #define rtkDivergenceOfGradientConjugateGradientOperator_hxx
-#include "rtkDivergenceOfGradientConjugateGradientOperator.h"
 
 #include "itkConstShapedNeighborhoodIterator.h"
 #include "itkNeighborhoodInnerProduct.h"

--- a/include/rtkDownsampleImageFilter.hxx
+++ b/include/rtkDownsampleImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDownsampleImageFilter_hxx
 #define rtkDownsampleImageFilter_hxx
 
-#include "rtkDownsampleImageFilter.h"
 
 #include "itkImageRegionIterator.h"
 #include "itkObjectFactory.h"

--- a/include/rtkDrawBoxImageFilter.hxx
+++ b/include/rtkDrawBoxImageFilter.hxx
@@ -23,7 +23,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkDrawBoxImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkDrawConeImageFilter.hxx
+++ b/include/rtkDrawConeImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDrawConeImageFilter_hxx
 #define rtkDrawConeImageFilter_hxx
 
-#include "rtkDrawConeImageFilter.h"
 #include "rtkQuadricShape.h"
 
 namespace rtk

--- a/include/rtkDrawConvexImageFilter.hxx
+++ b/include/rtkDrawConvexImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDrawConvexImageFilter_hxx
 #define rtkDrawConvexImageFilter_hxx
 
-#include "rtkDrawConvexImageFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkDrawCylinderImageFilter.hxx
+++ b/include/rtkDrawCylinderImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDrawCylinderImageFilter_hxx
 #define rtkDrawCylinderImageFilter_hxx
 
-#include "rtkDrawCylinderImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkDrawEllipsoidImageFilter.hxx
+++ b/include/rtkDrawEllipsoidImageFilter.hxx
@@ -23,7 +23,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkDrawEllipsoidImageFilter.h"
 #include "rtkQuadricShape.h"
 
 namespace rtk

--- a/include/rtkDrawGeometricPhantomImageFilter.hxx
+++ b/include/rtkDrawGeometricPhantomImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDrawGeometricPhantomImageFilter_hxx
 #define rtkDrawGeometricPhantomImageFilter_hxx
 
-#include "rtkDrawGeometricPhantomImageFilter.h"
 #include "rtkGeometricPhantomFileReader.h"
 #include "rtkForbildPhantomFileReader.h"
 #include "rtkDrawConvexImageFilter.h"

--- a/include/rtkDrawQuadricImageFilter.hxx
+++ b/include/rtkDrawQuadricImageFilter.hxx
@@ -23,7 +23,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkDrawQuadricImageFilter.h"
 #include "rtkQuadricShape.h"
 
 namespace rtk

--- a/include/rtkDrawSheppLoganFilter.hxx
+++ b/include/rtkDrawSheppLoganFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkDrawSheppLoganFilter_hxx
 #define rtkDrawSheppLoganFilter_hxx
 
-#include "rtkDrawSheppLoganFilter.h"
 #include "rtkSheppLoganPhantom.h"
 
 namespace rtk

--- a/include/rtkEdfRawToAttenuationImageFilter.hxx
+++ b/include/rtkEdfRawToAttenuationImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkEdfRawToAttenuationImageFilter_hxx
 #define rtkEdfRawToAttenuationImageFilter_hxx
 
-#include "rtkEdfRawToAttenuationImageFilter.h"
 
 #include <itkImageFileWriter.h>
 #include <itksys/SystemTools.hxx>

--- a/include/rtkElektaSynergyLookupTableImageFilter.hxx
+++ b/include/rtkElektaSynergyLookupTableImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkElektaSynergyLookupTableImageFilter_hxx
 #define rtkElektaSynergyLookupTableImageFilter_hxx
 
-#include "rtkElektaSynergyLookupTableImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkElektaSynergyRawLookupTableImageFilter.hxx
+++ b/include/rtkElektaSynergyRawLookupTableImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkElektaSynergyRawLookupTableImageFilter_hxx
 #define rtkElektaSynergyRawLookupTableImageFilter_hxx
 
-#include "rtkElektaSynergyRawLookupTableImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkExtractPhaseImageFilter.hxx
+++ b/include/rtkExtractPhaseImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkExtractPhaseImageFilter_hxx
 #define rtkExtractPhaseImageFilter_hxx
 
-#include "rtkExtractPhaseImageFilter.h"
 
 #include "rtkHilbertImageFilter.h"
 

--- a/include/rtkFDKBackProjectionImageFilter.hxx
+++ b/include/rtkFDKBackProjectionImageFilter.hxx
@@ -105,12 +105,12 @@ FDKBackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
     matrix /= perspFactor;
 
     // Optimized version
-    if (fabs(matrix[1][0]) < 1e-10 && fabs(matrix[2][0]) < 1e-10)
+    if (itk::Math::abs(matrix[1][0]) < 1e-10 && itk::Math::abs(matrix[2][0]) < 1e-10)
     {
       OptimizedBackprojectionX(outputRegionForThread, matrix, projection);
       continue;
     }
-    if (fabs(matrix[1][1]) < 1e-10 && fabs(matrix[2][1]) < 1e-10)
+    if (itk::Math::abs(matrix[1][1]) < 1e-10 && itk::Math::abs(matrix[2][1]) < 1e-10)
     {
       OptimizedBackprojectionY(outputRegionForThread, matrix, projection);
       continue;

--- a/include/rtkFDKBackProjectionImageFilter.hxx
+++ b/include/rtkFDKBackProjectionImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkFDKBackProjectionImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkLinearInterpolateImageFunction.h>

--- a/include/rtkFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkFDKConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFDKConeBeamReconstructionFilter_hxx
 #define rtkFDKConeBeamReconstructionFilter_hxx
 
-#include "rtkFDKConeBeamReconstructionFilter.h"
 
 #include <itkProgressAccumulator.h>
 

--- a/include/rtkFDKWarpBackProjectionImageFilter.hxx
+++ b/include/rtkFDKWarpBackProjectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFDKWarpBackProjectionImageFilter_hxx
 #define rtkFDKWarpBackProjectionImageFilter_hxx
 
-#include "rtkFDKWarpBackProjectionImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkLinearInterpolateImageFunction.h>

--- a/include/rtkFDKWeightProjectionFilter.hxx
+++ b/include/rtkFDKWeightProjectionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFDKWeightProjectionFilter_hxx
 #define rtkFDKWeightProjectionFilter_hxx
 
-#include "rtkFDKWeightProjectionFilter.h"
 
 #include <itkImageRegionIterator.h>
 

--- a/include/rtkFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFFTProjectionsConvolutionImageFilter_hxx
 #define rtkFFTProjectionsConvolutionImageFilter_hxx
 
-#include "rtkFFTProjectionsConvolutionImageFilter.h"
 
 // Use local RTK FFTW files taken from Gaëtan Lehmann's code for
 // thread safety: http://hdl.handle.net/10380/3154

--- a/include/rtkFFTRampImageFilter.hxx
+++ b/include/rtkFFTRampImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFFTRampImageFilter_hxx
 #define rtkFFTRampImageFilter_hxx
 
-#include "rtkFFTRampImageFilter.h"
 
 // Use local RTK FFTW files taken from Gaëtan Lehmann's code for
 // thread safety: http://hdl.handle.net/10380/3154

--- a/include/rtkFieldOfViewImageFilter.hxx
+++ b/include/rtkFieldOfViewImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkFieldOfViewImageFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionConstIteratorWithIndex.h>

--- a/include/rtkForwardDifferenceGradientImageFilter.hxx
+++ b/include/rtkForwardDifferenceGradientImageFilter.hxx
@@ -18,7 +18,6 @@
 
 #ifndef rtkForwardDifferenceGradientImageFilter_hxx
 #define rtkForwardDifferenceGradientImageFilter_hxx
-#include "rtkForwardDifferenceGradientImageFilter.h"
 
 #include <itkConstNeighborhoodIterator.h>
 #include <itkNeighborhoodInnerProduct.h>

--- a/include/rtkForwardProjectionImageFilter.hxx
+++ b/include/rtkForwardProjectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkForwardProjectionImageFilter_hxx
 #define rtkForwardProjectionImageFilter_hxx
 
-#include "rtkForwardProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 

--- a/include/rtkForwardWarpImageFilter.hxx
+++ b/include/rtkForwardWarpImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkForwardWarpImageFilter_hxx
 #define rtkForwardWarpImageFilter_hxx
 
-#include "rtkForwardWarpImageFilter.h"
 #include "rtkHomogeneousMatrix.h"
 
 #include <itkImageRegionIterator.h>

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "rtkJosephForwardProjectionImageFilter.h"
 #include "rtkJosephBackProjectionImageFilter.h"
-#include "rtkFourDConjugateGradientConeBeamReconstructionFilter.h"
 
 #include <algorithm>
 

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkFourDROOSTERConeBeamReconstructionFilter_hxx
 #define rtkFourDROOSTERConeBeamReconstructionFilter_hxx
 
-#include "rtkFourDROOSTERConeBeamReconstructionFilter.h"
 #include <itkImageFileWriter.h>
 #include <itkIterationReporter.h>
 

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkFourDReconstructionConjugateGradientOperator_hxx
 #define rtkFourDReconstructionConjugateGradientOperator_hxx
 
-#include "rtkFourDReconstructionConjugateGradientOperator.h"
 #include "rtkGeneralPurposeFunctions.h"
 
 namespace rtk

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -274,7 +274,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
   {
     for (int proj = FirstProj + 1; proj < FirstProj + NumberProjs; proj++)
     {
-      if (fabs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
+      if (itk::Math::abs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
       {
         // Compute the number of projections in the current slab
         sizeOfSlabs.push_back(proj - firstProjectionInSlabs[firstProjectionInSlabs.size() - 1]);

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkFourDSARTConeBeamReconstructionFilter_hxx
 #define rtkFourDSARTConeBeamReconstructionFilter_hxx
 
-#include "rtkFourDSARTConeBeamReconstructionFilter.h"
 #include "rtkGeneralPurposeFunctions.h"
 
 #include <algorithm>

--- a/include/rtkFourDToProjectionStackImageFilter.hxx
+++ b/include/rtkFourDToProjectionStackImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkFourDToProjectionStackImageFilter_hxx
 #define rtkFourDToProjectionStackImageFilter_hxx
 
-#include "rtkFourDToProjectionStackImageFilter.h"
 #include "rtkGeneralPurposeFunctions.h"
 
 namespace rtk

--- a/include/rtkGetNewtonUpdateImageFilter.hxx
+++ b/include/rtkGetNewtonUpdateImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkGetNewtonUpdateImageFilter_hxx
 #define rtkGetNewtonUpdateImageFilter_hxx
 
-#include "rtkGetNewtonUpdateImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "vnl/vnl_inverse.h"

--- a/include/rtkHilbertImageFilter.hxx
+++ b/include/rtkHilbertImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkHilbertImageFilter_hxx
 #define rtkHilbertImageFilter_hxx
 
-#include "rtkHilbertImageFilter.h"
 
 #include <itkConfigure.h>
 #include <itkForwardFFTImageFilter.h>

--- a/include/rtkI0EstimationProjectionFilter.hxx
+++ b/include/rtkI0EstimationProjectionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkI0EstimationProjectionFilter_hxx
 #define rtkI0EstimationProjectionFilter_hxx
 
-#include "rtkI0EstimationProjectionFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkImagXGeometryReader.hxx
+++ b/include/rtkImagXGeometryReader.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkImagXGeometryReader_hxx
 #define rtkImagXGeometryReader_hxx
 
-#include "rtkImagXGeometryReader.h"
 
 #include "rtkMacro.h"
 #include "rtkImagXXMLFileReader.h"

--- a/include/rtkImageToVectorImageFilter.hxx
+++ b/include/rtkImageToVectorImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkImageToVectorImageFilter_hxx
 #define rtkImageToVectorImageFilter_hxx
 
-#include "rtkImageToVectorImageFilter.h"
 
 #include <itkObjectFactory.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkImportImageFilter.hxx
+++ b/include/rtkImportImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkImportImageFilter_hxx
 #define rtkImportImageFilter_hxx
 
-#include "rtkImportImageFilter.h"
 #include <itkObjectFactory.h>
 #ifdef RTK_USE_CUDA
 #  include <itkCudaImage.h>

--- a/include/rtkInterpolatorWithKnownWeightsImageFilter.hxx
+++ b/include/rtkInterpolatorWithKnownWeightsImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "math.h"
 
-#include "rtkInterpolatorWithKnownWeightsImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/include/rtkIterativeConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkIterativeConeBeamReconstructionFilter_hxx
 #define rtkIterativeConeBeamReconstructionFilter_hxx
 
-#include "rtkIterativeConeBeamReconstructionFilter.h"
 
 namespace rtk
 {

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkIterativeFDKConeBeamReconstructionFilter_hxx
 #define rtkIterativeFDKConeBeamReconstructionFilter_hxx
 
-#include "rtkIterativeFDKConeBeamReconstructionFilter.h"
 
 #include <algorithm>
 #include <itkIterationReporter.h>

--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkJosephBackAttenuatedProjectionImageFilter_hxx
 #define rtkJosephBackAttenuatedProjectionImageFilter_hxx
 
-#include "rtkJosephBackAttenuatedProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -210,7 +210,7 @@ JosephBackProjectionImageFilter<TInputImage,
       bool isNewRay = true;
       if (fs == ns) // If the voxel is a corner, we can skip most steps
       {
-        attenuationRay += BilinearInterpolationOnBorders(std::abs(fp[mainDir] - np[mainDir]),
+        attenuationRay += BilinearInterpolationOnBorders(itk::Math::abs(fp[mainDir] - np[mainDir]),
                                                          pxiyi,
                                                          pxsyi,
                                                          pxiys,
@@ -226,7 +226,7 @@ JosephBackProjectionImageFilter<TInputImage,
         const typename TInputImage::PixelType & rayValue =
           m_SumAlongRay(itIn->Value(), attenuationRay, stepMM, isNewRay);
         BilinearSplatOnBorders(rayValue,
-                               std::abs(fp[mainDir] - np[mainDir]),
+                               itk::Math::abs(fp[mainDir] - np[mainDir]),
                                stepMM.GetNorm(),
                                pxiyi,
                                pxsyi,
@@ -275,7 +275,7 @@ JosephBackProjectionImageFilter<TInputImage,
         currenty += stepy;
 
         // Middle steps
-        for (int i{ 0 }; i < std::abs(fs - ns) - 1; ++i)
+        for (int i{ 0 }; i < itk::Math::abs(fs - ns) - 1; ++i)
         {
           attenuationRay += BilinearInterpolation(1., pxiyi, pxsyi, pxiys, pxsys, currentx, currenty, offsetx, offsety);
 

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkJosephBackProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkJosephForwardAttenuatedProjectionImageFilter_hxx
 #define rtkJosephForwardAttenuatedProjectionImageFilter_hxx
 
-#include "rtkJosephForwardAttenuatedProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -189,7 +189,7 @@ JosephForwardProjectionImageFilter<TInputImage,
       if (fs == ns) // If the voxel is a corner, we can skip most steps
       {
         volumeValue = BilinearInterpolationOnBorders(threadId,
-                                                     std::abs(fp[mainDir] - np[mainDir]),
+                                                     itk::Math::abs(fp[mainDir] - np[mainDir]),
                                                      pxiyi,
                                                      pxsyi,
                                                      pxiys,
@@ -232,7 +232,7 @@ JosephForwardProjectionImageFilter<TInputImage,
         currenty += stepy;
 
         // Middle steps
-        for (int i{ 0 }; i < std::abs(fs - ns) - 1; ++i)
+        for (int i{ 0 }; i < itk::Math::abs(fs - ns) - 1; ++i)
         {
           volumeValue =
             BilinearInterpolation(threadId, 1., pxiyi, pxsyi, pxiys, pxsys, currentx, currenty, offsetx, offsety);

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkJosephForwardProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkLUTbasedVariableI0RawToAttenuationImageFilter_hxx
 #define rtkLUTbasedVariableI0RawToAttenuationImageFilter_hxx
 
-#include "rtkLUTbasedVariableI0RawToAttenuationImageFilter.h"
 
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkLagCorrectionImageFilter.hxx
+++ b/include/rtkLagCorrectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkLagCorrectionImageFilter_hxx
 #define rtkLagCorrectionImageFilter_hxx
 
-#include "rtkLagCorrectionImageFilter.h"
 
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/include/rtkLaplacianImageFilter.hxx
+++ b/include/rtkLaplacianImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkLaplacianImageFilter_hxx
 #define rtkLaplacianImageFilter_hxx
 
-#include "rtkLaplacianImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkLastDimensionL0GradientDenoisingImageFilter.hxx
+++ b/include/rtkLastDimensionL0GradientDenoisingImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkLastDimensionL0GradientDenoisingImageFilter_hxx
 #define rtkLastDimensionL0GradientDenoisingImageFilter_hxx
 
-#include "rtkLastDimensionL0GradientDenoisingImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/rtkLookupTableImageFilter.hxx
+++ b/include/rtkLookupTableImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkLookupTableImageFilter_hxx
 #define rtkLookupTableImageFilter_hxx
 
-#include "rtkLookupTableImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkMagnitudeThresholdImageFilter.hxx
+++ b/include/rtkMagnitudeThresholdImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkMagnitudeThresholdImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkMaskCollimationImageFilter.hxx
+++ b/include/rtkMaskCollimationImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkMaskCollimationImageFilter_hxx
 #define rtkMaskCollimationImageFilter_hxx
 
-#include "rtkMaskCollimationImageFilter.h"
 
 #include <itkImageRegionIteratorWithIndex.h>
 

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkMechlemOneStepSpectralReconstructionFilter_hxx
 #define rtkMechlemOneStepSpectralReconstructionFilter_hxx
 
-#include "rtkMechlemOneStepSpectralReconstructionFilter.h"
 
 #include <itkIterationReporter.h>
 

--- a/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_hxx
 #define rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter_hxx
 
-#include "rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h"
 
 namespace rtk
 {

--- a/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_hxx
 #define rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter_hxx
 
-#include "rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h"
 #include <itkImageFileWriter.h>
 
 namespace rtk

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_hxx
 #define rtkMotionCompensatedFourDReconstructionConjugateGradientOperator_hxx
 
-#include "rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h"
 
 #include "rtkJosephForwardProjectionImageFilter.h"
 

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.hxx
@@ -145,7 +145,7 @@ MotionCompensatedFourDReconstructionConjugateGradientOperator<VolumeSeriesType, 
   {
     for (int proj = FirstProj + 1; proj < FirstProj + NumberProjs; proj++)
     {
-      if (fabs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
+      if (itk::Math::abs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
       {
         // Compute the number of projections in the current slab
         sizeOfSlabs.push_back(proj - firstProjectionInSlabs[firstProjectionInSlabs.size() - 1]);

--- a/include/rtkMultiplyByVectorImageFilter.hxx
+++ b/include/rtkMultiplyByVectorImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkMultiplyByVectorImageFilter_hxx
 #define rtkMultiplyByVectorImageFilter_hxx
 
-#include "rtkMultiplyByVectorImageFilter.h"
 #include "itkImageRegionIterator.h"
 
 

--- a/include/rtkNesterovUpdateImageFilter.hxx
+++ b/include/rtkNesterovUpdateImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkNesterovUpdateImageFilter_hxx
 #define rtkNesterovUpdateImageFilter_hxx
 
-#include "rtkNesterovUpdateImageFilter.h"
 #include "itkImageRegionIterator.h"
 
 namespace rtk

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkOSEMConeBeamReconstructionFilter_hxx
 #define rtkOSEMConeBeamReconstructionFilter_hxx
 
-#include "rtkOSEMConeBeamReconstructionFilter.h"
 #include "rtkGeneralPurposeFunctions.h"
 
 #include <algorithm>

--- a/include/rtkOraLookupTableImageFilter.hxx
+++ b/include/rtkOraLookupTableImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkOraLookupTableImageFilter_hxx
 #define rtkOraLookupTableImageFilter_hxx
 
-#include "rtkOraLookupTableImageFilter.h"
 
 #include <itkImageIOBase.h>
 #include <itkImageIOFactory.h>

--- a/include/rtkParkerShortScanImageFilter.hxx
+++ b/include/rtkParkerShortScanImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkParkerShortScanImageFilter_hxx
 #define rtkParkerShortScanImageFilter_hxx
 
-#include "rtkParkerShortScanImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionIteratorWithIndex.h>

--- a/include/rtkPhaseGatingImageFilter.hxx
+++ b/include/rtkPhaseGatingImageFilter.hxx
@@ -50,7 +50,7 @@ PhaseGatingImageFilter<ProjectionStackType>::ComputeWeights()
   // Compute the gating weights
   for (float m_Phase : m_Phases)
   {
-    distance = std::min(fabs(m_GatingWindowCenter - 1 - m_Phase), fabs(m_GatingWindowCenter - m_Phase));
+    distance = std::min(itk::Math::abs(m_GatingWindowCenter - 1 - m_Phase), itk::Math::abs(m_GatingWindowCenter - m_Phase));
     distance = std::min(distance, itk::Math::abs(m_GatingWindowCenter + 1.f - m_Phase));
 
     switch (m_GatingWindowShape)

--- a/include/rtkPhaseGatingImageFilter.hxx
+++ b/include/rtkPhaseGatingImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "math.h"
 
-#include "rtkPhaseGatingImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkPolynomialGainCorrectionImageFilter.hxx
+++ b/include/rtkPolynomialGainCorrectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkPolynomialGainCorrectionImageFilter_hxx
 #define rtkPolynomialGainCorrectionImageFilter_hxx
 
-#include "rtkPolynomialGainCorrectionImageFilter.h"
 
 #include <itkImageFileReader.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkProjectGeometricPhantomImageFilter.hxx
+++ b/include/rtkProjectGeometricPhantomImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkProjectGeometricPhantomImageFilter_hxx
 #define rtkProjectGeometricPhantomImageFilter_hxx
 
-#include "rtkProjectGeometricPhantomImageFilter.h"
 #include "rtkGeometricPhantomFileReader.h"
 #include "rtkForbildPhantomFileReader.h"
 #include "rtkRayConvexIntersectionImageFilter.h"

--- a/include/rtkProjectionGeometry.hxx
+++ b/include/rtkProjectionGeometry.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkProjectionGeometry_hxx
 #define rtkProjectionGeometry_hxx
 
-#include "rtkProjectionGeometry.h"
 
 namespace rtk
 {

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkProjectionStackToFourDImageFilter_hxx
 #define rtkProjectionStackToFourDImageFilter_hxx
 
-#include "rtkProjectionStackToFourDImageFilter.h"
 #include "rtkGeneralPurposeFunctions.h"
 
 #include "itkObjectFactory.h"

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -227,7 +227,7 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
   {
     for (int proj = FirstProj + 1; proj < FirstProj + NumberProjs; proj++)
     {
-      if (fabs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
+      if (itk::Math::abs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
       {
         // Compute the number of projections in the current slab
         sizeOfSlabs.push_back(proj - firstProjectionInSlabs[firstProjectionInSlabs.size() - 1]);

--- a/include/rtkProjectionsReader.hxx
+++ b/include/rtkProjectionsReader.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkProjectionsReader_hxx
 #define rtkProjectionsReader_hxx
 
-#include "rtkProjectionsReader.h"
 
 // ITK
 #include <itkConfigure.h>

--- a/include/rtkProjectionsRegionConstIteratorRayBased.hxx
+++ b/include/rtkProjectionsRegionConstIteratorRayBased.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkProjectionsRegionConstIteratorRayBased_hxx
 #define rtkProjectionsRegionConstIteratorRayBased_hxx
 
-#include "rtkProjectionsRegionConstIteratorRayBased.h"
 #include "rtkProjectionsRegionConstIteratorRayBasedParallel.h"
 #include "rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.h"
 #include "rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.h"

--- a/include/rtkProjectionsRegionConstIteratorRayBasedParallel.hxx
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedParallel.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkProjectionsRegionConstIteratorRayBasedParallel_hxx
 #define rtkProjectionsRegionConstIteratorRayBasedParallel_hxx
 
-#include "rtkProjectionsRegionConstIteratorRayBasedParallel.h"
 #include "rtkHomogeneousMatrix.h"
 #include "rtkMacro.h"
 

--- a/include/rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.hxx
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel_hxx
 #define rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel_hxx
 
-#include "rtkProjectionsRegionConstIteratorRayBasedWithCylindricalPanel.h"
 #include "rtkHomogeneousMatrix.h"
 #include "rtkMacro.h"
 

--- a/include/rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.hxx
+++ b/include/rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel_hxx
 #define rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel_hxx
 
-#include "rtkProjectionsRegionConstIteratorRayBasedWithFlatPanel.h"
 #include "rtkHomogeneousMatrix.h"
 #include "rtkMacro.h"
 

--- a/include/rtkRayBoxIntersectionImageFilter.hxx
+++ b/include/rtkRayBoxIntersectionImageFilter.hxx
@@ -23,7 +23,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkRayBoxIntersectionImageFilter.h"
 #include "rtkBoxShape.h"
 
 namespace rtk

--- a/include/rtkRayConvexIntersectionImageFilter.hxx
+++ b/include/rtkRayConvexIntersectionImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkRayConvexIntersectionImageFilter.h"
 #include "rtkProjectionsRegionConstIteratorRayBased.h"
 
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkRayEllipsoidIntersectionImageFilter.hxx
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkRayEllipsoidIntersectionImageFilter_hxx
 #define rtkRayEllipsoidIntersectionImageFilter_hxx
 
-#include "rtkRayEllipsoidIntersectionImageFilter.h"
 #include "rtkQuadricShape.h"
 
 namespace rtk

--- a/include/rtkRayQuadricIntersectionImageFilter.hxx
+++ b/include/rtkRayQuadricIntersectionImageFilter.hxx
@@ -23,7 +23,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkRayQuadricIntersectionImageFilter.h"
 #include "rtkQuadricShape.h"
 
 namespace rtk

--- a/include/rtkReconstructImageFilter.hxx
+++ b/include/rtkReconstructImageFilter.hxx
@@ -20,7 +20,6 @@
 #define rtkReconstructImageFilter_hxx
 
 // Includes
-#include "rtkReconstructImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkReconstructionConjugateGradientOperator_hxx
 #define rtkReconstructionConjugateGradientOperator_hxx
 
-#include "rtkReconstructionConjugateGradientOperator.h"
 
 namespace rtk
 {

--- a/include/rtkReg1DExtractShroudSignalImageFilter.hxx
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkReg1DExtractShroudSignalImageFilter_hxx
 #define rtkReg1DExtractShroudSignalImageFilter_hxx
 
-#include "rtkReg1DExtractShroudSignalImageFilter.h"
 
 #include <itkExtractImageFilter.h>
 #include <itkTranslationTransform.h>

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkRegularizedConjugateGradientConeBeamReconstructionFilter_hxx
 #define rtkRegularizedConjugateGradientConeBeamReconstructionFilter_hxx
 
-#include "rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h"
 
 #include <itkIterationReporter.h>
 

--- a/include/rtkReorderProjectionsImageFilter.hxx
+++ b/include/rtkReorderProjectionsImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkReorderProjectionsImageFilter_hxx
 #define rtkReorderProjectionsImageFilter_hxx
 
-#include "rtkReorderProjectionsImageFilter.h"
 
 #include "rtkGeneralPurposeFunctions.h"
 

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSARTConeBeamReconstructionFilter_hxx
 #define rtkSARTConeBeamReconstructionFilter_hxx
 
-#include "rtkSARTConeBeamReconstructionFilter.h"
 
 #include <algorithm>
 #include <itkIterationReporter.h>

--- a/include/rtkScatterGlareCorrectionImageFilter.hxx
+++ b/include/rtkScatterGlareCorrectionImageFilter.hxx
@@ -79,8 +79,8 @@ ScatterGlareCorrectionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::Upd
   while (!itK.IsAtEnd())
   {
     idx = itK.GetIndex();
-    double xx = halfXSz - fabs(halfXSz - idx[0]); // Distance to nearest x border
-    double yy = halfYSz - fabs(halfYSz - idx[1]); // Distance to nearest y border
+    double xx = halfXSz - itk::Math::abs(halfXSz - idx[0]); // Distance to nearest x border
+    double yy = halfYSz - itk::Math::abs(halfYSz - idx[1]); // Distance to nearest y border
     double rr2 = (xx * xx + yy * yy);
     g = (a3 * dx * dy / (2. * itk::Math::pi * b3sq)) / std::pow((1. + rr2 / b3sq), 1.5);
     itK.Set(g);

--- a/include/rtkScatterGlareCorrectionImageFilter.hxx
+++ b/include/rtkScatterGlareCorrectionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkScatterGlareCorrectionImageFilter_hxx
 #define rtkScatterGlareCorrectionImageFilter_hxx
 
-#include "rtkScatterGlareCorrectionImageFilter.h"
 
 // Use local RTK FFTW files taken from Gaëtan Lehmann's code for
 // thread safety: http://hdl.handle.net/10380/3154

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkSelectOneProjectionPerCycleImageFilter_hxx
 #define rtkSelectOneProjectionPerCycleImageFilter_hxx
 
-#include "rtkSelectOneProjectionPerCycleImageFilter.h"
 #include <itkCSVArray2DFileReader.h>
 
 namespace rtk

--- a/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.hxx
+++ b/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSeparableQuadraticSurrogateRegularizationImageFilter_hxx
 #define rtkSeparableQuadraticSurrogateRegularizationImageFilter_hxx
 
-#include "rtkSeparableQuadraticSurrogateRegularizationImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkSheppLoganPhantomFilter.hxx
+++ b/include/rtkSheppLoganPhantomFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSheppLoganPhantomFilter_hxx
 #define rtkSheppLoganPhantomFilter_hxx
 
-#include "rtkSheppLoganPhantomFilter.h"
 #include "rtkSheppLoganPhantom.h"
 
 namespace rtk

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSimplexSpectralProjectionsDecompositionImageFilter_hxx
 #define rtkSimplexSpectralProjectionsDecompositionImageFilter_hxx
 
-#include "rtkSimplexSpectralProjectionsDecompositionImageFilter.h"
 #include "rtkSpectralForwardModelImageFilter.h"
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkSingularValueThresholdImageFilter.hxx
+++ b/include/rtkSingularValueThresholdImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSingularValueThresholdImageFilter_hxx
 #define rtkSingularValueThresholdImageFilter_hxx
 
-#include "rtkSingularValueThresholdImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkSoftThresholdImageFilter.hxx
+++ b/include/rtkSoftThresholdImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSoftThresholdImageFilter_hxx
 #define rtkSoftThresholdImageFilter_hxx
 
-#include "rtkSoftThresholdImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkSoftThresholdTVImageFilter.hxx
+++ b/include/rtkSoftThresholdTVImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkSoftThresholdTVImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkSpectralForwardModelImageFilter.hxx
+++ b/include/rtkSpectralForwardModelImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSpectralForwardModelImageFilter_hxx
 #define rtkSpectralForwardModelImageFilter_hxx
 
-#include "rtkSpectralForwardModelImageFilter.h"
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>
 

--- a/include/rtkSplatWithKnownWeightsImageFilter.hxx
+++ b/include/rtkSplatWithKnownWeightsImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "math.h"
 
-#include "rtkSplatWithKnownWeightsImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/include/rtkSubSelectFromListImageFilter.hxx
+++ b/include/rtkSubSelectFromListImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkSubSelectFromListImageFilter_hxx
 #define rtkSubSelectFromListImageFilter_hxx
 
-#include "rtkSubSelectFromListImageFilter.h"
 
 #include <itkImageRegionIterator.h>
 #include <itkImageRegionConstIterator.h>

--- a/include/rtkSubSelectImageFilter.hxx
+++ b/include/rtkSubSelectImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkSubSelectImageFilter_hxx
 #define rtkSubSelectImageFilter_hxx
 
-#include "rtkSubSelectImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkSumOfSquaresImageFilter.hxx
+++ b/include/rtkSumOfSquaresImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkSumOfSquaresImageFilter_hxx
 #define rtkSumOfSquaresImageFilter_hxx
 
-#include "rtkSumOfSquaresImageFilter.h"
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 

--- a/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.hxx
+++ b/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkTotalNuclearVariationDenoisingBPDQImageFilter_hxx
 #define rtkTotalNuclearVariationDenoisingBPDQImageFilter_hxx
 
-#include "rtkTotalNuclearVariationDenoisingBPDQImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkTotalVariationDenoiseSequenceImageFilter_hxx
 #define rtkTotalVariationDenoiseSequenceImageFilter_hxx
 
-#include "rtkTotalVariationDenoiseSequenceImageFilter.h"
 #include <itkImageFileWriter.h>
 
 namespace rtk

--- a/include/rtkTotalVariationDenoisingBPDQImageFilter.hxx
+++ b/include/rtkTotalVariationDenoisingBPDQImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkTotalVariationDenoisingBPDQImageFilter_hxx
 #define rtkTotalVariationDenoisingBPDQImageFilter_hxx
 
-#include "rtkTotalVariationDenoisingBPDQImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkTotalVariationImageFilter.hxx
+++ b/include/rtkTotalVariationImageFilter.hxx
@@ -20,7 +20,6 @@
 #define rtkTotalVariationImageFilter_hxx
 #include "math.h"
 
-#include "rtkTotalVariationImageFilter.h"
 
 
 #include "itkConstNeighborhoodIterator.h"

--- a/include/rtkUnwarpSequenceConjugateGradientOperator.hxx
+++ b/include/rtkUnwarpSequenceConjugateGradientOperator.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkUnwarpSequenceConjugateGradientOperator_hxx
 #define rtkUnwarpSequenceConjugateGradientOperator_hxx
 
-#include "rtkUnwarpSequenceConjugateGradientOperator.h"
 
 namespace rtk
 {

--- a/include/rtkUnwarpSequenceImageFilter.hxx
+++ b/include/rtkUnwarpSequenceImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkUnwarpSequenceImageFilter_hxx
 #define rtkUnwarpSequenceImageFilter_hxx
 
-#include "rtkUnwarpSequenceImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkUpsampleImageFilter.hxx
+++ b/include/rtkUpsampleImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkUpsampleImageFilter_hxx
 #define rtkUpsampleImageFilter_hxx
 
-#include "rtkUpsampleImageFilter.h"
 
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/include/rtkVarianObiRawImageFilter.hxx
+++ b/include/rtkVarianObiRawImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkVarianObiRawImageFilter_hxx
 #define rtkVarianObiRawImageFilter_hxx
 
-#include "rtkVarianObiRawImageFilter.h"
 #include "rtkI0EstimationProjectionFilter.h"
 
 namespace rtk

--- a/include/rtkVectorImageToImageFilter.hxx
+++ b/include/rtkVectorImageToImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkVectorImageToImageFilter_hxx
 #define rtkVectorImageToImageFilter_hxx
 
-#include "rtkVectorImageToImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/include/rtkWarpFourDToProjectionStackImageFilter.hxx
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkWarpFourDToProjectionStackImageFilter_hxx
 #define rtkWarpFourDToProjectionStackImageFilter_hxx
 
-#include "rtkWarpFourDToProjectionStackImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkWarpProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkWarpProjectionStackToFourDImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkWarpProjectionStackToFourDImageFilter_hxx
 #define rtkWarpProjectionStackToFourDImageFilter_hxx
 
-#include "rtkWarpProjectionStackToFourDImageFilter.h"
 
 #include <itkObjectFactory.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkWarpSequenceImageFilter.hxx
+++ b/include/rtkWarpSequenceImageFilter.hxx
@@ -21,7 +21,6 @@
 
 #include "math.h"
 
-#include "rtkWarpSequenceImageFilter.h"
 
 #include <itkImageFileWriter.h>
 #include <iostream>

--- a/include/rtkWaterPrecorrectionImageFilter.hxx
+++ b/include/rtkWaterPrecorrectionImageFilter.hxx
@@ -22,7 +22,6 @@
 #include <itkImageRegionConstIterator.h>
 #include <itkImageRegionIterator.h>
 
-#include "rtkWaterPrecorrectionImageFilter.h"
 
 namespace rtk
 {

--- a/include/rtkWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkWeidingerForwardModelImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef rtkWeidingerForwardModelImageFilter_hxx
 #define rtkWeidingerForwardModelImageFilter_hxx
 
-#include "rtkWeidingerForwardModelImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/rtkXRadRawToAttenuationImageFilter.hxx
+++ b/include/rtkXRadRawToAttenuationImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef rtkXRadRawToAttenuationImageFilter_hxx
 #define rtkXRadRawToAttenuationImageFilter_hxx
 
-#include "rtkXRadRawToAttenuationImageFilter.h"
 
 #include <itkImageFileReader.h>
 #include <itkImageRegionIterator.h>

--- a/include/rtkZengBackProjectionImageFilter.hxx
+++ b/include/rtkZengBackProjectionImageFilter.hxx
@@ -23,7 +23,6 @@
 
 #include "math.h"
 
-#include "rtkZengBackProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/include/rtkZengForwardProjectionImageFilter.hxx
+++ b/include/rtkZengForwardProjectionImageFilter.hxx
@@ -23,7 +23,6 @@
 
 #include "math.h"
 
-#include "rtkZengForwardProjectionImageFilter.h"
 
 #include "rtkHomogeneousMatrix.h"
 #include "rtkBoxShape.h"

--- a/src/rtkConditionalMedianImageFilter.cxx
+++ b/src/rtkConditionalMedianImageFilter.cxx
@@ -60,7 +60,7 @@ rtk::ConditionalMedianImageFilter<itk::VectorImage<float, 3>>::DynamicThreadedGe
       std::nth_element(pixels[mat].begin(), pixels[mat].begin() + pixels[mat].size() / 2, pixels[mat].end());
 
       // If the pixel value is too far from the median, replace it by the median
-      if (fabs(pixels[mat][pixels[mat].size() / 2] - nIt.GetCenterPixel()[mat]) > (m_ThresholdMultiplier * stdev))
+      if (itk::Math::abs(pixels[mat][pixels[mat].size() / 2] - nIt.GetCenterPixel()[mat]) > (m_ThresholdMultiplier * stdev))
         vlv[mat] = pixels[mat][pixels[mat].size() / 2];
       else // Otherwise, leave it as is
         vlv[mat] = nIt.GetCenterPixel()[mat];

--- a/src/rtkCudaDisplacedDetectorImageFilter.cxx
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cxx
@@ -40,8 +40,8 @@ CudaDisplacedDetectorImageFilter ::GPUGenerateData()
   outBuffer += this->GetOutput()->ComputeOffset(this->GetOutput()->GetRequestedRegion().GetIndex());
 
   // nothing to do
-  if ((fabs(this->GetInferiorCorner() + this->GetSuperiorCorner()) <
-       0.1 * fabs(this->GetSuperiorCorner() - this->GetInferiorCorner())) ||
+  if ((itk::Math::abs(this->GetInferiorCorner() + this->GetSuperiorCorner()) <
+       0.1 * itk::Math::abs(this->GetSuperiorCorner() - this->GetInferiorCorner())) ||
       this->GetDisable())
   {
     if (outBuffer != inBuffer)

--- a/src/rtkDigisensGeometryReader.cxx
+++ b/src/rtkDigisensGeometryReader.cxx
@@ -66,8 +66,8 @@ rtk::DigisensGeometryReader ::GenerateData()
   }
 
   // Source / Detector / Center distances
-  double sdd = fabs(sourcePosition[2] - detectorPosition[2]);
-  double sid = fabs(sourcePosition[2] - rotationCenter[2]);
+  double sdd = itk::Math::abs(sourcePosition[2] - detectorPosition[2]);
+  double sid = itk::Math::abs(sourcePosition[2] - rotationCenter[2]);
 
   // Scaling
   using MetaDataIntegerType = itk::MetaDataObject<int>;

--- a/src/rtkForbildPhantomFileReader.cxx
+++ b/src/rtkForbildPhantomFileReader.cxx
@@ -419,7 +419,7 @@ ForbildPhantomFileReader::ComputeRotationMatrixBetweenVectors(const VectorType &
   RotationMatrixType r;
   r.SetIdentity();
   ScalarType c = s * d;
-  if (fabs(c) - 1. == itk::NumericTraits<ScalarType>::ZeroValue())
+  if (itk::Math::abs(c) - 1. == itk::NumericTraits<ScalarType>::ZeroValue())
   {
     return r;
   }

--- a/src/rtkPhaseReader.cxx
+++ b/src/rtkPhaseReader.cxx
@@ -16,7 +16,6 @@
  *
  *=========================================================================*/
 
-#include "rtkPhaseReader.h"
 
 #include "itksys/SystemTools.hxx"
 

--- a/src/rtkPhasesToInterpolationWeights.cxx
+++ b/src/rtkPhasesToInterpolationWeights.cxx
@@ -15,7 +15,9 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "rtkPhasesToInterpolationWeights.h"
+#ifndef rtkPhasesToInterpolationWeights_hxx
+#define rtkPhasesToInterpolationWeights_hxx
+
 
 #include <itksys/SystemTools.hxx>
 #include <itkMath.h>

--- a/src/rtkSignalToInterpolationWeights.cxx
+++ b/src/rtkSignalToInterpolationWeights.cxx
@@ -16,7 +16,6 @@
  *
  *=========================================================================*/
 
-#include "rtkSignalToInterpolationWeights.h"
 
 #include <itksys/SystemTools.hxx>
 #include <itkMath.h>

--- a/src/rtkThreeDCircularProjectionGeometry.cxx
+++ b/src/rtkThreeDCircularProjectionGeometry.cxx
@@ -165,7 +165,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const PointType &  sourcePo
   const PointType &  S = sourcePosition;          // source pos
   const PointType &  R = detectorPosition;        // detector pos
 
-  if (fabs(r * c) > 1e-6) // non-orthogonal row/column vectors
+  if (itk::Math::abs(r * c) > 1e-6) // non-orthogonal row/column vectors
     return false;
 
   // Euler angles (ZXY convention) from detector orientation in IEC-based WCS:
@@ -637,7 +637,7 @@ rtk::ThreeDCircularProjectionGeometry::VerifyAngles(const double          outOfP
 
   for (int i = 0; i < 3; i++) // check whether matrices match
     for (int j = 0; j < 3; j++)
-      if (fabs(rm[i][j] - m[i][j]) > EPSILON)
+      if (itk::Math::abs(rm[i][j] - m[i][j]) > EPSILON)
         return false;
 
   return true;
@@ -652,7 +652,7 @@ rtk::ThreeDCircularProjectionGeometry::FixAngles(double &              outOfPlan
   const Matrix3x3Type & rm = referenceMatrix; // shortcut
   const double          EPSILON = 1e-6;       // internal tolerance for comparison
 
-  if (fabs(fabs(rm[2][1]) - 1.) > EPSILON)
+  if (itk::Math::abs(fabs(rm[2][1]) - 1.) > EPSILON)
   {
     double oa = NAN, ga = NAN, ia = NAN;
 

--- a/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
+++ b/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
@@ -153,7 +153,7 @@ ThreeDCircularProjectionGeometryXMLFileReader::EndElement(const char * name)
       {
         // Tolerance can not be vcl_numeric_limits<double>::epsilon(), too strict
         // 0.001 is a random choice to catch "large" inconsistencies
-        if (fabs(m_Matrix[i][j] - m_OutputObject->GetMatrices().back()[i][j]) > 0.001)
+        if (itk::Math::abs(m_Matrix[i][j] - m_OutputObject->GetMatrices().back()[i][j]) > 0.001)
         {
           itkGenericExceptionMacro(<< "Matrix and parameters are not consistent." << std::endl
                                    << "Read matrix from geometry file: " << std::endl

--- a/test/rtkTest.h
+++ b/test/rtkTest.h
@@ -302,7 +302,7 @@ CheckGeometries(const rtk::ThreeDCircularProjectionGeometry * g1, const rtk::Thr
     std::cerr << "Unequal number of projections in the two geometries" << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (e < std::fabs(g1->GetRadiusCylindricalDetector() - g2->GetRadiusCylindricalDetector()))
+  if (e < itk::Math::abs(g1->GetRadiusCylindricalDetector() - g2->GetRadiusCylindricalDetector()))
   {
     std::cerr << "Geometries don't have the same cylindrical detector radius" << std::endl;
     exit(EXIT_FAILURE);
@@ -312,21 +312,21 @@ CheckGeometries(const rtk::ThreeDCircularProjectionGeometry * g1, const rtk::Thr
   {
     // std::cout << g1->GetGantryAngles()[i] << " " << g2->GetGantryAngles()[i] << std::endl;
     if (e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              std::fabs(g1->GetGantryAngles()[i] - g2->GetGantryAngles()[i])) ||
+              itk::Math::abs(g1->GetGantryAngles()[i] - g2->GetGantryAngles()[i])) ||
         e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              std::fabs(g1->GetOutOfPlaneAngles()[i] - g2->GetOutOfPlaneAngles()[i])) ||
+              itk::Math::abs(g1->GetOutOfPlaneAngles()[i] - g2->GetOutOfPlaneAngles()[i])) ||
         e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              std::fabs(g1->GetInPlaneAngles()[i] - g2->GetInPlaneAngles()[i])) ||
-        e < std::fabs(g1->GetSourceToIsocenterDistances()[i] - g2->GetSourceToIsocenterDistances()[i]) ||
-        e < std::fabs(g1->GetSourceOffsetsX()[i] - g2->GetSourceOffsetsX()[i]) ||
-        e < std::fabs(g1->GetSourceOffsetsY()[i] - g2->GetSourceOffsetsY()[i]) ||
-        e < std::fabs(g1->GetSourceToDetectorDistances()[i] - g2->GetSourceToDetectorDistances()[i]) ||
-        e < std::fabs(g1->GetProjectionOffsetsX()[i] - g2->GetProjectionOffsetsX()[i]) ||
-        e < std::fabs(g1->GetProjectionOffsetsY()[i] - g2->GetProjectionOffsetsY()[i]) ||
-        e < std::fabs(g1->GetCollimationUInf()[i] - g2->GetCollimationUInf()[i]) ||
-        e < std::fabs(g1->GetCollimationVInf()[i] - g2->GetCollimationVInf()[i]) ||
-        e < std::fabs(g1->GetCollimationUSup()[i] - g2->GetCollimationUSup()[i]) ||
-        e < std::fabs(g1->GetCollimationVSup()[i] - g2->GetCollimationVSup()[i]))
+              itk::Math::abs(g1->GetInPlaneAngles()[i] - g2->GetInPlaneAngles()[i])) ||
+        e < itk::Math::abs(g1->GetSourceToIsocenterDistances()[i] - g2->GetSourceToIsocenterDistances()[i]) ||
+        e < itk::Math::abs(g1->GetSourceOffsetsX()[i] - g2->GetSourceOffsetsX()[i]) ||
+        e < itk::Math::abs(g1->GetSourceOffsetsY()[i] - g2->GetSourceOffsetsY()[i]) ||
+        e < itk::Math::abs(g1->GetSourceToDetectorDistances()[i] - g2->GetSourceToDetectorDistances()[i]) ||
+        e < itk::Math::abs(g1->GetProjectionOffsetsX()[i] - g2->GetProjectionOffsetsX()[i]) ||
+        e < itk::Math::abs(g1->GetProjectionOffsetsY()[i] - g2->GetProjectionOffsetsY()[i]) ||
+        e < itk::Math::abs(g1->GetCollimationUInf()[i] - g2->GetCollimationUInf()[i]) ||
+        e < itk::Math::abs(g1->GetCollimationVInf()[i] - g2->GetCollimationVInf()[i]) ||
+        e < itk::Math::abs(g1->GetCollimationUSup()[i] - g2->GetCollimationUSup()[i]) ||
+        e < itk::Math::abs(g1->GetCollimationVSup()[i] - g2->GetCollimationVSup()[i]))
     {
       std::cerr << "Geometry of projection #" << i << " is unvalid." << std::endl;
       exit(EXIT_FAILURE);

--- a/test/rtkTestReg23ProjectionGeometry.cxx
+++ b/test/rtkTestReg23ProjectionGeometry.cxx
@@ -293,8 +293,8 @@ main(int argc, char * argv[])
     {
       for (std::size_t i = 0; i < referenceMarkerProjections.size(); ++i)
       {
-        if (fabs(referenceMarkerProjections[i][0] - rtkMarkerProjections[i][0]) > EPSILON ||
-            fabs(referenceMarkerProjections[i][1] - rtkMarkerProjections[i][1]) > EPSILON)
+        if (itk::Math::abs(referenceMarkerProjections[i][0] - rtkMarkerProjections[i][0]) > EPSILON ||
+            itk::Math::abs(referenceMarkerProjections[i][1] - rtkMarkerProjections[i][1]) > EPSILON)
         {
           VERBOSE(<< "\nAngle-combination out-of-plane=" << anglesList[i][0] << ", gantry=" << anglesList[i][1]
                   << ", in-plane=" << anglesList[i][2] << " failed:\n")

--- a/test/rtkcroptest.cxx
+++ b/test/rtkcroptest.cxx
@@ -50,7 +50,7 @@ main(int, char **)
   ImageType::IndexType index;
   index.Fill(2);
 
-  if (fabs(crop->GetOutput()->GetPixel(index) - 12.3) > 0.0001)
+  if (itk::Math::abs(crop->GetOutput()->GetPixel(index) - 12.3) > 0.0001)
   {
     std::cout << "Output should be 12.3. Value Computed = " << crop->GetOutput()->GetPixel(index) << std::endl;
     return EXIT_FAILURE;

--- a/test/rtkrampfiltertest2.cxx
+++ b/test/rtkrampfiltertest2.cxx
@@ -61,7 +61,7 @@ main(int, char **)
   index[2] = 26;
 
   float value = 0.132652;
-  if (fabs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (itk::Math::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #0 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;
@@ -72,7 +72,7 @@ main(int, char **)
   rampFilter->SetHannCutFrequency(0.8);
   rampFilter->Update();
   value = 0.149724;
-  if (fabs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (itk::Math::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #1 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;
@@ -83,7 +83,7 @@ main(int, char **)
   rampFilter->SetHannCutFrequencyY(0.1);
   rampFilter->Update();
   value = 0.150181;
-  if (fabs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (itk::Math::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #2 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

