### PR TITLE
COMP: fix incorrect casts from scalar or vector to points

### DIFF
--- a/src/rtkOraGeometryReader.cxx
+++ b/src/rtkOraGeometryReader.cxx
@@ -119,7 +119,7 @@ OraGeometryReader::GenerateData()
       MetaDataDoubleType * zvecMeta =
         dynamic_cast<MetaDataDoubleType *>(dic["zdistancebaseunitcs2imagingcs_cm"].GetPointer());
       double zvec = zvecMeta->GetMetaDataObjectValue();
-      tiltTransform->SetCenter(itk::MakeVector(0., -10. * yvec, -10. * zvec));
+      tiltTransform->SetCenter(itk::MakePoint(0., -10. * yvec, -10. * zvec));
 
       sp = tiltTransform->TransformPoint(sp);
       dp = tiltTransform->TransformPoint(dp);

--- a/test/rtkoratest.cxx
+++ b/test/rtkoratest.cxx
@@ -82,8 +82,7 @@ main(int argc, char * argv[])
   spacing[1] = 2.;
   spacing[2] = 1.;
   reader->SetSpacing(spacing);
-  ReaderType::OutputImagePointType origin(0.);
-  reader->SetOrigin(0.);
+  reader->SetOrigin(itk::MakePoint(0., 0., 0.));
   ReaderType::OutputImageDirectionType direction;
   direction.SetIdentity();
   reader->SetDirection(direction);


### PR DESCRIPTION
Compilation errors were purposely introduced by
InsightSoftwareConsortium/ITK#3237