### PR TITLE
ENH: add flag in rtkosem application to store the normalization images

### DIFF
--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
 
   osem->SetNumberOfIterations(args_info.niterations_arg);
   osem->SetNumberOfProjectionsPerSubset(args_info.nprojpersubset_arg);
-
+  osem->SetStoreNormalizationImages(!args_info.nostorenormalizationimages_flag);
   REPORT_ITERATIONS(osem, rtk::OSEMConeBeamReconstructionFilter<OutputImageType>, OutputImageType)
 
   // Write

--- a/applications/rtkosem/rtkosem.ggo
+++ b/applications/rtkosem/rtkosem.ggo
@@ -9,3 +9,4 @@ option "niterations" n "Number of iterations"                                  i
 option "input"     i "Input volume"              string          no
 option "nprojpersubset" - "Number of projections processed between each update of the reconstructed volume (several for OSEM, all for MLEM)" int no default="1"
 option "betaregularization" - "Hyperparameter for the regularization"          float  no   default="0"
+option "nostorenormalizationimages"       - "Do not store the normalization images during the reconstruction"   flag   off


### PR DESCRIPTION
Add flag to rtkosem application to choose to store or not the normalization images. Storing the normalization images can increase the speed of the reconstruction but could also create memory issues if the size of the normalization images is too big.