### PR TITLE
Corrected Parker weights references

### DIFF
--- a/include/rtkParkerShortScanImageFilter.h
+++ b/include/rtkParkerShortScanImageFilter.h
@@ -29,12 +29,10 @@ namespace rtk
 
 /** \class ParkerShortScanImageFilter
  *
- * Weighting of image projections to handle off-centered panels
- * in tomography reconstruction. Based on [Wang, Med Phys, 2002].
- *
- * Note that the filter does nothing if the panel shift is less than 10%
- * of its size. Otherwise, it does the weighting described in the publication
- * and zero pads the data on the nearest side to the center.
+ * Weighting of image projections to handle short-scans
+ * in tomography reconstruction. Based on [Parker, Med Phys, 1982].
+ * Class implements a fix to typo in equation (12) of Parker as seen
+ * in book "Principles of computerized tomographic imaging" by Kak and Slaney
  *
  * \test rtkshortscantest.cxx, rtkshortscancompcudatest.cxx
  *

--- a/include/rtkParkerShortScanImageFilter.hxx
+++ b/include/rtkParkerShortScanImageFilter.hxx
@@ -193,6 +193,7 @@ ParkerShortScanImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDa
       else if (beta <= pi - 2 * alpha)
         itWeights.Set(2.);
       else if (beta <= pi + 2 * m_Delta)
+        // Denominator fix to a typo in equation (12) of Parker's article.
         itWeights.Set(2. * pow(sin((pi * (pi + 2 * m_Delta - beta)) / (4 * (m_Delta + alpha))), 2.));
       else
         itWeights.Set(0.);


### PR DESCRIPTION
Corrected a description of the Parker filter to match the exact literature it's based upon. In particular, Parker's paper version available online still carries an error that was later amended, as seen in classic book "Principles of computerized tomographic imaging" by Kak and Slaney.