### PR TITLE
BUG: Fix SDD parameter calculation for parallel geometry

### DIFF
--- a/include/rtkThreeDCircularProjectionGeometry.h
+++ b/include/rtkThreeDCircularProjectionGeometry.h
@@ -115,7 +115,25 @@ public:
   /** Add projection from a projection matrix. A projection matrix is defined
    * up to a scaling factor. The function here Assumes that the input matrix
    * pMat is normalized such that pMat*(x,y,z,1)'=(u,v,1)'.
-   * This code assumes that the SourceToDetectorDistance is positive. */
+   * This code assumes that the SourceToDetectorDistance is positive.
+   *
+   * \warning For parallel geometry the matrix has a special form
+   *
+   *     | R11 R12 R13 -ProjectionOffsetX |
+   * Mp =| R21 R22 R23 -ProjectionOffsetY |
+   *     |  0   0   0           1         |
+   *
+   * where
+   *
+   * | R11 R12 R13 |
+   * | R21 R22 R23 | - cropped rotation 3x3 matrix
+   * |  0   0   0  |
+   *
+   * outOfPlaneAngle must be within (-90, 90) degrees range,
+   * otherwise the rotation angles could be miscalculated.
+   *
+   * If projection matrix is for parallel geometry, then SID is set to 1000. mm
+   */
   bool
   AddProjection(const HomogeneousProjectionMatrixType & pMat);
 
@@ -265,7 +283,6 @@ public:
   {
     return this->m_MagnificationMatrices[i];
   }
-
 
   /** Get the vector containing the collimation jaw parameters. */
   const std::vector<double> &

--- a/src/rtkThreeDCircularProjectionGeometry.cxx
+++ b/src/rtkThreeDCircularProjectionGeometry.cxx
@@ -165,7 +165,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const PointType &  sourcePo
   const PointType &  S = sourcePosition;          // source pos
   const PointType &  R = detectorPosition;        // detector pos
 
-  if (fabs(r * c) > 1e-6) // non-orthogonal row/column vectors
+  if (itk::Math::abs(r * c) > 1e-6) // non-orthogonal row/column vectors
     return false;
 
   // Euler angles (ZXY convention) from detector orientation in IEC-based WCS:
@@ -685,7 +685,7 @@ rtk::ThreeDCircularProjectionGeometry::VerifyAngles(const double          outOfP
 
   for (int i = 0; i < 3; i++) // check whether matrices match
     for (int j = 0; j < 3; j++)
-      if (fabs(rm[i][j] - m[i][j]) > EPSILON)
+      if (itk::Math::abs(rm[i][j] - m[i][j]) > EPSILON)
         return false;
 
   return true;
@@ -700,7 +700,7 @@ rtk::ThreeDCircularProjectionGeometry::FixAngles(double &              outOfPlan
   const Matrix3x3Type & rm = referenceMatrix; // shortcut
   const double          EPSILON = 1e-6;       // internal tolerance for comparison
 
-  if (fabs(fabs(rm[2][1]) - 1.) > EPSILON)
+  if (itk::Math::abs(itk::Math::abs(rm[2][1]) - 1.) > EPSILON)
   {
     double oa = NAN, ga = NAN, ia = NAN;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -285,6 +285,7 @@ rtk_add_test(rtkArgsInfoManagerTest rtkargsinfomanagertest.cxx)
 
 rtk_add_test(rtkGeometryCloneTest rtkgeometryclonetest.cxx)
 rtk_add_test(rtkGeometryFromMatrixTest rtkgeometryfrommatrixtest.cxx)
+rtk_add_test(rtkParallelGeometryFromMatrixTest rtkparallelgeometryfrommatrixtest.cxx)
 
 rtk_add_test(rtkOraTest rtkoratest.cxx
   DATA{Input/Ora/0_afterLog.ora.xml,0_afterLog.mhd,0_afterLog.raw}

--- a/test/rtkparallelgeometryfrommatrixtest.cxx
+++ b/test/rtkparallelgeometryfrommatrixtest.cxx
@@ -1,0 +1,101 @@
+// RTK
+#include "rtkThreeDCircularProjectionGeometry.h"
+
+
+int
+main(int, char **)
+{
+  rtk::ThreeDCircularProjectionGeometry::Pointer geometry1, geometry2;
+  geometry1 = rtk::ThreeDCircularProjectionGeometry::New();
+  geometry2 = rtk::ThreeDCircularProjectionGeometry::New();
+
+  const double sid = 1000.;
+  const double sdd = 0.; // Parallel geometry
+  for (double oa = -60.; oa < 65.; oa += 60.)
+  {
+    for (double ia = -360.; ia < 360.; ia += 60.)
+    {
+      for (double ga = -360.; ga < 360.; ga += 45.)
+      {
+        for (double px = -50.; px < 55.; px += 25.)
+        {
+          for (double py = -50.; py < 55.; py += 25.)
+          {
+            geometry1->AddProjection(sid, sdd, ga, px, py, oa, ia);
+            geometry2->AddProjection(geometry1->GetMatrices().back());
+
+            double g1 = geometry1->GetGantryAngles().back();
+            double g2 = geometry2->GetGantryAngles().back();
+            double d = g1 - g2;
+            d = itk::Math::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: GantryAngles 1 is " << g1 << " and GantryAngles 2 is " << g2;
+              return EXIT_FAILURE;
+            }
+
+            double ia1 = geometry1->GetInPlaneAngles().back();
+            double ia2 = geometry2->GetInPlaneAngles().back();
+            d = ia1 - ia2;
+            d = itk::Math::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: InPlaneAngles 1 is " << ia1 << " and InPlaneAngles 2 is " << ia2;
+              return EXIT_FAILURE;
+            }
+
+            double oa1 = geometry1->GetOutOfPlaneAngles().back();
+            double oa2 = geometry2->GetOutOfPlaneAngles().back();
+            d = oa1 - oa2;
+            d = itk::Math::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: OutOfPlaneAngle 1 is " << oa1 << " and OutOfPlaneAngle 2 is " << oa2;
+              return EXIT_FAILURE;
+            }
+
+            double py1 = geometry1->GetProjectionOffsetsY().back();
+            double py2 = geometry2->GetProjectionOffsetsY().back();
+            d = itk::Math::abs(py1 - py2);
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: ProjectionOffsetsY 1 is " << py1 << " and ProjectionOffsetsY 2 is " << py2;
+              return EXIT_FAILURE;
+            }
+
+            double px1 = geometry1->GetProjectionOffsetsX().back();
+            double px2 = geometry2->GetProjectionOffsetsX().back();
+            d = itk::Math::abs(px1 - px2);
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: ProjectionOffsetsX 1 is " << px1 << " and ProjectionOffsetsX 2 is " << px2;
+              return EXIT_FAILURE;
+            }
+
+            double sid1 = geometry1->GetSourceToIsocenterDistances().back();
+            double sid2 = geometry2->GetSourceToIsocenterDistances().back();
+            d = itk::Math::abs(sid1 - sid2);
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: GetSourceToIsocenterDistances 1 is " << sid1
+                        << " and GetSourceToIsocenterDistances 2 is " << sid2;
+              return EXIT_FAILURE;
+            }
+
+            double sdd1 = geometry1->GetSourceToDetectorDistances().back();
+            double sdd2 = geometry2->GetSourceToDetectorDistances().back();
+            d = itk::Math::abs(sdd1 - sdd2);
+            if (d > 0.01)
+            {
+              std::cerr << "ERROR: GetSourceToDetectorDistances 1 is " << sdd1
+                        << " and GetSourceToDetectorDistances 2 is " << sdd2;
+              return EXIT_FAILURE;
+            }
+          }
+        }
+      }
+    }
+  }
+  std::cout << "Test PASSED! " << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The source to detector distance (SDD) parameter is forced to be equal `0.0` when it calculated by [AddProjection methods](http://www.openrtk.org/Doxygen/classrtk_1_1ThreeDCircularProjectionGeometry.html#a0fb1475ed76a28cde24fac85eae18e1e) and the SDD absolute value is less than 1.E-06.

For example:
A forward projection, in case of parallel geometry, can't be calculated if `SDD == 1.E-10;` because of checks like:

1. https://github.com/SimonRit/RTK/blob/master/src/rtkThreeDCircularProjectionGeometry.cxx#L469
2. https://github.com/SimonRit/RTK/blob/master/src/rtkThreeDCircularProjectionGeometry.cxx#L570
