### PR TITLE
ENH: Add superior and inferior clip images for Joseph-based forward projector

### DIFF
--- a/applications/rtkforwardprojections/rtkforwardprojections.cxx
+++ b/applications/rtkforwardprojections/rtkforwardprojections.cxx
@@ -80,6 +80,23 @@ main(int argc, char * argv[])
     attenuationMap = itk::ReadImage<OutputImageType>(args_info.attenuationmap_arg);
   }
 
+  using ClipImageType = itk::Image<double, Dimension>;
+  ClipImageType::Pointer inferiorClipImage, superiorClipImage;
+  if (args_info.inferiorclipimage_given)
+  {
+    if (args_info.verbose_flag)
+      std::cout << "Reading inferior clip image " << args_info.inferiorclipimage_arg << "..." << std::endl;
+    // Read an existing image to initialize the attenuation map
+    inferiorClipImage = itk::ReadImage<ClipImageType>(args_info.inferiorclipimage_arg);
+  }
+  if (args_info.superiorclipimage_given)
+  {
+    if (args_info.verbose_flag)
+      std::cout << "Reading superior clip image " << args_info.superiorclipimage_arg << "..." << std::endl;
+    // Read an existing image to initialize the attenuation map
+    superiorClipImage = itk::ReadImage<ClipImageType>(args_info.superiorclipimage_arg);
+  }
+
   // Create forward projection image filter
   if (args_info.verbose_flag)
     std::cout << "Projecting volume..." << std::endl;
@@ -116,6 +133,36 @@ main(int argc, char * argv[])
   forwardProjection->SetInput(1, inputVolume);
   if (args_info.attenuationmap_given)
     forwardProjection->SetInput(2, attenuationMap);
+  if (args_info.inferiorclipimage_given)
+  {
+    if (args_info.fp_arg == fp_arg_Joseph)
+    {
+      dynamic_cast<rtk::JosephForwardProjectionImageFilter<OutputImageType, OutputImageType> *>(
+        forwardProjection.GetPointer())
+        ->SetInferiorClipImage(inferiorClipImage);
+    }
+    else if (args_info.fp_arg == fp_arg_JosephAttenuated)
+    {
+      dynamic_cast<rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType> *>(
+        forwardProjection.GetPointer())
+        ->SetInferiorClipImage(inferiorClipImage);
+    }
+  }
+  if (args_info.superiorclipimage_given)
+  {
+    if (args_info.fp_arg == fp_arg_Joseph)
+    {
+      dynamic_cast<rtk::JosephForwardProjectionImageFilter<OutputImageType, OutputImageType> *>(
+        forwardProjection.GetPointer())
+        ->SetSuperiorClipImage(superiorClipImage);
+    }
+    else if (args_info.fp_arg == fp_arg_JosephAttenuated)
+    {
+      dynamic_cast<rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType> *>(
+        forwardProjection.GetPointer())
+        ->SetSuperiorClipImage(superiorClipImage);
+    }
+  }
   if (args_info.sigmazero_given && args_info.fp_arg == fp_arg_Zeng)
     dynamic_cast<rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType> *>(
       forwardProjection.GetPointer())

--- a/applications/rtkforwardprojections/rtkforwardprojections.ggo
+++ b/applications/rtkforwardprojections/rtkforwardprojections.ggo
@@ -13,6 +13,6 @@ section "Projectors"
 option "fp"    f "Forward projection method" values="Joseph","JosephAttenuated","CudaRayCast","Zeng" enum no default="Joseph"
 option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
 option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
-option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 
+option "alphapsf" - "Slope of the PSF against the detector distance"   double  no
 option "inferiorclipimage" - "Value of the inferior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no
 option "superiorclipimage" - "Value of the superior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no

--- a/applications/rtkforwardprojections/rtkforwardprojections.ggo
+++ b/applications/rtkforwardprojections/rtkforwardprojections.ggo
@@ -14,3 +14,5 @@ option "fp"    f "Forward projection method" values="Joseph","JosephAttenuated",
 option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
 option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
 option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 
+option "inferiorclipimage" - "Value of the inferior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no
+option "superiorclipimage" - "Value of the superior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no

--- a/applications/rtkiterativefdk/rtkiterativefdk.ggo
+++ b/applications/rtkiterativefdk/rtkiterativefdk.ggo
@@ -19,3 +19,8 @@ option "hannY"     - "Cut frequency for hann window in ]0,1] (0.0 disables it)" 
 
 section "Projectors"
 option "fp"    f "Forward projection method" values="Joseph","CudaRayCast","JosephAttenuated","Zeng" enum no default="Joseph"
+option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no
+option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
+option "alphapsf" - "Slope of the PSF against the detector distance"   double  no
+option "inferiorclipimage" - "Value of the inferior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no
+option "superiorclipimage" - "Value of the superior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no

--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -75,13 +75,6 @@ main(int argc, char * argv[])
     inputFilter = constantImageSource;
   }
 
-  OutputImageType::Pointer attenuationMap;
-  if (args_info.attenuationmap_given)
-  {
-    // Read an existing image to initialize the attenuation map
-    attenuationMap = itk::ReadImage<OutputImageType>(args_info.attenuationmap_arg);
-  }
-
   // OSEM reconstruction filter
   rtk::OSEMConeBeamReconstructionFilter<OutputImageType>::Pointer osem =
     rtk::OSEMConeBeamReconstructionFilter<OutputImageType>::New();
@@ -91,15 +84,9 @@ main(int argc, char * argv[])
   SetBackProjectionFromGgo(args_info, osem.GetPointer());
   osem->SetInput(inputFilter->GetOutput());
   osem->SetInput(1, reader->GetOutput());
-  if (args_info.attenuationmap_given)
-    osem->SetInput(2, attenuationMap);
-  if (args_info.sigmazero_given)
-    osem->SetSigmaZero(args_info.sigmazero_arg);
-  if (args_info.alphapsf_given)
-    osem->SetAlpha(args_info.alphapsf_arg);
+  osem->SetGeometry(geometry);
   if (args_info.betaregularization_given)
     osem->SetBetaRegularization(args_info.betaregularization_arg);
-  osem->SetGeometry(geometry);
 
   osem->SetNumberOfIterations(args_info.niterations_arg);
   osem->SetNumberOfProjectionsPerSubset(args_info.nprojpersubset_arg);

--- a/applications/rtkprojectors_section.ggo
+++ b/applications/rtkprojectors_section.ggo
@@ -4,3 +4,5 @@ option "bp"    b "Back projection method" values="VoxelBasedBackProjection","Jos
 option "attenuationmap" - "Attenuation map relative to the volume to perfom the attenuation correction"   string  no 
 option "sigmazero" - "PSF value at a distance of 0 meter of the detector"   double  no
 option "alphapsf" - "Slope of the PSF against the detector distance"   double  no 
+option "inferiorclipimage" - "Value of the inferior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no
+option "superiorclipimage" - "Value of the superior clip of the ray for each pixel of the projections (only with Joseph-based projector)" string no

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -281,6 +281,14 @@ template <class TArgsInfo, class TIterativeReconstructionFilter>
 void
 SetBackProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructionFilter * recon)
 {
+  typename TIterativeReconstructionFilter::VolumeType::Pointer attenuationMap;
+  using VolumeType = typename TIterativeReconstructionFilter::VolumeType;
+  if (args_info.attenuationmap_given)
+  {
+    // Read an existing image to initialize the attenuation map
+    attenuationMap = itk::ReadImage<VolumeType>(args_info.attenuationmap_arg);
+  }
+
   switch (args_info.bp_arg)
   {
     case (-1): // bp__NULL, keep default
@@ -299,9 +307,17 @@ SetBackProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructionFi
       break;
     case (4): // bp_arg_JosephAttenuated
       recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_JOSEPHATTENUATED);
+      if (args_info.attenuationmap_given)
+        recon->SetAttenuationMap(attenuationMap);
       break;
     case (5): // bp_arg_RotationBased
       recon->SetBackProjectionFilter(TIterativeReconstructionFilter::BP_ZENG);
+      if (args_info.sigmazero_given)
+        recon->SetSigmaZero(args_info.sigmazero_arg);
+      if (args_info.alphapsf_given)
+        recon->SetAlphaPSF(args_info.alphapsf_arg);
+      if (args_info.attenuationmap_given)
+        recon->SetAttenuationMap(attenuationMap);
       break;
   }
 }
@@ -318,21 +334,57 @@ template <class TArgsInfo, class TIterativeReconstructionFilter>
 void
 SetForwardProjectionFromGgo(const TArgsInfo & args_info, TIterativeReconstructionFilter * recon)
 {
+  typename TIterativeReconstructionFilter::VolumeType::Pointer attenuationMap;
+  using VolumeType = typename TIterativeReconstructionFilter::VolumeType;
+  if (args_info.attenuationmap_given)
+  {
+    // Read an existing image to initialize the attenuation map
+    attenuationMap = itk::ReadImage<VolumeType>(args_info.attenuationmap_arg);
+  }
+  using ClipImageType = itk::Image<double, TIterativeReconstructionFilter::VolumeType::ImageDimension>;
+  typename ClipImageType::Pointer inferiorClipImage, superiorClipImage;
+  if (args_info.inferiorclipimage_given)
+  {
+    // Read an existing image to initialize the attenuation map
+    inferiorClipImage = itk::ReadImage<ClipImageType>(args_info.inferiorclipimage_arg);
+  }
+  if (args_info.superiorclipimage_given)
+  {
+    // Read an existing image to initialize the attenuation map
+    superiorClipImage = itk::ReadImage<ClipImageType>(args_info.superiorclipimage_arg);
+  }
+
   switch (args_info.fp_arg)
   {
     case (-1): // fp__NULL, keep default
       break;
     case (0): // fp_arg_Joseph
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_JOSEPH);
+      if (args_info.superiorclipimage_given)
+        recon->SetSuperiorClipImage(superiorClipImage);
+      if (args_info.inferiorclipimage_given)
+        recon->SetInferiorClipImage(inferiorClipImage);
       break;
     case (1): // fp_arg_CudaRayCast
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_CUDARAYCAST);
       break;
     case (2): // fp_arg_JosephAttenuated
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_JOSEPHATTENUATED);
+      if (args_info.superiorclipimage_given)
+        recon->SetSuperiorClipImage(superiorClipImage);
+      if (args_info.inferiorclipimage_given)
+        recon->SetInferiorClipImage(inferiorClipImage);
+      if (args_info.attenuationmap_given)
+        recon->SetAttenuationMap(attenuationMap);
       break;
     case (3): // fp_arg_RotationBased
       recon->SetForwardProjectionFilter(TIterativeReconstructionFilter::FP_ZENG);
+      if (args_info.sigmazero_given)
+        recon->SetSigmaZero(args_info.sigmazero_arg);
+      if (args_info.alphapsf_given)
+        recon->SetAlphaPSF(args_info.alphapsf_arg);
+      if (args_info.attenuationmap_given)
+        recon->SetAttenuationMap(attenuationMap);
       break;
   }
 }

--- a/include/rtkIterativeConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeConeBeamReconstructionFilter.hxx
@@ -39,6 +39,16 @@ IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::Instan
   {
     case (FP_JOSEPH):
       fw = JosephForwardProjectionImageFilter<VolumeType, ProjectionStackType>::New();
+      if (this->GetSuperiorClipImage().IsNotNull())
+      {
+        dynamic_cast<rtk::JosephForwardProjectionImageFilter<VolumeType, ProjectionStackType> *>(fw.GetPointer())
+          ->SetSuperiorClipImage(this->GetSuperiorClipImage());
+      }
+      if (this->GetInferiorClipImage().IsNotNull())
+      {
+        dynamic_cast<rtk::JosephForwardProjectionImageFilter<VolumeType, ProjectionStackType> *>(fw.GetPointer())
+          ->SetInferiorClipImage(this->GetInferiorClipImage());
+      }
       break;
     case (FP_CUDARAYCAST):
       fw = InstantiateCudaForwardProjection<ProjectionStackType>();

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
@@ -81,6 +81,7 @@ JosephForwardAttenuatedProjectionImageFilter<TInputImage,
                                              TProjectedValueAccumulation,
                                              TComputeAttenuationCorrection>::VerifyInputInformation() const
 {
+  Superclass::VerifyInputInformation();
   using ImageBaseType = const itk::ImageBase<InputImageDimension>;
 
   ImageBaseType * inputPtr1 = nullptr;
@@ -93,7 +94,7 @@ JosephForwardAttenuatedProjectionImageFilter<TInputImage,
     // method since it returns the input as a pointer to a
     // DataObject as opposed to the subclass version which
     // static_casts the input to an TInputImage).
-    if (it.GetName() != "Primary")
+    if (it.GetName() == "_1")
     {
       inputPtr1 = dynamic_cast<ImageBaseType *>(it.GetInput());
     }
@@ -105,7 +106,7 @@ JosephForwardAttenuatedProjectionImageFilter<TInputImage,
 
   for (; !it.IsAtEnd(); ++it)
   {
-    if (it.GetName() != "Primary")
+    if (it.GetName() == "_2")
     {
       auto * inputPtrN = dynamic_cast<ImageBaseType *>(it.GetInput());
       // Physical space computation only matters if we're using two

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -306,7 +306,7 @@ protected:
   ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
   /** If a third input is given, it should be in the same physical space
-   * than the first one. */
+   * as the first one. */
   void
   VerifyInputInformation() const override;
 

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -45,6 +45,130 @@ JosephForwardProjectionImageFilter<TInputImage,
   this->DynamicMultiThreadingOff();
 }
 
+
+template <class TInputImage,
+          class TOutputImage,
+          class TInterpolationWeightMultiplication,
+          class TProjectedValueAccumulation,
+          class TSumAlongRay>
+void
+JosephForwardProjectionImageFilter<TInputImage,
+                                   TOutputImage,
+                                   TInterpolationWeightMultiplication,
+                                   TProjectedValueAccumulation,
+                                   TSumAlongRay>::GenerateInputRequestedRegion()
+{
+  Superclass::GenerateInputRequestedRegion();
+
+  if (this->GetInferiorClipImage().IsNotNull())
+  {
+    TClipImagePointer inputInferiorClipImage = const_cast<TClipImageType *>(this->GetInferiorClipImage().GetPointer());
+    if (!inputInferiorClipImage)
+      return;
+    inputInferiorClipImage->SetRequestedRegion(inputInferiorClipImage->GetRequestedRegion());
+  }
+
+  if (this->GetSuperiorClipImage().IsNotNull())
+  {
+    TClipImagePointer inputSuperiorClipImage = const_cast<TClipImageType *>(this->GetSuperiorClipImage().GetPointer());
+    if (!inputSuperiorClipImage)
+      return;
+    inputSuperiorClipImage->SetRequestedRegion(inputSuperiorClipImage->GetRequestedRegion());
+  }
+}
+
+
+template <class TInputImage,
+          class TOutputImage,
+          class TInterpolationWeightMultiplication,
+          class TProjectedValueAccumulation,
+          class TSumAlongRay>
+void
+JosephForwardProjectionImageFilter<TInputImage,
+                                   TOutputImage,
+                                   TInterpolationWeightMultiplication,
+                                   TProjectedValueAccumulation,
+                                   TSumAlongRay>::VerifyInputInformation() const
+{
+  using ImageBaseType = const itk::ImageBase<TInputImage::ImageDimension>;
+
+  ImageBaseType * inputPtr1 = nullptr;
+
+  itk::InputDataObjectConstIterator it(this);
+  for (; !it.IsAtEnd(); ++it)
+  {
+    // Check whether the output is an image of the appropriate
+    // dimension (use ProcessObject's version of the GetInput()
+    // method since it returns the input as a pointer to a
+    // DataObject as opposed to the subclass version which
+    // static_casts the input to an TInputImage).
+    if (it.GetName() == "Primary")
+    {
+      inputPtr1 = dynamic_cast<ImageBaseType *>(it.GetInput());
+    }
+    if (inputPtr1)
+    {
+      break;
+    }
+  }
+
+  for (; !it.IsAtEnd(); ++it)
+  {
+    if (it.GetName() == "InferiorClipImage" || it.GetName() == "SuperiorClipImage")
+    {
+      auto * inputPtrN = dynamic_cast<ImageBaseType *>(it.GetInput());
+      // Physical space computation only matters if we're using two
+      // images, and not an image and a constant.
+      if (inputPtrN)
+      {
+        // check that the image occupy the same physical space, and that
+        // each index is at the same physical location
+
+        // tolerance for origin and spacing depends on the size of pixel
+        // tolerance for directions a fraction of the unit cube.
+        const double coordinateTol = itk::Math::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                                    inputPtr1->GetSpacing()[0]); // use first dimension spacing
+
+        if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
+            !inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+              inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+        {
+          std::ostringstream originString, spacingString, directionString;
+          if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol))
+          {
+            originString.setf(std::ios::scientific);
+            originString.precision(7);
+            originString << "InputImage Origin: " << inputPtr1->GetOrigin() << ", InputImage" << it.GetName()
+                         << " Origin: " << inputPtrN->GetOrigin() << std::endl;
+            originString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol))
+          {
+            spacingString.setf(std::ios::scientific);
+            spacingString.precision(7);
+            spacingString << "InputImage Spacing: " << inputPtr1->GetSpacing() << ", InputImage" << it.GetName()
+                          << " Spacing: " << inputPtrN->GetSpacing() << std::endl;
+            spacingString << "\tTolerance: " << coordinateTol << std::endl;
+          }
+          if (!inputPtr1->GetDirection().GetVnlMatrix().as_ref().is_equal(
+                inputPtrN->GetDirection().GetVnlMatrix().as_ref(), Self::GetGlobalDefaultDirectionTolerance()))
+          {
+            directionString.setf(std::ios::scientific);
+            directionString.precision(7);
+            directionString << "InputImage Direction: " << inputPtr1->GetDirection() << ", InputImage" << it.GetName()
+                            << " Direction: " << inputPtrN->GetDirection() << std::endl;
+            directionString << "\tTolerance: " << Self::GetGlobalDefaultDirectionTolerance() << std::endl;
+          }
+          itkExceptionMacro(<< "Inputs do not occupy the same physical space! " << std::endl
+                            << originString.str() << spacingString.str() << directionString.str());
+        }
+      }
+    }
+  }
+}
+
+
 template <class TInputImage,
           class TOutputImage,
           class TInterpolationWeightMultiplication,
@@ -85,6 +209,17 @@ JosephForwardProjectionImageFilter<TInputImage,
   itIn = InputRegionIterator::New(this->GetInput(), outputRegionForThread, geometry, volPPToIndex);
   using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
   OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  using ClipImageIterator = itk::ImageRegionConstIterator<TClipImageType>;
+  ClipImageIterator * itInferiorImage = nullptr;
+  ClipImageIterator * itSuperiorImage = nullptr;
+  if (this->GetInferiorClipImage().IsNotNull())
+  {
+    itInferiorImage = new ClipImageIterator(this->GetInferiorClipImage(), outputRegionForThread);
+  }
+  if (this->GetSuperiorClipImage().IsNotNull())
+  {
+    itSuperiorImage = new ClipImageIterator(this->GetSuperiorClipImage(), outputRegionForThread);
+  }
 
   // Create intersection functions, one for each possible main direction
   typename BoxShape::Pointer    box = BoxShape::New();
@@ -108,8 +243,9 @@ JosephForwardProjectionImageFilter<TInputImage,
   typename BoxShape::VectorType stepMM, np, fp;
   for (unsigned int pix = 0; pix < outputRegionForThread.GetNumberOfPixels(); pix++, itIn->Next(), ++itOut)
   {
-    typename InputRegionIterator::PointType pixelPosition = itIn->GetPixelPosition();
-    typename InputRegionIterator::PointType dirVox = -itIn->GetSourceToPixel();
+    typename InputRegionIterator::PointType  pixelPosition = itIn->GetPixelPosition();
+    typename InputRegionIterator::PointType  dirVox = -itIn->GetSourceToPixel();
+    typename InputRegionIterator ::IndexType pixelIndex = itIn->GetIndex();
 
     // Select main direction
     unsigned int                  mainDir = 0;
@@ -121,16 +257,30 @@ JosephForwardProjectionImageFilter<TInputImage,
         mainDir = i;
     }
 
+    if (this->GetInferiorClipImage().IsNotNull())
+    {
+      double superiorClipImage = 1 - itInferiorImage->Get();
+      superiorClip = std::min(1. - m_InferiorClip, superiorClipImage);
+      ++(*itInferiorImage);
+    }
+    if (this->GetSuperiorClipImage().IsNotNull())
+    {
+      double inferiorClipImage = 1 - itSuperiorImage->Get();
+      inferiorClip = std::max(1. - m_SuperiorClip, inferiorClipImage);
+      ++(*itSuperiorImage);
+    }
+
     // Test if there is an intersection
     BoxShape::ScalarType nearDist = NAN, farDist = NAN;
-    if (box->IsIntersectedByRay(pixelPosition, dirVox, nearDist, farDist) &&
-        farDist >= 0. && // check if detector after the source
-        nearDist <= 1.)  // check if detector after or in the volume
-    {
-      // Clip the casting between source and pixel of the detector
-      nearDist = std::max(nearDist, inferiorClip);
-      farDist = std::min(farDist, superiorClip);
+    bool                 isIntersectByRay = box->IsIntersectedByRay(pixelPosition, dirVox, nearDist, farDist);
+    // Clip the casting between source and pixel of the detector
+    nearDist = std::max(nearDist, inferiorClip);
+    farDist = std::min(farDist, superiorClip);
 
+    if (isIntersectByRay && farDist > 0. && // check if detector after the source
+        nearDist <= 1. &&                   // check if detector after or in the volume
+        farDist > nearDist)
+    {
       // Compute and sort intersections: (n)earest and (f)arthest (p)points
       np = pixelPosition + nearDist * dirVox;
       fp = pixelPosition + farDist * dirVox;

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -243,9 +243,8 @@ JosephForwardProjectionImageFilter<TInputImage,
   typename BoxShape::VectorType stepMM, np, fp;
   for (unsigned int pix = 0; pix < outputRegionForThread.GetNumberOfPixels(); pix++, itIn->Next(), ++itOut)
   {
-    typename InputRegionIterator::PointType  pixelPosition = itIn->GetPixelPosition();
-    typename InputRegionIterator::PointType  dirVox = -itIn->GetSourceToPixel();
-    typename InputRegionIterator ::IndexType pixelIndex = itIn->GetIndex();
+    typename InputRegionIterator::PointType pixelPosition = itIn->GetPixelPosition();
+    typename InputRegionIterator::PointType dirVox = -itIn->GetSourceToPixel();
 
     // Select main direction
     unsigned int                  mainDir = 0;

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -163,14 +163,6 @@ public:
   itkGetMacro(NumberOfProjectionsPerSubset, unsigned int);
   itkSetMacro(NumberOfProjectionsPerSubset, unsigned int);
 
-  /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
-  itkGetMacro(SigmaZero, double);
-  itkSetMacro(SigmaZero, double);
-
-  /** Get / Set the alpha of the PSF. Default is 0.016241189545787734 */
-  itkGetMacro(Alpha, double);
-  itkSetMacro(Alpha, double);
-
   /** Get / Set the hyperparameter for the regularization. Default is 0.01 */
   itkGetMacro(BetaRegularization, double);
   itkSetMacro(BetaRegularization, double);
@@ -228,10 +220,6 @@ private:
 
   /** Number of iterations */
   unsigned int m_NumberOfIterations{ 3 };
-
-  /** PSF correction coefficients */
-  double m_SigmaZero{ -1. };
-  double m_Alpha{ -1. };
 
   /** Hyperparameter for the regularization */
   double m_BetaRegularization{ 0. };

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -117,66 +117,10 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
 
   m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_DivideProjectionFilter->GetOutput());
-  if (this->GetBackProjectionFilter() == this->BP_JOSEPHATTENUATED || this->GetBackProjectionFilter() == this->BP_ZENG)
-  {
-    if (!(this->GetInput(2)) && this->GetBackProjectionFilter() == this->BP_JOSEPHATTENUATED)
-    {
-      itkExceptionMacro(<< "Set Joseph attenuated backprojection filter but no attenuation map is given");
-    }
-    else
-    {
-      m_BackProjectionFilter->SetInput(2, this->GetInput(2));
-    }
-  }
-  if (m_SigmaZero != -1 || m_Alpha != -1)
-  {
-    if (this->GetBackProjectionFilter() == this->BP_ZENG)
-    {
-      if (m_SigmaZero != -1)
-        dynamic_cast<ZengBackProjectionImageFilter<TVolumeImage, TProjectionImage> *>(
-          m_BackProjectionFilter.GetPointer())
-          ->SetSigmaZero(m_SigmaZero);
-      if (m_Alpha != -1)
-        dynamic_cast<ZengBackProjectionImageFilter<TVolumeImage, TProjectionImage> *>(
-          m_BackProjectionFilter.GetPointer())
-          ->SetAlpha(m_Alpha);
-    }
-    else
-      itkExceptionMacro(<< "PSF correction only available with Zeng projector type");
-  }
-
   m_BackProjectionFilter->SetTranspose(false);
 
   m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
   m_BackProjectionNormalizationFilter->SetInput(1, m_OneConstantProjectionStackSource->GetOutput());
-  if (this->GetBackProjectionFilter() == this->BP_JOSEPHATTENUATED || this->GetBackProjectionFilter() == this->BP_ZENG)
-  {
-    if (!(this->GetInput(2)) && this->GetBackProjectionFilter() == this->BP_JOSEPHATTENUATED)
-    {
-      itkExceptionMacro(<< "Set Joseph attenuated backprojection filter but no attenuation map is given");
-    }
-    else
-    {
-      m_BackProjectionNormalizationFilter->SetInput(2, this->GetInput(2));
-    }
-  }
-  if (m_SigmaZero != -1 || m_Alpha != -1)
-  {
-    if (this->GetBackProjectionFilter() == this->BP_ZENG)
-    {
-      if (m_SigmaZero != -1)
-        dynamic_cast<ZengBackProjectionImageFilter<TVolumeImage, TProjectionImage> *>(
-          m_BackProjectionNormalizationFilter.GetPointer())
-          ->SetSigmaZero(m_SigmaZero);
-      if (m_Alpha != -1)
-        dynamic_cast<ZengBackProjectionImageFilter<TVolumeImage, TProjectionImage> *>(
-          m_BackProjectionNormalizationFilter.GetPointer())
-          ->SetAlpha(m_Alpha);
-    }
-    else
-      itkExceptionMacro(<< "PSF correction only available with Zeng projector type");
-  }
-
   m_BackProjectionNormalizationFilter->SetTranspose(false);
 
   m_MultiplyFilter->SetInput1(m_BackProjectionFilter->GetOutput());
@@ -191,34 +135,6 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
 
   m_ForwardProjectionFilter->SetInput(0, m_ZeroConstantProjectionStackSource->GetOutput());
   m_ForwardProjectionFilter->SetInput(1, this->GetInput(0));
-  if (this->GetForwardProjectionFilter() == this->FP_JOSEPHATTENUATED ||
-      this->GetForwardProjectionFilter() == this->FP_ZENG)
-  {
-    if (!(this->GetInput(2)) && this->GetForwardProjectionFilter() == this->FP_JOSEPHATTENUATED)
-    {
-      itkExceptionMacro(<< "Set Joseph attenuated forward projection filter but no attenuation map is given");
-    }
-    else
-    {
-      m_ForwardProjectionFilter->SetInput(2, this->GetInput(2));
-    }
-  }
-  if (m_SigmaZero != -1 || m_Alpha != -1)
-  {
-    if (this->GetForwardProjectionFilter() == this->FP_ZENG)
-    {
-      if (m_SigmaZero != -1)
-        dynamic_cast<ZengForwardProjectionImageFilter<TProjectionImage, TVolumeImage> *>(
-          m_ForwardProjectionFilter.GetPointer())
-          ->SetSigmaZero(m_SigmaZero);
-      if (m_Alpha != -1)
-        dynamic_cast<ZengForwardProjectionImageFilter<TProjectionImage, TVolumeImage> *>(
-          m_ForwardProjectionFilter.GetPointer())
-          ->SetAlpha(m_Alpha);
-    }
-    else
-      itkExceptionMacro(<< "PSF correction only available with Zeng projector type");
-  }
 
   m_DivideProjectionFilter->SetInput2(m_ForwardProjectionFilter->GetOutput());
   m_DivideProjectionFilter->SetConstant(1);


### PR DESCRIPTION
The superior and inferior clip images define for each pixel of the projections the value of the superior and inferior clip of the ray emitted from that pixel. Each ray is clipped from
source+inferior_clip*(pixel-source) to
source+superior_clip*(pixel-source) with inferior_clip and superior_clip equal 0 and 1 by default.