### PR TITLE
ENH: Add convenience functions ReadGeometry and WriteGeometry

### DIFF
--- a/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
+++ b/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
@@ -69,13 +69,11 @@ main(int argc, char * argv[])
     shroudFilter->SetCorner2(c2);
 
     // Geometry
-    rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-    geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
+    rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
     if (args_info.geometry_given)
     {
-      geometryReader->SetFilename(args_info.geometry_arg);
-      TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
-      shroudFilter->SetGeometry(geometryReader->GetOutputObject());
+      TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
+      shroudFilter->SetGeometry(geometry);
     }
   }
   TRY_AND_EXIT_ON_ITK_EXCEPTION(shroudFilter->UpdateOutputInformation())

--- a/applications/rtkbioscangeometry/rtkbioscangeometry.cxx
+++ b/applications/rtkbioscangeometry/rtkbioscangeometry.cxx
@@ -32,11 +32,8 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(bioscanReader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(const_cast<rtk::ThreeDCircularProjectionGeometry *>(bioscanReader->GetGeometry()));
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(
+    const_cast<rtk::ThreeDCircularProjectionGeometry *>(bioscanReader->GetGeometry()), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkdigisensgeometry/rtkdigisensgeometry.cxx
+++ b/applications/rtkdigisensgeometry/rtkdigisensgeometry.cxx
@@ -27,21 +27,13 @@ main(int argc, char * argv[])
 {
   GGO(rtkdigisensgeometry, args_info);
 
-  // RTK geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  GeometryType::Pointer geometry = GeometryType::New();
-
   // Create geometry reader
   rtk::DigisensGeometryReader::Pointer reader = rtk::DigisensGeometryReader::New();
   reader->SetXMLFileName(args_info.xml_file_arg);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(&(*geometry));
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(reader->GetGeometry(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
+++ b/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
@@ -105,13 +105,9 @@ main(int argc, char * argv[])
   }
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(output);
   if (args_info.verbose_flag)
     std::cout << "Writing reference... " << std::flush;
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(output, args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkdrawshepploganphantom/rtkdrawshepploganphantom.cxx
+++ b/applications/rtkdrawshepploganphantom/rtkdrawshepploganphantom.cxx
@@ -73,11 +73,7 @@ main(int argc, char * argv[])
   }
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(output);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(output, args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.cxx
+++ b/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.cxx
@@ -37,11 +37,8 @@ main(int argc, char * argv[])
     TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputData())
 
     // Write
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-      rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-    xmlWriter->SetFilename(args_info.output_arg);
-    xmlWriter->SetObject(reader->GetGeometry());
-    TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(reader->GetGeometry(), args_info.output_arg))
+
 
     return EXIT_SUCCESS;
   }
@@ -54,11 +51,7 @@ main(int argc, char * argv[])
     TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation());
 
     // Write
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-      rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-    xmlWriter->SetFilename(args_info.output_arg);
-    xmlWriter->SetObject(geometryReader->GetGeometry());
-    TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(geometryReader->GetGeometry(), args_info.output_arg))
 
     return EXIT_SUCCESS;
   }

--- a/applications/rtkextractphasesignal/rtkextractphasesignal.cxx
+++ b/applications/rtkextractphasesignal/rtkextractphasesignal.cxx
@@ -24,6 +24,8 @@
 #include <itkImageFileReader.h>
 #include <fstream>
 
+namespace rtk
+{
 template <class TSignalType>
 void
 WriteSignalToTextFile(TSignalType * sig, const std::string & fileName)
@@ -36,6 +38,7 @@ WriteSignalToTextFile(TSignalType * sig, const std::string & fileName)
   }
   ofs.close();
 }
+} // namespace rtk
 
 int
 main(int argc, char * argv[])
@@ -50,11 +53,8 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // Read
-  itk::ImageFileReader<InputImageType>::Pointer reader = itk::ImageFileReader<InputImageType>::New();
-  reader->SetFileName(args_info.input_arg);
-
   OutputImageType::Pointer signal;
-  signal = reader->GetOutput();
+  signal = itk::ReadImage<OutputImageType>(args_info.input_arg);
 
   // Process phase signal if required
   using PhaseFilter = rtk::ExtractPhaseImageFilter<OutputImageType>;
@@ -66,7 +66,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(phase->Update())
 
   // Write output phase
-  WriteSignalToTextFile(phase->GetOutput(), args_info.output_arg);
+  rtk::WriteSignalToTextFile(phase->GetOutput(), args_info.output_arg);
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkfdktwodweights/rtkfdktwodweights.cxx
+++ b/applications/rtkfdktwodweights/rtkfdktwodweights.cxx
@@ -42,16 +42,14 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Weights filter
   using WeightType = rtk::FDKWeightProjectionFilter<OutputImageType>;
   WeightType::Pointer wf = WeightType::New();
   wf->SetInput(reader->GetOutput());
-  wf->SetGeometry(geometryReader->GetOutputObject());
+  wf->SetGeometry(geometry);
   wf->SetNumberOfWorkUnits(1);
   wf->InPlaceOff();
 

--- a/applications/rtkfourdsart/rtkfourdsart.cxx
+++ b/applications/rtkfourdsart/rtkfourdsart.cxx
@@ -54,10 +54,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Create input: either an existing volume read from a file or a blank image
   itk::ImageSource<VolumeSeriesType>::Pointer inputFilter;
@@ -105,7 +103,7 @@ main(int argc, char * argv[])
   SetBackProjectionFromGgo(args_info, fourdsart.GetPointer());
   fourdsart->SetInputVolumeSeries(inputFilter->GetOutput());
   fourdsart->SetInputProjectionStack(reader->GetOutput());
-  fourdsart->SetGeometry(geometryReader->GetOutputObject());
+  fourdsart->SetGeometry(geometry);
   fourdsart->SetNumberOfIterations(args_info.niterations_arg);
   fourdsart->SetNumberOfProjectionsPerSubset(args_info.nprojpersubset_arg);
   fourdsart->SetWeights(phaseReader->GetOutput());
@@ -123,11 +121,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(fourdsart->Update())
 
   // Write
-  using WriterType = itk::ImageFileWriter<VolumeSeriesType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(fourdsart->GetOutput());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(fourdsart->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkgaincorrection/rtkgaincorrection.cxx
+++ b/applications/rtkgaincorrection/rtkgaincorrection.cxx
@@ -178,11 +178,7 @@ main(int argc, char * argv[])
     TRY_AND_EXIT_ON_ITK_EXCEPTION(pasteFilter->Update())
   }
 
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(pasteFilter->GetOutput());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(pasteFilter->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkimagxgeometry/rtkimagxgeometry.cxx
+++ b/applications/rtkimagxgeometry/rtkimagxgeometry.cxx
@@ -45,11 +45,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(imagxReader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(imagxReader->GetGeometry());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(imagxReader->GetGeometry(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtklagcorrection/rtklagcorrection.cxx
+++ b/applications/rtklagcorrection/rtklagcorrection.cxx
@@ -86,13 +86,7 @@ main(int argc, char * argv[])
   streamer->SetNumberOfStreamDivisions(100);
 
   // Save corrected projections
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(streamer->GetOutput());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->UpdateOutputInformation())
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(streamer->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtklastdimensionl0gradientdenoising/rtklastdimensionl0gradientdenoising.cxx
+++ b/applications/rtklastdimensionl0gradientdenoising/rtklastdimensionl0gradientdenoising.cxx
@@ -59,12 +59,7 @@ main(int argc, char * argv[])
   denoising->ReleaseDataFlagOn();
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(denoising->GetOutput());
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(denoising->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtklut/rtklut.cxx
+++ b/applications/rtklut/rtklut.cxx
@@ -53,13 +53,9 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(lutFilter->Update())
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(lutFilter->GetOutput());
   if (args_info.verbose_flag)
     std::cout << "Writing result... " << std::endl;
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(lutFilter->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkmaskcollimation/rtkmaskcollimation.cxx
+++ b/applications/rtkmaskcollimation/rtkmaskcollimation.cxx
@@ -38,10 +38,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<OutputImageType>;
@@ -52,7 +50,7 @@ main(int argc, char * argv[])
   using OFMType = rtk::MaskCollimationImageFilter<OutputImageType, OutputImageType>;
   OFMType::Pointer ofm = OFMType::New();
   ofm->SetInput(reader->GetOutput());
-  ofm->SetGeometry(geometryReader->GetOutputObject());
+  ofm->SetGeometry(geometry);
 
   // Write
   using WriterType = itk::ImageFileWriter<OutputImageType>;

--- a/applications/rtkorageometry/rtkorageometry.cxx
+++ b/applications/rtkorageometry/rtkorageometry.cxx
@@ -38,11 +38,8 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(oraReader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(const_cast<rtk::ThreeDCircularProjectionGeometry *>(oraReader->GetGeometry()));
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(
+    const_cast<rtk::ThreeDCircularProjectionGeometry *>(oraReader->GetGeometry()), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkoverlayphaseandshroud/rtkoverlayphaseandshroud.cxx
+++ b/applications/rtkoverlayphaseandshroud/rtkoverlayphaseandshroud.cxx
@@ -42,9 +42,8 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<RGBPixelType, Dimension>;
 
   // Read
-  itk::ImageFileReader<InputImageType>::Pointer reader = itk::ImageFileReader<InputImageType>::New();
-  reader->SetFileName(args_info.input_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->Update())
+  InputImageType::Pointer readImage;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(readImage = itk::ReadImage<InputImageType>(args_info.input_arg))
 
   // Read signal file
   using ReaderType = itk::CSVArray2DFileReader<double>;
@@ -66,12 +65,11 @@ main(int argc, char * argv[])
 
   // Create output RGB image
   OutputImageType::Pointer RGBout = OutputImageType::New();
-  RGBout->SetRegions(reader->GetOutput()->GetLargestPossibleRegion());
+  RGBout->SetRegions(readImage->GetLargestPossibleRegion());
   RGBout->Allocate();
 
   // Compute min and max of shroud to scale output
-  itk::ImageRegionConstIterator<InputImageType>      itIn(reader->GetOutput(),
-                                                     reader->GetOutput()->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<InputImageType>      itIn(readImage, readImage->GetLargestPossibleRegion());
   itk::ImageRegionIteratorWithIndex<OutputImageType> itOut(RGBout, RGBout->GetLargestPossibleRegion());
 
   double min = itk::NumericTraits<double>::max();
@@ -109,11 +107,7 @@ main(int argc, char * argv[])
     ++itOut;
   }
 
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(RGBout);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(RGBout, args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkparkershortscanweighting/rtkparkershortscanweighting.cxx
+++ b/applications/rtkparkershortscanweighting/rtkparkershortscanweighting.cxx
@@ -58,10 +58,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Short scan image filter
   using PSSFCPUType = rtk::ParkerShortScanImageFilter<OutputImageType>;
@@ -76,7 +74,7 @@ main(int argc, char * argv[])
   else
     pssf = PSSFCPUType::New();
   pssf->SetInput(reader->GetOutput());
-  pssf->SetGeometry(geometryReader->GetOutputObject());
+  pssf->SetGeometry(geometry);
   pssf->InPlaceOff();
 
   // Write

--- a/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
+++ b/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
@@ -123,10 +123,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
   if (args_info.verbose_flag)
     std::cout << " done." << std::endl;
 
@@ -151,8 +149,7 @@ main(int argc, char * argv[])
   }
 
   // Adjust size according to geometry
-  if (reader->GetOutput()->GetLargestPossibleRegion().GetSize()[2] !=
-      geometryReader->GetOutputObject()->GetGantryAngles().size())
+  if (reader->GetOutput()->GetLargestPossibleRegion().GetSize()[2] != geometry->GetGantryAngles().size())
   {
     std::cerr << "Number of projections in the geometry and in the stack do not match." << std::endl;
     return EXIT_FAILURE;
@@ -170,7 +167,7 @@ main(int argc, char * argv[])
   JosephType::Pointer backProjection = JosephType::New();
   backProjection->SetInput(constantImageSource->GetOutput());
   backProjection->SetInput(1, reader->GetOutput());
-  backProjection->SetGeometry(geometryReader->GetOutputObject());
+  backProjection->SetGeometry(geometry);
   backProjection->GetSplatWeightMultiplication().SetProjectionsBuffer(reader->GetOutput()->GetBufferPointer());
   backProjection->GetSplatWeightMultiplication().SetVolumeBuffer(constantImageSource->GetOutput()->GetBufferPointer());
   backProjection->GetSplatWeightMultiplication().GetVnlSparseMatrix().resize(

--- a/applications/rtkramp/rtkramp.cxx
+++ b/applications/rtkramp/rtkramp.cxx
@@ -112,13 +112,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(streamer->Update())
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(streamer->GetOutput());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->UpdateOutputInformation())
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(streamer->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkrayboxintersection/rtkrayboxintersection.cxx
+++ b/applications/rtkrayboxintersection/rtkrayboxintersection.cxx
@@ -37,10 +37,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Create a stack of empty projection images
   using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
@@ -52,31 +50,25 @@ main(int argc, char * argv[])
   ConstantImageSourceType::SizeType sizeOutput;
   sizeOutput[0] = constantImageSource->GetSize()[0];
   sizeOutput[1] = constantImageSource->GetSize()[1];
-  sizeOutput[2] = geometryReader->GetOutputObject()->GetGantryAngles().size();
+  sizeOutput[2] = geometry->GetGantryAngles().size();
   constantImageSource->SetSize(sizeOutput);
 
   // Input reader
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(args_info.input_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputInformation())
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create projection image filter
   using RBIType = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>;
   RBIType::Pointer rbi = RBIType::New();
   rbi->SetInput(constantImageSource->GetOutput());
-  rbi->SetBoxFromImage(reader->GetOutput());
-  rbi->SetGeometry(geometryReader->GetOutputObject());
+  rbi->SetBoxFromImage(input);
+  rbi->SetGeometry(geometry);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rbi->Update())
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(rbi->GetOutput());
   if (args_info.verbose_flag)
     std::cout << "Projecting and writing... " << std::flush;
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(rbi->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
+++ b/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
@@ -58,8 +58,7 @@ main(int argc, char * argv[])
 
   // Input projection parameters
   InputImageType::SizeType sizeInput = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
-  ;
-  int Nproj = sizeInput[2];
+  int                      Nproj = sizeInput[2];
 
 
   std::vector<float> coef;
@@ -174,13 +173,9 @@ main(int argc, char * argv[])
     projid += curBufferSize;
   }
 
-  using FileWriterType = itk::ImageFileWriter<InputImageType>;
-  FileWriterType::Pointer writer = FileWriterType::New();
   if (args_info.output_given)
   {
-    writer->SetFileName(args_info.output_arg);
-    writer->SetInput(paste->GetOutput());
-    TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(paste->GetOutput(), args_info.output_arg))
   }
 
   return EXIT_SUCCESS;

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.cxx
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.cxx
@@ -50,11 +50,7 @@ main(int argc, char * argv[])
     geometry->SetRadiusCylindricalDetector(args_info.rad_cyl_arg);
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(&(*geometry));
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(geometry, args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkspectraldenoiseprojections/rtkspectraldenoiseprojections.cxx
+++ b/applications/rtkspectraldenoiseprojections/rtkspectraldenoiseprojections.cxx
@@ -34,9 +34,8 @@ main(int argc, char * argv[])
   using OutputImageType = itk::VectorImage<OutputPixelType, Dimension>;
 
   // Reader
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(args_info.input_arg);
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Remove aberrant pixels
   using MedianType = rtk::ConditionalMedianImageFilter<OutputImageType>;
@@ -50,18 +49,10 @@ main(int argc, char * argv[])
       radius[i] = args_info.radius_arg[i];
   }
   median->SetRadius(radius);
-  median->SetInput(reader->GetOutput());
+  median->SetInput(input);
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(median->GetOutput());
-  //  TRY_AND_EXIT_ON_ITK_EXCEPTION( writer->UpdateOutputInformation() )
-  //  writer->SetNumberOfStreamDivisions( 1 + reader->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() /
-  //  (1024*1024*4) );
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(median->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtktotalnuclearvariationdenoising/rtktotalnuclearvariationdenoising.cxx
+++ b/applications/rtktotalnuclearvariationdenoising/rtktotalnuclearvariationdenoising.cxx
@@ -41,25 +41,17 @@ main(int argc, char * argv[])
     rtk::TotalNuclearVariationDenoisingBPDQImageFilter<OutputImageType, GradientOutputImageType>;
 
   // Read input
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(args_info.input_arg);
-  //  reader->ReleaseDataFlagOn();
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Apply total nuclear variation denoising
   TVDenoisingFilterType::Pointer tv = TVDenoisingFilterType::New();
-  tv->SetInput(reader->GetOutput());
+  tv->SetInput(input);
   tv->SetGamma(args_info.gamma_arg);
   tv->SetNumberOfIterations(args_info.niter_arg);
-  //  tv->ReleaseDataFlagOn();
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(tv->GetOutput());
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(tv->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtktotalvariationdenoising/rtktotalvariationdenoising.cxx
+++ b/applications/rtktotalvariationdenoising/rtktotalvariationdenoising.cxx
@@ -49,15 +49,13 @@ main(int argc, char * argv[])
 #endif
 
   // Read input
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(args_info.input_arg);
-  reader->Update();
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Compute total variation before denoising
   using TVFilterType = rtk::TotalVariationImageFilter<OutputImageType>;
   TVFilterType::Pointer tv = TVFilterType::New();
-  tv->SetInput(reader->GetOutput());
+  tv->SetInput(input);
   if (args_info.verbose_flag)
   {
     tv->Update();
@@ -66,17 +64,12 @@ main(int argc, char * argv[])
 
   // Apply total variation denoising
   TVDenoisingFilterType::Pointer tvdenoising = TVDenoisingFilterType::New();
-  tvdenoising->SetInput(reader->GetOutput());
+  tvdenoising->SetInput(input);
   tvdenoising->SetGamma(args_info.gamma_arg);
   tvdenoising->SetNumberOfIterations(args_info.niter_arg);
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(tvdenoising->GetOutput());
-
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(tvdenoising->GetOutput(), args_info.output_arg))
 
   // Compute total variation after denoising
   if (args_info.verbose_flag)

--- a/applications/rtktutorialapplication/rtktutorialapplication.cxx
+++ b/applications/rtktutorialapplication/rtktutorialapplication.cxx
@@ -75,24 +75,19 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // Read the input volume
-  using InputReaderType = itk::ImageFileReader<OutputImageType>;
-  InputReaderType::Pointer inputReader = InputReaderType::New();
-  inputReader->SetFileName(args_info.input_arg);
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create the Add filter
   using AddFilterType = itk::AddImageFilter<OutputImageType>;
   AddFilterType::Pointer add = AddFilterType::New();
-  add->SetInput1(inputReader->GetOutput());
+  add->SetInput1(input);
   add->SetConstant2(args_info.constant_arg);
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(add->Update())
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName(args_info.output_arg);
-  writer->SetInput(add->GetOutput());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(add->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkvarianobigeometry/rtkvarianobigeometry.cxx
+++ b/applications/rtkvarianobigeometry/rtkvarianobigeometry.cxx
@@ -37,11 +37,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(reader->GetGeometry());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(reader->GetGeometry(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkvarianprobeamgeometry/rtkvarianprobeamgeometry.cxx
+++ b/applications/rtkvarianprobeamgeometry/rtkvarianprobeamgeometry.cxx
@@ -35,11 +35,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(reader->GetGeometry());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(reader->GetGeometry(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkwangdisplaceddetectorweighting/rtkwangdisplaceddetectorweighting.cxx
+++ b/applications/rtkwangdisplaceddetectorweighting/rtkwangdisplaceddetectorweighting.cxx
@@ -58,10 +58,8 @@ main(int argc, char * argv[])
   // Geometry
   if (args_info.verbose_flag)
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
-  rtk::ThreeDCircularProjectionGeometryXMLFileReader::Pointer geometryReader;
-  geometryReader = rtk::ThreeDCircularProjectionGeometryXMLFileReader::New();
-  geometryReader->SetFilename(args_info.geometry_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometryReader->GenerateOutputInformation())
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Displaced detector weighting
   using DDFCPUType = rtk::DisplacedDetectorImageFilter<OutputImageType>;
@@ -76,7 +74,7 @@ main(int argc, char * argv[])
   else
     ddf = DDFCPUType::New();
   ddf->SetInput(reader->GetOutput());
-  ddf->SetGeometry(geometryReader->GetOutputObject());
+  ddf->SetGeometry(geometry);
   if (args_info.minOffset_given && args_info.maxOffset_given)
     ddf->SetOffsets(args_info.minOffset_arg, args_info.maxOffset_arg);
 

--- a/applications/rtkwaveletsdenoising/rtkwaveletsdenoising.cxx
+++ b/applications/rtkwaveletsdenoising/rtkwaveletsdenoising.cxx
@@ -36,24 +36,19 @@ main(int argc, char * argv[])
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // Read the input image
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(args_info.input_arg);
+  OutputImageType::Pointer input;
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create the denoising filter
   using WaveletsSoftThresholdFilterType = rtk::DeconstructSoftThresholdReconstructImageFilter<OutputImageType>;
   WaveletsSoftThresholdFilterType::Pointer wst = WaveletsSoftThresholdFilterType::New();
-  wst->SetInput(reader->GetOutput());
+  wst->SetInput(input);
   wst->SetOrder(args_info.order_arg);
   wst->SetThreshold(args_info.threshold_arg);
   wst->SetNumberOfLevels(args_info.level_arg);
 
   // Write reconstruction
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetInput(wst->GetOutput());
-  writer->SetFileName(args_info.output_arg);
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(wst->GetOutput(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkxradgeometry/rtkxradgeometry.cxx
+++ b/applications/rtkxradgeometry/rtkxradgeometry.cxx
@@ -32,11 +32,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputData())
 
   // Write
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
-  xmlWriter->SetFilename(args_info.output_arg);
-  xmlWriter->SetObject(reader->GetGeometry());
-  TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rtk::WriteGeometry(reader->GetGeometry(), args_info.output_arg))
 
   return EXIT_SUCCESS;
 }

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
@@ -116,5 +116,14 @@ private:
   /** File format version */
   unsigned int m_Version{ 0 };
 };
+
+/** Convenience function for reading a geometry XML file.
+ *
+ * The function reads the geometry from the specified XML file, and returns the
+ * geometry that it has read.
+ * */
+RTK_EXPORT ThreeDCircularProjectionGeometry::Pointer
+           ReadGeometry(const std::string & filename);
+
 } // namespace rtk
 #endif

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
@@ -83,6 +83,26 @@ protected:
   void
   WriteLocalParameter(std::ofstream & output, const std::string & indent, const double & v, const std::string & s);
 };
+
+/** Convenience function for writing an geometry.
+ *
+ * The geometry parameter may be a either SmartPointer or a raw pointer and const or non-const.
+ * */
+template <typename TGeometryPointer>
+ITK_TEMPLATE_EXPORT void
+WriteGeometry(TGeometryPointer && geometry, const std::string & filename)
+{
+  using NonReferenceImagePointer = std::remove_reference_t<TGeometryPointer>;
+  static_assert(std::is_pointer<NonReferenceImagePointer>::value ||
+                  itk::mpl::IsSmartPointer<NonReferenceImagePointer>::Value,
+                "WriteGeometry requires a raw pointer or SmartPointer.");
+
+  auto writer = ThreeDCircularProjectionGeometryXMLFileWriter::New();
+  writer->SetObject(geometry);
+  writer->SetFilename(filename);
+  writer->WriteFile();
+}
+
 } // namespace rtk
 
 #endif

--- a/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
+++ b/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
@@ -172,6 +172,14 @@ ThreeDCircularProjectionGeometryXMLFileReader::CharacterDataHandler(const char *
     m_CurCharacterData = m_CurCharacterData + inData[i];
 }
 
+ThreeDCircularProjectionGeometry::Pointer
+ReadGeometry(const std::string & filename)
+{
+  const auto reader = ThreeDCircularProjectionGeometryXMLFileReader::New();
+  reader->SetFilename(filename);
+  reader->GenerateOutputInformation();
+  return reader->GetOutputObject();
+}
 } // namespace rtk
 
 #endif


### PR DESCRIPTION
These functions allow to simplify the C++ code for reading and writing a
geometry.

Inspired by the work done in ITK for reading
(https://github.com/InsightSoftwareConsortium/ITK/commit/aeea88b192) and
writing
(https://github.com/InsightSoftwareConsortium/ITK/commit/60b0984d4196841844424e33963e161f3f0c709d)
an image.