### PR TITLE
STYLE: Remove traces of CG cost function calculation

### DIFF
--- a/applications/rtkconjugategradient/rtkconjugategradient.cxx
+++ b/applications/rtkconjugategradient/rtkconjugategradient.cxx
@@ -38,9 +38,7 @@ main(int argc, char * argv[])
   GGO(rtkconjugategradient, args_info);
 
   using OutputPixelType = float;
-  constexpr unsigned int        Dimension = 3;
-  std::vector<double>           costs;
-  std::ostream_iterator<double> costs_it(std::cout, "\n");
+  constexpr unsigned int Dimension = 3;
 
 #ifdef RTK_USE_CUDA
   using OutputImageType = itk::CudaImage<OutputPixelType, Dimension>;
@@ -120,7 +118,6 @@ main(int argc, char * argv[])
   {
     conjugategradient->SetSupportMask(supportmaskSource);
   }
-  //  conjugategradient->SetIterationCosts(args_info.costs_flag);
 
   if (args_info.gamma_given)
     conjugategradient->SetGamma(args_info.gamma_arg);
@@ -134,13 +131,6 @@ main(int argc, char * argv[])
   REPORT_ITERATIONS(conjugategradient, ConjugateGradientFilterType, OutputImageType)
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(conjugategradient->Update())
-
-  if (args_info.costs_given)
-  {
-    costs = conjugategradient->GetResidualCosts();
-    std::cout << "Residual costs at each iteration :" << std::endl;
-    copy(costs.begin(), costs.end(), costs_it);
-  }
 
   // Write
   TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(conjugategradient->GetOutput(), args_info.output_arg))

--- a/applications/rtkconjugategradient/rtkconjugategradient.ggo
+++ b/applications/rtkconjugategradient/rtkconjugategradient.ggo
@@ -12,5 +12,4 @@ option "gamma"          - "Laplacian regularization weight"                     
 option "tikhonov"       - "Tikhonov regularization weight"                                                            float  no   default="0"
 option "nocudacg"       - "Do not perform conjugate gradient calculations on GPU"                                     flag   off
 option "mask"           m "Apply a support binary mask: reconstruction kept null outside the mask)"                   string no
-option "costs"          - "Show residual costs at each iteration at the end of the process"                           flag   off
 option "nodisplaced"    - "Disable the displaced detector filter"                                                     flag   off

--- a/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
+++ b/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
@@ -118,7 +118,6 @@ main(int argc, char * argv[])
   {
     regularizedConjugateGradient->SetSupportMask(supportmaskSource);
   }
-  regularizedConjugateGradient->SetIterationCosts(args_info.costs_flag);
 
   // Positivity
   if (args_info.nopositivity_flag)

--- a/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.ggo
+++ b/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.ggo
@@ -13,7 +13,6 @@ option "tikhonov"       - "Tikhonov regularization weight"                      
 option "cgiter"         - "Number of conjugate gradient nested iterations"                                            int    no   default="4"
 option "nocudacg"       - "Do not perform conjugate gradient calculations on GPU"                                     flag   off
 option "mask"           m "Apply a support binary mask: reconstruction kept null outside the mask)"                   string no
-option "costs"          - "Show residual costs at each iteration at the end of the process"                           flag   off
 option "nodisplaced"    - "Disable the displaced detector filter"                                                     flag   off
 
 section "Regularization"

--- a/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.cxx
+++ b/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.cxx
@@ -43,9 +43,6 @@ main(int argc, char * argv[])
   using PixelType = itk::Vector<DataType, nMaterials>;
   using WeightsType = itk::Vector<DataType, nMaterials * nMaterials>;
 
-  std::vector<double>           costs;
-  std::ostream_iterator<double> costs_it(std::cout << std::setprecision(15), "\n");
-
 #ifdef RTK_USE_CUDA
   using SingleComponentImageType = itk::CudaImage<DataType, Dimension>;
   using OutputImageType = itk::CudaImage<PixelType, Dimension>;
@@ -129,7 +126,6 @@ main(int argc, char * argv[])
   {
     conjugategradient->SetSupportMask(supportmask);
   }
-  conjugategradient->SetIterationCosts(args_info.costs_flag);
 
   if (args_info.tikhonov_given)
     conjugategradient->SetTikhonov(args_info.tikhonov_arg);
@@ -152,13 +148,6 @@ main(int argc, char * argv[])
     //    conjugategradient->PrintTiming(std::cout);
     readerProbe.Stop();
     std::cout << "It took...  " << readerProbe.GetMean() << ' ' << readerProbe.GetUnit() << std::endl;
-  }
-
-  if (args_info.costs_given)
-  {
-    costs = conjugategradient->GetResidualCosts();
-    std::cout << "Residual costs at each iteration :" << std::endl;
-    copy(costs.begin(), costs.end(), costs_it);
   }
 
   // Write

--- a/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.ggo
+++ b/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.ggo
@@ -13,6 +13,5 @@ option "weights"        w "Weights file for Weighted Least Squares (WLS)"       
 option "tikhonov"       - "Tikhonov regularization weight"                                                            float  no   default="0"
 option "nocudacg"       - "Do not perform conjugate gradient calculations on GPU"                                     flag   off
 option "mask"           m "Apply a support binary mask: reconstruction kept null outside the mask)"                   string no
-option "costs"          - "Show residual costs at each iteration at the end of the process"                           flag   off
 option "nodisplaced"    - "Disable the displaced detector filter"                                                     flag   off
 option "targetSDD"      - "Target sum of squared difference between consecutive iterates, as stopping criterion"      double no   default="0"

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -183,9 +183,6 @@ public:
   itkSetMacro(NumberOfIterations, int);
   itkGetMacro(NumberOfIterations, int);
 
-  itkSetMacro(IterationCosts, bool);
-  itkGetMacro(IterationCosts, bool);
-
   /** Set / Get whether the displaced detector filter should be disabled */
   itkSetMacro(DisableDisplacedDetectorFilter, bool);
   itkGetMacro(DisableDisplacedDetectorFilter, bool);
@@ -200,10 +197,6 @@ public:
   /** Get / Set whether conjugate gradient should be performed on GPU */
   itkGetMacro(CudaConjugateGradient, bool);
   itkSetMacro(CudaConjugateGradient, bool);
-
-  /** Getter for ResidualCosts storing array **/
-  const std::vector<double> &
-  GetResidualCosts();
 
 protected:
   ConjugateGradientConeBeamReconstructionFilter();
@@ -274,7 +267,6 @@ private:
   int   m_NumberOfIterations;
   float m_Gamma;
   float m_Tikhonov;
-  bool  m_IterationCosts;
   bool  m_CudaConjugateGradient;
   bool  m_DisableDisplacedDetectorFilter;
 

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -33,7 +33,6 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 
   // Set the default values of member parameters
   m_NumberOfIterations = 3;
-  m_IterationCosts = false;
 
   m_Gamma = 0;
   m_Tikhonov = 0;
@@ -116,13 +115,6 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 }
 
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
-const std::vector<double> &
-ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::GetResidualCosts()
-{
-  return m_ConjugateGradientFilter->GetResidualCosts();
-}
-
-template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
 ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImage, TWeightsImage>::VerifyPreconditions()
   ITKv5_CONST
@@ -179,7 +171,6 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
     m_ConjugateGradientFilter = InstantiateCudaConjugateGradientImageFilter<TOutputImage>();
 #endif
   m_ConjugateGradientFilter->SetA(m_CGOperator.GetPointer());
-  m_ConjugateGradientFilter->SetIterationCosts(m_IterationCosts);
 
   // Set forward projection filter
   m_ForwardProjectionFilter = this->InstantiateForwardProjectionFilter(this->m_CurrentForwardProjectionConfiguration);

--- a/include/rtkConjugateGradientImageFilter.h
+++ b/include/rtkConjugateGradientImageFilter.h
@@ -67,10 +67,6 @@ public:
   itkGetMacro(NumberOfIterations, int);
   itkSetMacro(NumberOfIterations, int);
 
-  /** Displays the conjugate gradient cost function at each iteration. */
-  itkGetMacro(IterationCosts, bool);
-  itkSetMacro(IterationCosts, bool);
-
   void
   SetA(ConjugateGradientOperatorPointerType _arg);
 
@@ -81,16 +77,6 @@ public:
   /** The image called "B" in the CG algorithm.*/
   void
   SetB(const OutputImageType * OutputImage);
-
-  /** Set and Get the constant quantity BtWB for residual costs calculation */
-  void
-  SetC(const double _arg);
-  double
-  GetC();
-
-  /** Getter for ResidualCosts storing array **/
-  const std::vector<double> &
-  GetResidualCosts();
 
 protected:
   ConjugateGradientImageFilter();
@@ -113,10 +99,7 @@ protected:
 
   ConjugateGradientOperatorPointerType m_A;
 
-  int                 m_NumberOfIterations;
-  bool                m_IterationCosts;
-  std::vector<double> m_ResidualCosts;
-  double              m_C;
+  int m_NumberOfIterations;
 };
 } // namespace rtk
 

--- a/include/rtkConjugateGradientImageFilter.hxx
+++ b/include/rtkConjugateGradientImageFilter.hxx
@@ -33,32 +33,8 @@ ConjugateGradientImageFilter<OutputImageType>::ConjugateGradientImageFilter()
   this->SetInPlace(true);
 
   m_NumberOfIterations = 1;
-  m_IterationCosts = false;
-  m_C = 0.0;
 
   m_A = ConjugateGradientOperatorType::New();
-}
-
-template <typename OutputImageType>
-void
-ConjugateGradientImageFilter<OutputImageType>::SetC(const double _arg)
-{
-  this->m_C = _arg;
-  this->Modified();
-}
-
-template <typename OutputImageType>
-double
-ConjugateGradientImageFilter<OutputImageType>::GetC()
-{
-  return this->m_C;
-}
-
-template <typename OutputImageType>
-const std::vector<double> &
-ConjugateGradientImageFilter<OutputImageType>::GetResidualCosts()
-{
-  return this->m_ResidualCosts;
 }
 
 template <typename OutputImageType>

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -269,9 +269,6 @@ public:
   itkSetMacro(RegularizationRadius, typename TOutputImage::RegionType::SizeType);
   itkGetMacro(RegularizationRadius, typename TOutputImage::RegionType::SizeType);
 
-  //    itkSetMacro(IterationCosts, bool);
-  //    itkGetMacro(IterationCosts, bool);
-
   /** Set methods forwarding the detector response and material attenuation
    * matrices to the internal WeidingerForwardModel filter */
   using BinnedDetectorResponseType = vnl_matrix<dataType>;
@@ -365,9 +362,6 @@ protected:
 
   typename TOutputImage::PixelType            m_RegularizationWeights;
   typename TOutputImage::RegionType::SizeType m_RegularizationRadius;
-
-  // private:
-  //    bool                         m_IterationCosts;
 };
 } // namespace rtk
 

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -187,10 +187,6 @@ public:
   itkGetMacro(Order, unsigned int);
   itkSetMacro(Order, unsigned int);
 
-  /** Displays the conjugate gradient cost function at each iteration. */
-  itkSetMacro(IterationCosts, bool);
-  itkGetMacro(IterationCosts, bool);
-
   // Iterations
   itkSetMacro(MainLoop_iterations, int);
   itkGetMacro(MainLoop_iterations, int);
@@ -275,7 +271,6 @@ protected:
   unsigned int m_NumberOfLevels;
 
   /** Conjugate gradient parameters */
-  bool m_IterationCosts;
   bool m_DisableDisplacedDetectorFilter;
 
   // Iterations

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.hxx
@@ -56,7 +56,6 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<
   m_Order = 5;
   m_NumberOfLevels = 3;
   m_DisableDisplacedDetectorFilter = false;
-  m_IterationCosts = false;
 
   // Create the filters
   m_CGFilter = CGFilterType::New();
@@ -167,7 +166,6 @@ RegularizedConjugateGradientConeBeamReconstructionFilter<TImage>::GenerateOutput
   m_CGFilter->SetCudaConjugateGradient(this->GetCudaConjugateGradient());
   m_CGFilter->SetGamma(this->m_Gamma);
   m_CGFilter->SetTikhonov(this->m_Tikhonov);
-  //  m_CGFilter->SetIterationCosts(m_IterationCosts);
   m_CGFilter->SetDisableDisplacedDetectorFilter(m_DisableDisplacedDetectorFilter);
 
   currentDownstreamFilter = m_CGFilter;


### PR DESCRIPTION
Fixes #448. The code has been removed with
0e0049625349eaa9acf105719437d7b871470d60 and these traces were misleading. Currently one can record the iterates and do the calculations manually.