### PR TITLE
COMP: Move call to wrap_itk_python_bindings_install for in ITK config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,12 +262,6 @@ if(ITK_WRAP_PYTHON)
                 applications/rtkvarianobigeometry/rtkvarianobigeometry.py
           DESTINATION ${RTK_INSTALL_LIB_DIR}
           COMPONENT PythonWheelRuntimeLibraries)
-  WRAP_ITK_PYTHON_BINDINGS_INSTALL(/itk "RTK"
-      applications/rtk3Doutputimage_group.py
-      applications/rtkinputprojections_group.py
-      applications/rtkiterations_group.py
-      applications/rtkprojectors_group.py
-      wrapping/__init_rtk__.py)
 endif()
 
 # --------------------------------------------------------

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -26,3 +26,10 @@ set(WRAPPER_SUBMODULE_ORDER
 
 itk_auto_load_submodules()
 itk_end_wrap_module()
+
+wrap_itk_python_bindings_install(/itk "RTK"
+    __init_rtk__.py
+    ${RTK_SOURCE_DIR}/applications/rtk3Doutputimage_group.py
+    ${RTK_SOURCE_DIR}/applications/rtkinputprojections_group.py
+    ${RTK_SOURCE_DIR}/applications/rtkiterations_group.py
+    ${RTK_SOURCE_DIR}/applications/rtkprojectors_group.py)


### PR DESCRIPTION
Configuration was failing when compiling Python wrappings along with ITK's because the macro is not visible from the root CMakeLists.txt.