### PR TITLE
BUG: Activate displaced detector padding in iterative FDK #499

### DIFF
--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.hxx
@@ -52,7 +52,7 @@ IterativeFDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecisio
   m_DivideFilter = DivideFilterType::New();
 
   // Filter parameters
-  m_DisplacedDetectorFilter->SetPadOnTruncatedSide(false);
+  m_DisplacedDetectorFilter->SetPadOnTruncatedSide(true);
   m_DisableDisplacedDetectorFilter = false;
 }
 


### PR DESCRIPTION
Set displaced detector filter in iterative FDK reconstruction filter to true by default, to avoid dark hole in reconstructed image from displaced detector projections. #499 