### PR TITLE
WIP: ENH: Enable to stop the rays at a given distance for Joseph-based projectors

### DIFF
--- a/applications/rtkforwardprojections/rtkforwardprojections.cxx
+++ b/applications/rtkforwardprojections/rtkforwardprojections.cxx
@@ -80,6 +80,14 @@ main(int argc, char * argv[])
     attenuationMap = itk::ReadImage<OutputImageType>(args_info.attenuationmap_arg);
   }
 
+  OutputImageType::Pointer stopRay;
+  if (args_info.stopray_given)
+  {
+    if (args_info.verbose_flag)
+      std::cout << "Reading stop ray " << args_info.stopray_arg << "..." << std::endl;
+    // Read an existing image to initialize the attenuation map
+    stopRay = itk::ReadImage<OutputImageType>(args_info.stopray_arg);
+  }
   // Create forward projection image filter
   if (args_info.verbose_flag)
     std::cout << "Projecting volume..." << std::endl;
@@ -116,6 +124,8 @@ main(int argc, char * argv[])
   forwardProjection->SetInput(1, inputVolume);
   if (args_info.attenuationmap_given)
     forwardProjection->SetInput(2, attenuationMap);
+  if (args_info.stopray_given)
+    forwardProjection->SetInput(3, stopRay);
   if (args_info.sigmazero_given && args_info.fp_arg == fp_arg_Zeng)
     dynamic_cast<rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType> *>(
       forwardProjection.GetPointer())

--- a/applications/rtkforwardprojections/rtkforwardprojections.ggo
+++ b/applications/rtkforwardprojections/rtkforwardprojections.ggo
@@ -14,3 +14,4 @@ option "fp"    f "Forward projection method" values="Joseph","JosephAttenuated",
 option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
 option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
 option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 
+option "stopray" - "Positions along the rays where to stop the projections (only with Joseph-based projector)" string no

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -266,6 +266,10 @@ protected:
   JosephForwardProjectionImageFilter();
   ~JosephForwardProjectionImageFilter() override = default;
 
+  /** Apply changes to the input image requested region. */
+  void
+  GenerateInputRequestedRegion() override;
+
   void
   ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 


### PR DESCRIPTION
The user can now give as a third input of Joseph-based projectors a projection image where each pixel value correspond to the position on the ray where to stop the computation of the projection. 