### PR TITLE
COMP: remove unused wrapping of FDKWarpBackProjectionImageFilter

### DIFF
--- a/wrapping/rtkFDKWarpBackProjectionImageFilter.wrap
+++ b/wrapping/rtkFDKWarpBackProjectionImageFilter.wrap
@@ -1,9 +1,6 @@
 itk_wrap_include(rtkCyclicDeformationImageFilter.h)
 
 itk_wrap_class("rtk::FDKWarpBackProjectionImageFilter"  POINTER)
-  itk_wrap_template("I${ITKM_F}3I${ITKM_F}3CDFI${ITKM_F}4I${ITKM_F}3"
-    "itk::Image<${ITKT_F}, 3>, itk::Image<${ITKT_F}, 3>, rtk::CyclicDeformationImageFilter< itk::Image<${ITKT_F}, 4>, itk::Image<${ITKT_F}, 3> >")
-
   itk_wrap_template("I${ITKM_F}3I${ITKM_F}3CDFI${ITKM_VF3}4I${ITKM_VF3}3"
     "itk::Image<${ITKT_F}, 3>, itk::Image<${ITKT_F}, 3>, rtk::CyclicDeformationImageFilter< itk::Image<${ITKT_VF3}, 4>, itk::Image<${ITKT_VF3}, 3> >")
 itk_end_wrap_class()


### PR DESCRIPTION
The wrapping does not compile with ITK_LEGACY_REMOVE=ON since
InsightSoftwareConsortium/ITK#3255