### PR TITLE
BUG: Fix the inconsistency between CUDA and multi-threads(MT) code for negative SourceToDetectorDistance

### DIFF
--- a/src/rtkCudaDisplacedDetectorImageFilter.cu
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cu
@@ -41,7 +41,7 @@ ToUntiltedCoordinateAtIsocenter(float tiltedCoord, float sdd, float sid, float s
   const float cosa = sx / sidu;
   // the following relation refers to a note by R. Clackdoyle, title
   // "Samping a tilted detector"
-  return l * sid / (sidu - l * cosa);
+  return l * abs(sid) / (sidu - l * cosa);
 }
 
 __global__ void


### PR DESCRIPTION
I have found that for geometry that have negative _**sdd**_ and **_sid_**, which means the projection geometry is described in a right handed coordinate system, the **_DisplacedDetectorFilter_** implemented on CUDA behaves differently, and the CUDA version obviously takes the wrong direction of the detector row and gives wrong weights on the padded projections.
After looking into the implementation, I have found that the function **_ToUntiltedCoordinateAtIsocenter_**  has been implemented differently in CUDA and MT versions.
I have altered function **_ToUntiltedCoordinateAtIsocenter_** in rtkCudaDisplacedDetector.cu, to make it have consistent results with rtkDisplacedDetector.hxx.