### PR TITLE
COMP: avoid implicit conversion from scalar to itk::Vector

### DIFF
--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -73,7 +73,7 @@ public:
   using OutputImageType = TOutputImage;
   static constexpr unsigned int NDimension = TInputImage::ImageDimension;
   using OutputImageRegionType = typename OutputImageType::RegionType;
-  using WeightImageType = itk::Image<typename TOutputImage::InternalPixelType, 1>;
+  using WeightImageType = itk::Image<double, 1>;
 
   using GeometryType = ThreeDCircularProjectionGeometry;
   using GeometryConstPointer = GeometryType::ConstPointer;

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -197,7 +197,7 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
     // No overlap, set output region to 0
     while (!itOut.IsAtEnd())
     {
-      itOut.Set(0.);
+      itOut.Set({});
       ++itOut;
     }
     return;

--- a/include/rtkDrawGeometricPhantomImageFilter.h
+++ b/include/rtkDrawGeometricPhantomImageFilter.h
@@ -72,6 +72,13 @@ public:
   itkSetMacro(PhantomScale, VectorType);
   itkGetMacro(PhantomScale, VectorType);
 
+  /** Set isotropic scaling factor. */
+  virtual void
+  SetPhantomScale(const ScalarType _arg)
+  {
+    SetPhantomScale(VectorType(_arg));
+  }
+
   /** Get / Set the spatial offset of the phantom relative to its center. The
    * default value is (0, 0, 0). */
   itkSetMacro(OriginOffset, VectorType);

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -81,7 +81,7 @@ SetConstantImageSourceFromGgo(typename TConstantImageSourceType::Pointer source,
   source->SetSpacing(imageSpacing);
   source->SetDirection(imageDirection);
   source->SetSize(imageDimension);
-  source->SetConstant(0.);
+  source->SetConstant({});
 
   // Copy output image information from an existing file, if requested
   // Overwrites parameters given in command line, if any

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -54,13 +54,13 @@ public:
     return !(*this != other);
   }
 
-  inline int
+  inline TOutput
   operator()(const double        itkNotUsed(stepLengthInVoxel),
              const TCoordRepType itkNotUsed(weight),
              const TInput *      itkNotUsed(p),
              const int           itkNotUsed(i)) const
   {
-    return 0;
+    return {};
   }
 };
 

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -269,7 +269,7 @@ JosephForwardProjectionImageFilter<TInputImage,
     }
     else
       m_ProjectedValueAccumulation(
-        threadId, itIn->Get(), itOut.Value(), 0., pixelPosition, pixelPosition, dirVox, pixelPosition, pixelPosition);
+        threadId, itIn->Get(), itOut.Value(), {}, pixelPosition, pixelPosition, dirVox, pixelPosition, pixelPosition);
   }
   delete itIn;
 }

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -79,6 +79,13 @@ public:
   itkSetMacro(PhantomScale, VectorType);
   itkGetMacro(PhantomScale, VectorType);
 
+  /** Set isotropic scaling factor. */
+  virtual void
+  SetPhantomScale(const ScalarType _arg)
+  {
+    SetPhantomScale(VectorType(_arg));
+  }
+
   /** Get / Set the spatial offset of the phantom relative to its center. The
    * default value is (0, 0, 0). */
   itkSetMacro(OriginOffset, VectorType);


### PR DESCRIPTION
Required with ITK_LEGACY_REMOVE=ON since InsightSoftwareConsortium/ITK#3255