### PR TITLE
STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`

### DIFF
--- a/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
+++ b/include/rtkADMMTotalVariationConeBeamReconstructionFilter.h
@@ -152,7 +152,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ADMMTotalVariationConeBeamReconstructionFilter);
+#else
   itkTypeMacro(ADMMTotalVariationConeBeamReconstructionFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   using ForwardProjectionFilterType = rtk::ForwardProjectionImageFilter<TOutputImage, TOutputImage>;
   using ForwardProjectionFilterPointer = typename ForwardProjectionFilterType::Pointer;

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -118,7 +118,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(rtkADMMTotalVariationConjugateGradientOperator);
+#else
   itkTypeMacro(rtkADMMTotalVariationConjugateGradientOperator, ConjugateGradientOperator);
+#endif
 
   using BackProjectionFilterType = rtk::BackProjectionImageFilter<TOutputImage, TOutputImage>;
   using BackProjectionFilterPointer = typename BackProjectionFilterType::Pointer;

--- a/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
+++ b/include/rtkADMMWaveletsConeBeamReconstructionFilter.h
@@ -155,7 +155,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ADMMWaveletsConeBeamReconstructionFilter);
+#else
   itkTypeMacro(ADMMWaveletsConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   //    /** The 3D image to be updated */
   //    void SetInputVolume(const TOutputImage* Volume);

--- a/include/rtkADMMWaveletsConjugateGradientOperator.h
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.h
@@ -109,7 +109,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(rtkADMMWaveletsConjugateGradientOperator);
+#else
   itkTypeMacro(rtkADMMWaveletsConjugateGradientOperator, ConjugateGradientOperator);
+#endif
 
   using BackProjectionFilterType = rtk::BackProjectionImageFilter<TOutputImage, TOutputImage>;
   using BackProjectionFilterPointer = typename BackProjectionFilterType::Pointer;

--- a/include/rtkAddMatrixAndDiagonalImageFilter.h
+++ b/include/rtkAddMatrixAndDiagonalImageFilter.h
@@ -55,7 +55,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(AddMatrixAndDiagonalImageFilter);
+#else
   itkTypeMacro(AddMatrixAndDiagonalImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Convenient parameters extracted from template types */
   static constexpr unsigned int nChannels = TDiagonal::PixelType::Dimension;

--- a/include/rtkAdditiveGaussianNoiseImageFilter.h
+++ b/include/rtkAdditiveGaussianNoiseImageFilter.h
@@ -183,7 +183,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(AdditiveGaussianNoiseImageFilter);
+#else
   itkTypeMacro(AdditiveGaussianNoiseImageFilter, ImageToImageFilter);
+#endif
 
   /** Superclass type alias. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;

--- a/include/rtkAmsterdamShroudImageFilter.h
+++ b/include/rtkAmsterdamShroudImageFilter.h
@@ -125,7 +125,11 @@ public:
   itkSetMacro(Corner2, PointType);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(AmsterdamShroudImageFilter);
+#else
   itkTypeMacro(AmsterdamShroudImageFilter, itk::ImageToImageFilter);
+#endif
 
 protected:
   AmsterdamShroudImageFilter();

--- a/include/rtkAverageOutOfROIImageFilter.h
+++ b/include/rtkAverageOutOfROIImageFilter.h
@@ -64,7 +64,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(AverageOutOfROIImageFilter);
+#else
   itkTypeMacro(AverageOutOfROIImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** The image containing the weights applied to the temporal components */
   void

--- a/include/rtkBackProjectionImageFilter.h
+++ b/include/rtkBackProjectionImageFilter.h
@@ -71,7 +71,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BackProjectionImageFilter);
+#else
   itkTypeMacro(BackProjectionImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetConstObjectMacro(Geometry, GeometryType);

--- a/include/rtkBackwardDifferenceDivergenceImageFilter.h
+++ b/include/rtkBackwardDifferenceDivergenceImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BackwardDifferenceDivergenceImageFilter);
+#else
   itkTypeMacro(BackwardDifferenceDivergenceImageFilter, ImageToImageFilter);
+#endif
 
   /** Use the image spacing information in calculations. Use this option if you
    *  want derivatives in physical space. Default is UseImageSpacingOn. */

--- a/include/rtkBioscanGeometryReader.h
+++ b/include/rtkBioscanGeometryReader.h
@@ -64,7 +64,11 @@ public:
   using GeometryPointer = GeometryType::Pointer;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BioscanGeometryReader);
+#else
   itkTypeMacro(BioscanGeometryReader, itk::LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
+++ b/include/rtkBlockDiagonalMatrixVectorMultiplyImageFilter.h
@@ -51,7 +51,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BlockDiagonalMatrixVectorMultiplyImageFilter);
+#else
   itkTypeMacro(BlockDiagonalMatrixVectorMultiplyImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Convenient parameters extracted from template types */
   static constexpr unsigned int nChannels = TVectorImage::PixelType::Dimension;

--- a/include/rtkBoellaardScatterCorrectionImageFilter.h
+++ b/include/rtkBoellaardScatterCorrectionImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BoellaardScatterCorrectionImageFilter);
+#else
   itkTypeMacro(BoellaardScatterCorrectionImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the air threshold on projection images. The threshold is used to
    ** evaluate which part of the x-rays have traversed the patient. */

--- a/include/rtkBoxShape.h
+++ b/include/rtkBoxShape.h
@@ -62,7 +62,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(BoxShape);
+#else
   itkTypeMacro(BoxShape, ConvexShape);
+#endif
 
   /** See rtk::ConvexShape::IsInside. */
   bool

--- a/include/rtkConditionalMedianImageFilter.h
+++ b/include/rtkConditionalMedianImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConditionalMedianImageFilter);
+#else
   itkTypeMacro(ConditionalMedianImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Set/Get neighborhood radius */
   itkSetMacro(Radius, MedianRadiusType);

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -122,7 +122,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientConeBeamReconstructionFilter);
+#else
   itkTypeMacro(ConjugateGradientConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Setters for the inputs */
   void

--- a/include/rtkConjugateGradientImageFilter.h
+++ b/include/rtkConjugateGradientImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientImageFilter);
+#else
   itkTypeMacro(ConjugateGradientImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get and Set macro*/
   itkGetMacro(NumberOfIterations, int);

--- a/include/rtkConjugateGradientOperator.h
+++ b/include/rtkConjugateGradientOperator.h
@@ -43,7 +43,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientOperator);
+#else
   itkTypeMacro(ConjugateGradientOperator, itk::ImageToImageFilter);
+#endif
 
   /** The image to be updated.*/
   virtual void

--- a/include/rtkConstantImageSource.h
+++ b/include/rtkConstantImageSource.h
@@ -69,7 +69,11 @@ public:
   using OutputImageRegionType = typename TOutputImage::RegionType;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConstantImageSource);
+#else
   itkTypeMacro(ConstantImageSource, itk::ImageSource);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkConvexShape.h
+++ b/include/rtkConvexShape.h
@@ -65,7 +65,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConvexShape);
+#else
   itkTypeMacro(ConvexShape, itk::DataObject);
+#endif
 
   /** Returns true if a point is inside the object. */
   virtual bool

--- a/include/rtkCudaAverageOutOfROIImageFilter.h
+++ b/include/rtkCudaAverageOutOfROIImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaAverageOutOfROIImageFilter);
+#  else
   itkTypeMacro(CudaAverageOutOfROIImageFilter, AverageOutOfROIImageFilter);
+#  endif
 
 protected:
   CudaAverageOutOfROIImageFilter();

--- a/include/rtkCudaBackProjectionImageFilter.h
+++ b/include/rtkCudaBackProjectionImageFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaBackProjectionImageFilter);
+#  else
   itkTypeMacro(CudaBackProjectionImageFilter, Superclass);
+#  endif
 
 protected:
   CudaBackProjectionImageFilter();

--- a/include/rtkCudaConjugateGradientImageFilter.h
+++ b/include/rtkCudaConjugateGradientImageFilter.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaConjugateGradientImageFilter);
+#  else
   itkTypeMacro(CudaConjugateGradientImageFilter, ConjugateGradientImageFilter);
+#  endif
 
 protected:
   CudaConjugateGradientImageFilter();

--- a/include/rtkCudaConstantVolumeSeriesSource.h
+++ b/include/rtkCudaConstantVolumeSeriesSource.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaConstantVolumeSeriesSource);
+#  else
   itkTypeMacro(CudaConstantVolumeSeriesSource, ImageToImageFilter);
+#  endif
 
 protected:
   CudaConstantVolumeSeriesSource();

--- a/include/rtkCudaConstantVolumeSource.h
+++ b/include/rtkCudaConstantVolumeSource.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaConstantVolumeSource);
+#  else
   itkTypeMacro(CudaConstantVolumeSource, ImageToImageFilter);
+#  endif
 
 protected:
   CudaConstantVolumeSource();

--- a/include/rtkCudaCropImageFilter.h
+++ b/include/rtkCudaCropImageFilter.h
@@ -65,7 +65,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaCropImageFilter);
+#  else
   itkTypeMacro(CudaCropImageFilter, ImageToImageFilter);
+#  endif
 
 protected:
   CudaCropImageFilter();

--- a/include/rtkCudaCyclicDeformationImageFilter.h
+++ b/include/rtkCudaCyclicDeformationImageFilter.h
@@ -62,7 +62,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaCyclicDeformationImageFilter);
+#  else
   itkTypeMacro(CudaCyclicDeformationImageFilter, CyclicDeformationImageFilter);
+#  endif
 
 protected:
   CudaCyclicDeformationImageFilter();

--- a/include/rtkCudaDisplacedDetectorImageFilter.h
+++ b/include/rtkCudaDisplacedDetectorImageFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaDisplacedDetectorImageFilter);
+#  else
   itkTypeMacro(CudaDisplacedDetectorImageFilter, itk::CudaInPlaceImageFilter);
+#  endif
 
 protected:
   /** Standard constructor **/

--- a/include/rtkCudaFDKBackProjectionImageFilter.h
+++ b/include/rtkCudaFDKBackProjectionImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaFDKBackProjectionImageFilter);
+#  else
   itkTypeMacro(CudaFDKBackProjectionImageFilter, Superclass);
+#  endif
 
 protected:
   CudaFDKBackProjectionImageFilter();

--- a/include/rtkCudaFDKConeBeamReconstructionFilter.h
+++ b/include/rtkCudaFDKConeBeamReconstructionFilter.h
@@ -70,7 +70,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaFDKConeBeamReconstructionFilter);
+#  else
   itkTypeMacro(CudaFDKConeBeamReconstructionFilter, FDKConeBeamReconstructionFilter);
+#  endif
 
 protected:
   CudaFDKConeBeamReconstructionFilter();

--- a/include/rtkCudaFDKWeightProjectionFilter.h
+++ b/include/rtkCudaFDKWeightProjectionFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaFDKWeightProjectionFilter);
+#  else
   itkTypeMacro(CudaFDKWeightProjectionFilter, itk::CudaInPlaceImageFilter);
+#  endif
 
 protected:
   /** Standard constructor **/

--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.h
@@ -66,7 +66,11 @@ public:
   using CudaFFTOutputImagePointer = CudaFFTOutputImageType::Pointer;
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaFFTProjectionsConvolutionImageFilter);
+#  else
   itkTypeMacro(CudaFFTProjectionsConvolutionImageFilter, TParentImageFilter);
+#  endif
 
 protected:
   CudaFFTProjectionsConvolutionImageFilter();

--- a/include/rtkCudaFFTRampImageFilter.h
+++ b/include/rtkCudaFFTRampImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaFFTRampImageFilter);
+#  else
   itkTypeMacro(CudaFFTRampImageFilter, FFTRampImageFilter);
+#  endif
 
 protected:
   CudaFFTRampImageFilter() {}

--- a/include/rtkCudaForwardProjectionImageFilter.h
+++ b/include/rtkCudaForwardProjectionImageFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaForwardProjectionImageFilter);
+#  else
   itkTypeMacro(CudaForwardProjectionImageFilter, ImageToImageFilter);
+#  endif
 
   /** Set step size along ray (in mm). Default is 1 mm. */
   itkGetConstMacro(StepSize, double);

--- a/include/rtkCudaForwardWarpImageFilter.h
+++ b/include/rtkCudaForwardWarpImageFilter.h
@@ -70,7 +70,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaForwardWarpImageFilter);
+#  else
   itkTypeMacro(CudaForwardWarpImageFilter, Superclass);
+#  endif
 
 protected:
   CudaForwardWarpImageFilter();

--- a/include/rtkCudaInterpolateImageFilter.h
+++ b/include/rtkCudaInterpolateImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaInterpolateImageFilter);
+#  else
   itkTypeMacro(CudaInterpolateImageFilter, InterpolatorWithKnownWeightsImageFilter);
+#  endif
 
 protected:
   CudaInterpolateImageFilter();

--- a/include/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkCudaIterativeFDKConeBeamReconstructionFilter.h
@@ -74,7 +74,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaIterativeFDKConeBeamReconstructionFilter);
+#  else
   itkTypeMacro(CudaIterativeFDKConeBeamReconstructionFilter, IterativeFDKConeBeamReconstructionFilter);
+#  endif
 
 protected:
   CudaIterativeFDKConeBeamReconstructionFilter();

--- a/include/rtkCudaLagCorrectionImageFilter.h
+++ b/include/rtkCudaLagCorrectionImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaLagCorrectionImageFilter);
+#  else
   itkTypeMacro(CudaLagCorrectionImageFilter, itk::CudaInPlaceImageFilter);
+#  endif
 
 protected:
   /** Standard constructor **/

--- a/include/rtkCudaLaplacianImageFilter.h
+++ b/include/rtkCudaLaplacianImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaLaplacianImageFilter);
+#  else
   itkTypeMacro(CudaLaplacianImageFilter, LaplacianImageFilter);
+#  endif
 
 protected:
   CudaLaplacianImageFilter();

--- a/include/rtkCudaLastDimensionTVDenoisingImageFilter.h
+++ b/include/rtkCudaLastDimensionTVDenoisingImageFilter.h
@@ -63,7 +63,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaLastDimensionTVDenoisingImageFilter);
+#  else
   itkTypeMacro(CudaLastDimensionTVDenoisingImageFilter, TotalVariationDenoisingBPDQImageFilter);
+#  endif
 
 protected:
   CudaLastDimensionTVDenoisingImageFilter();

--- a/include/rtkCudaParkerShortScanImageFilter.h
+++ b/include/rtkCudaParkerShortScanImageFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaParkerShortScanImageFilter);
+#  else
   itkTypeMacro(CudaParkerShortScanImageFilter, itk::CudaInPlaceImageFilter);
+#  endif
 
 protected:
   /** Standard constructor **/

--- a/include/rtkCudaPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkCudaPolynomialGainCorrectionImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaPolynomialGainCorrectionImageFilter);
+#  else
   itkTypeMacro(CudaPolynomialGainCorrectionImageFilter, itk::CudaImageToImageFilter);
+#  endif
 
 protected:
   /** Standard constructor **/

--- a/include/rtkCudaRayCastBackProjectionImageFilter.h
+++ b/include/rtkCudaRayCastBackProjectionImageFilter.h
@@ -72,7 +72,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaRayCastBackProjectionImageFilter);
+#  else
   itkTypeMacro(CudaRayCastBackProjectionImageFilter, Superclass);
+#  endif
 
   /** Set step size along ray (in mm). Default is 1 mm. */
   itkGetConstMacro(StepSize, double);

--- a/include/rtkCudaScatterGlareCorrectionImageFilter.h
+++ b/include/rtkCudaScatterGlareCorrectionImageFilter.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaScatterGlareCorrectionImageFilter);
+#  else
   itkTypeMacro(CudaScatterGlareCorrectionImageFilter, FFTRampImageFilter);
+#  endif
 
 protected:
   CudaScatterGlareCorrectionImageFilter() {}

--- a/include/rtkCudaSplatImageFilter.h
+++ b/include/rtkCudaSplatImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaSplatImageFilter);
+#  else
   itkTypeMacro(CudaSplatImageFilter, SplatWithKnownWeightsImageFilter);
+#  endif
 
 protected:
   CudaSplatImageFilter();

--- a/include/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkCudaTotalVariationDenoisingBPDQImageFilter.h
@@ -62,7 +62,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaTotalVariationDenoisingBPDQImageFilter);
+#  else
   itkTypeMacro(CudaTotalVariationDenoisingBPDQImageFilter, TotalVariationDenoisingBPDQImageFilter);
+#  endif
 
 protected:
   CudaTotalVariationDenoisingBPDQImageFilter();

--- a/include/rtkCudaWarpBackProjectionImageFilter.h
+++ b/include/rtkCudaWarpBackProjectionImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaWarpBackProjectionImageFilter);
+#  else
   itkTypeMacro(CudaWarpBackProjectionImageFilter, Superclass);
+#  endif
 
   /** Input projection stack */
   void

--- a/include/rtkCudaWarpForwardProjectionImageFilter.h
+++ b/include/rtkCudaWarpForwardProjectionImageFilter.h
@@ -66,7 +66,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaWarpForwardProjectionImageFilter);
+#  else
   itkTypeMacro(CudaWarpForwardProjectionImageFilter, ForwardProjectionImageFilter);
+#  endif
 
   /** Input projection stack */
   void

--- a/include/rtkCudaWarpImageFilter.h
+++ b/include/rtkCudaWarpImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaWarpImageFilter);
+#  else
   itkTypeMacro(CudaWarpImageFilter, Superclass);
+#  endif
 
 protected:
   CudaWarpImageFilter();

--- a/include/rtkCudaWeidingerForwardModelImageFilter.h
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.h
@@ -63,7 +63,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#  ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CudaWeidingerForwardModelImageFilter);
+#  else
   itkTypeMacro(CudaWeidingerForwardModelImageFilter, ImageToImageFilter);
+#  endif
 
 protected:
   CudaWeidingerForwardModelImageFilter();

--- a/include/rtkCyclicDeformationImageFilter.h
+++ b/include/rtkCyclicDeformationImageFilter.h
@@ -65,7 +65,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(CyclicDeformationImageFilter);
+#else
   itkTypeMacro(CyclicDeformationImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the signal file name relating each frame to a phase position.
       The signal file is a text file containing one line per frame. */

--- a/include/rtkDCMImagXImageIO.h
+++ b/include/rtkDCMImagXImageIO.h
@@ -47,7 +47,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DCMImagXImageIO);
+#else
   itkTypeMacro(DCMImagXImageIO, itk::GDCMImageIO);
+#endif
 
   void
   ReadImageInformation() override;

--- a/include/rtkDCMImagXImageIOFactory.h
+++ b/include/rtkDCMImagXImageIOFactory.h
@@ -62,7 +62,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DCMImagXImageIOFactory);
+#else
   itkTypeMacro(DCMImagXImageIOFactory, ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkDPExtractShroudSignalImageFilter.h
+++ b/include/rtkDPExtractShroudSignalImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DPExtractShroudSignalImageFilter);
+#else
   itkTypeMacro(DPExtractShroudSignalImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Set/Get exploration amplitude. */
   itkGetMacro(Amplitude, double);

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.h
@@ -79,7 +79,11 @@ public:
   using PassVector = typename itk::Vector<typename Self::Pass, TImage::ImageDimension>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DaubechiesWaveletsConvolutionImageFilter);
+#else
   itkTypeMacro(DaubechiesWaveletsConvolutionImageFilter, itk::ImageSource);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
+++ b/include/rtkDaubechiesWaveletsDenoiseSequenceImageFilter.h
@@ -86,7 +86,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DaubechiesWaveletsDenoiseSequenceImageFilter);
+#else
   itkTypeMacro(DaubechiesWaveletsDenoiseSequenceImageFilter, ImageToImageFilter);
+#endif
 
   /** Set the number of levels of the deconstruction and reconstruction */
   itkGetMacro(NumberOfLevels, unsigned int);

--- a/include/rtkDePierroRegularizationImageFilter.h
+++ b/include/rtkDePierroRegularizationImageFilter.h
@@ -112,7 +112,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DePierroRegularizationImageFilter);
+#else
   itkTypeMacro(DePierroRegularizationImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the hyper parameter for the regularization */
   itkGetMacro(Beta, double);

--- a/include/rtkDeconstructImageFilter.h
+++ b/include/rtkDeconstructImageFilter.h
@@ -140,7 +140,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DeconstructImageFilter);
+#else
   itkTypeMacro(DeconstructImageFilter, ImageToImageFilter);
+#endif
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;

--- a/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
+++ b/include/rtkDeconstructSoftThresholdReconstructImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DeconstructSoftThresholdReconstructImageFilter);
+#else
   itkTypeMacro(DeconstructSoftThresholdReconstructImageFilter, ImageToImageFilter);
+#endif
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;

--- a/include/rtkDenoisingBPDQImageFilter.h
+++ b/include/rtkDenoisingBPDQImageFilter.h
@@ -53,7 +53,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DenoisingBPDQImageFilter);
+#else
   itkTypeMacro(DenoisingBPDQImageFilter, ImageToImageFilter);
+#endif
 
   /** Sub filter type definitions */
   typedef ForwardDifferenceGradientImageFilter<TOutputImage,

--- a/include/rtkDigisensGeometryReader.h
+++ b/include/rtkDigisensGeometryReader.h
@@ -51,7 +51,11 @@ public:
   using GeometryType = ThreeDCircularProjectionGeometry;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DigisensGeometryReader);
+#else
   itkTypeMacro(DigisensGeometryReader, LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkDigisensGeometryXMLFileReader.h
+++ b/include/rtkDigisensGeometryXMLFileReader.h
@@ -51,7 +51,11 @@ public:
   using CurrentSectionType = enum { NONE, ROTATION, XRAY, CAMERA, RADIOS, GRID, PROCESSING };
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DigisensGeometryXMLFileReader);
+#else
   itkTypeMacro(DigisensGeometryXMLFileReader, itk::XMLReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.h
@@ -63,7 +63,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DisplacedDetectorForOffsetFieldOfViewImageFilter);
+#else
   itkTypeMacro(DisplacedDetectorForOffsetFieldOfViewImageFilter, ImageToImageFilter);
+#endif
 
 protected:
   DisplacedDetectorForOffsetFieldOfViewImageFilter();

--- a/include/rtkDisplacedDetectorImageFilter.h
+++ b/include/rtkDisplacedDetectorImageFilter.h
@@ -82,7 +82,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DisplacedDetectorImageFilter);
+#else
   itkTypeMacro(DisplacedDetectorImageFilter, ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetConstObjectMacro(Geometry, GeometryType);

--- a/include/rtkDivergenceOfGradientConjugateGradientOperator.h
+++ b/include/rtkDivergenceOfGradientConjugateGradientOperator.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DivergenceOfGradientConjugateGradientOperator);
+#else
   itkTypeMacro(DivergenceOfGradientConjugateGradientOperator, ImageToImageFilter);
+#endif
 
   /** Image type alias support. */
   using InputPixelType = typename InputImageType::PixelType;

--- a/include/rtkDownsampleImageFilter.h
+++ b/include/rtkDownsampleImageFilter.h
@@ -50,7 +50,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DownsampleImageFilter);
+#else
   itkTypeMacro(DownsampleImageFilter, ImageToImageFilter);
+#endif
 
   /** Typedef to images */
   using OutputImageType = TOutputImage;

--- a/include/rtkDrawBoxImageFilter.h
+++ b/include/rtkDrawBoxImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawBoxImageFilter);
+#else
   itkTypeMacro(DrawBoxImageFilter, DrawConvexImageFilter);
+#endif
 
   /** Get / Set the constant density of the volume */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkDrawConeImageFilter.h
+++ b/include/rtkDrawConeImageFilter.h
@@ -53,7 +53,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawConeImageFilter);
+#else
   itkTypeMacro(DrawConeImageFilter, DrawConeImageFilter);
+#endif
 
 protected:
   DrawConeImageFilter() = default;

--- a/include/rtkDrawConvexImageFilter.h
+++ b/include/rtkDrawConvexImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawConvexImageFilter);
+#else
   itkTypeMacro(DrawConvexImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to the ConvexShape. */
   itkGetModifiableObjectMacro(ConvexShape, ConvexShape);

--- a/include/rtkDrawCylinderImageFilter.h
+++ b/include/rtkDrawCylinderImageFilter.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawCylinderImageFilter);
+#else
   itkTypeMacro(DrawCylinderImageFilter, DrawCylinderImageFilter);
+#endif
 
 protected:
   DrawCylinderImageFilter() = default;

--- a/include/rtkDrawEllipsoidImageFilter.h
+++ b/include/rtkDrawEllipsoidImageFilter.h
@@ -55,7 +55,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawEllipsoidImageFilter);
+#else
   itkTypeMacro(DrawEllipsoidImageFilter, DrawConvexImageFilter);
+#endif
 
   /** Get / Set the constant density of the volume */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkDrawGeometricPhantomImageFilter.h
+++ b/include/rtkDrawGeometricPhantomImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawGeometricPhantomImageFilter);
+#else
   itkTypeMacro(DrawGeometricPhantomImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to the geometry. */
   itkGetConstObjectMacro(GeometricPhantom, GeometricPhantom);

--- a/include/rtkDrawQuadricImageFilter.h
+++ b/include/rtkDrawQuadricImageFilter.h
@@ -54,7 +54,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawQuadricImageFilter);
+#else
   itkTypeMacro(DrawQuadricImageFilter, DrawConvexImageFilter);
+#endif
 
   /** Get / Set the constant density of the QuadricShape */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkDrawSheppLoganFilter.h
+++ b/include/rtkDrawSheppLoganFilter.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DrawSheppLoganFilter);
+#else
   itkTypeMacro(DrawSheppLoganFilter, DrawGeometricPhantomImageFilter);
+#endif
 
 protected:
   DrawSheppLoganFilter();

--- a/include/rtkDualEnergyNegativeLogLikelihood.h
+++ b/include/rtkDualEnergyNegativeLogLikelihood.h
@@ -50,7 +50,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
   itkNewMacro(Self);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(DualEnergyNegativeLogLikelihood);
+#else
   itkTypeMacro(DualEnergyNegativeLogLikelihood, rtk::ProjectionsDecompositionNegativeLogLikelihood);
+#endif
 
   using ParametersType = Superclass::ParametersType;
   using DerivativeType = Superclass::DerivativeType;

--- a/include/rtkEdfImageIO.h
+++ b/include/rtkEdfImageIO.h
@@ -55,7 +55,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(EdfImageIO);
+#else
   itkTypeMacro(EdfImageIO, ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkEdfImageIOFactory.h
+++ b/include/rtkEdfImageIOFactory.h
@@ -63,7 +63,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(EdfImageIOFactory);
+#else
   itkTypeMacro(EdfImageIOFactory, ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkEdfRawToAttenuationImageFilter.h
+++ b/include/rtkEdfRawToAttenuationImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(EdfRawToAttenuationImageFilter);
+#else
   itkTypeMacro(EdfRawToAttenuationImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Set the vector of strings that contains the file names. Files
    * are processed in sequential order. */

--- a/include/rtkElektaSynergyGeometryReader.h
+++ b/include/rtkElektaSynergyGeometryReader.h
@@ -50,7 +50,11 @@ public:
   using GeometryType = ThreeDCircularProjectionGeometry;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ElektaSynergyGeometryReader);
+#else
   itkTypeMacro(ElektaSynergyGeometryReader, LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkElektaSynergyLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyLookupTableImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ElektaSynergyLookupTableImageFilter);
+#else
   itkTypeMacro(ElektaSynergyLookupTableImageFilter, LookupTableImageFilter);
+#endif
 
 protected:
   ElektaSynergyLookupTableImageFilter();

--- a/include/rtkElektaSynergyRawLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyRawLookupTableImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ElektaSynergyRawLookupTableImageFilter);
+#else
   itkTypeMacro(ElektaSynergyRawLookupTableImageFilter, LookupTableImageFilter);
+#endif
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking

--- a/include/rtkExtractPhaseImageFilter.h
+++ b/include/rtkExtractPhaseImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ExtractPhaseImageFilter);
+#else
   itkTypeMacro(ExtractPhaseImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** The input signal may be smoothed before taking the phase of the Hilbert
    * transform. This parameter sets the number of samples for this smoothing. */

--- a/include/rtkFDKBackProjectionImageFilter.h
+++ b/include/rtkFDKBackProjectionImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FDKBackProjectionImageFilter);
+#else
   itkTypeMacro(FDKBackProjectionImageFilter, ImageToImageFilter);
+#endif
 
 protected:
   FDKBackProjectionImageFilter() = default;

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -86,7 +86,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FDKConeBeamReconstructionFilter);
+#else
   itkTypeMacro(FDKConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkFDKWarpBackProjectionImageFilter.h
+++ b/include/rtkFDKWarpBackProjectionImageFilter.h
@@ -70,7 +70,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FDKWarpBackProjectionImageFilter);
+#else
   itkTypeMacro(FDKWarpBackProjectionImageFilter, FDKBackProjectionImageFilter);
+#endif
 
   /** Set the deformation. */
   itkGetMacro(Deformation, DeformationPointer);

--- a/include/rtkFDKWeightProjectionFilter.h
+++ b/include/rtkFDKWeightProjectionFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FDKWeightProjectionFilter);
+#else
   itkTypeMacro(FDKWeightProjectionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get/ Set geometry structure */
   itkGetMacro(Geometry, ThreeDCircularProjectionGeometry::Pointer);

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -71,7 +71,11 @@ public:
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FFTProjectionsConvolutionImageFilter);
+#else
   itkTypeMacro(FFTProjectionsConvolutionImageFilter, ImageToImageFilter);
+#endif
 
   /**
    * Set/Get the greatest prime factor allowed on the size of the padded image.

--- a/include/rtkFFTRampImageFilter.h
+++ b/include/rtkFFTRampImageFilter.h
@@ -90,7 +90,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FFTRampImageFilter);
+#else
   itkTypeMacro(FFTRampImageFilter, FFTProjectionsConvolutionImageFilter);
+#endif
 
   /** Set/Get the Hann window frequency. 0 (default) disables it */
   itkGetConstMacro(HannCutFrequency, double);

--- a/include/rtkFieldOfViewImageFilter.h
+++ b/include/rtkFieldOfViewImageFilter.h
@@ -68,7 +68,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FieldOfViewImageFilter);
+#else
   itkTypeMacro(FieldOfViewImageFilter, InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetConstObjectMacro(Geometry, GeometryType);

--- a/include/rtkForbildPhantomFileReader.h
+++ b/include/rtkForbildPhantomFileReader.h
@@ -63,7 +63,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ForbildPhantomFileReader);
+#else
   itkTypeMacro(ForbildPhantomFileReader, itk::LightProcessObject);
+#endif
 
   /** Get / Set the object pointer to geometric phantom. */
   itkGetModifiableObjectMacro(GeometricPhantom, GeometricPhantom);

--- a/include/rtkForwardDifferenceGradientImageFilter.h
+++ b/include/rtkForwardDifferenceGradientImageFilter.h
@@ -80,7 +80,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ForwardDifferenceGradientImageFilter);
+#else
   itkTypeMacro(ForwardDifferenceGradientImageFilter, ImageToImageFilter);
+#endif
 
   /** Image type alias support. */
   using OperatorValueType = TOperatorValueType;

--- a/include/rtkForwardProjectionImageFilter.h
+++ b/include/rtkForwardProjectionImageFilter.h
@@ -49,7 +49,11 @@ public:
   using GeometryPointer = typename GeometryType::ConstPointer;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ForwardProjectionImageFilter);
+#else
   itkTypeMacro(ForwardProjectionImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetConstObjectMacro(Geometry, GeometryType);

--- a/include/rtkForwardWarpImageFilter.h
+++ b/include/rtkForwardWarpImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ForwardWarpImageFilter);
+#else
   itkTypeMacro(ForwardWarpImageFilter, Superclass);
+#endif
 
 protected:
   ForwardWarpImageFilter();

--- a/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -137,7 +137,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FourDConjugateGradientConeBeamReconstructionFilter);
+#else
   itkTypeMacro(FourDConjugateGradientConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetConstObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.h
@@ -261,7 +261,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FourDROOSTERConeBeamReconstructionFilter);
+#else
   itkTypeMacro(FourDROOSTERConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** The 4D image to be updated.*/
   void

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -145,7 +145,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FourDReconstructionConjugateGradientOperator);
+#else
   itkTypeMacro(FourDReconstructionConjugateGradientOperator, ConjugateGradientOperator);
+#endif
 
   /** Set/Get the 4D image to be updated.*/
   void

--- a/include/rtkFourDSARTConeBeamReconstructionFilter.h
+++ b/include/rtkFourDSARTConeBeamReconstructionFilter.h
@@ -162,7 +162,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FourDSARTConeBeamReconstructionFilter);
+#else
   itkTypeMacro(FourDSARTConeBeamReconstructionFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   /** The 4D image to be updated.*/
   void

--- a/include/rtkFourDToProjectionStackImageFilter.h
+++ b/include/rtkFourDToProjectionStackImageFilter.h
@@ -115,7 +115,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FourDToProjectionStackImageFilter);
+#else
   itkTypeMacro(FourDToProjectionStackImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** The 4D image to be updated.*/
   void

--- a/include/rtkGeometricPhantom.h
+++ b/include/rtkGeometricPhantom.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(GeometricPhantom);
+#else
   itkTypeMacro(GeometricPhantom, itk::DataObject);
+#endif
 
   /** Rescale object along each direction by a 3D vector. */
   virtual void

--- a/include/rtkGeometricPhantomFileReader.h
+++ b/include/rtkGeometricPhantomFileReader.h
@@ -54,7 +54,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(GeometricPhantomFileReader);
+#else
   itkTypeMacro(GeometricPhantomFileReader, itk::LightProcessObject);
+#endif
 
   /** Get / Set the object pointer to geometric phantom. */
   itkGetModifiableObjectMacro(GeometricPhantom, GeometricPhantom);

--- a/include/rtkGetNewtonUpdateImageFilter.h
+++ b/include/rtkGetNewtonUpdateImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(GetNewtonUpdateImageFilter);
+#else
   itkTypeMacro(GetNewtonUpdateImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Convenient parameters extracted from template types */
   static constexpr unsigned int nChannels = TGradient::PixelType::Dimension;

--- a/include/rtkGlobalResourceProbe.h
+++ b/include/rtkGlobalResourceProbe.h
@@ -45,7 +45,11 @@ public:
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(GlobalResourceProbe);
+#else
   itkTypeMacro(GlobalResourceProbe, itk::Object);
+#endif
 
   /** This is a singleton pattern New.  There will only be ONE
    * reference to a GlobalResourceProbe object per process.  Clients that

--- a/include/rtkHilbertImageFilter.h
+++ b/include/rtkHilbertImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HilbertImageFilter);
+#else
   itkTypeMacro(HilbertImageFilter, itk::ImageToImageFilter);
+#endif
 
 protected:
   HilbertImageFilter() = default;

--- a/include/rtkHisImageIO.h
+++ b/include/rtkHisImageIO.h
@@ -55,7 +55,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HisImageIO);
+#else
   itkTypeMacro(HisImageIO, itk::ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkHisImageIOFactory.h
+++ b/include/rtkHisImageIOFactory.h
@@ -66,7 +66,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HisImageIOFactory);
+#else
   itkTypeMacro(HisImageIOFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkHncImageIO.h
+++ b/include/rtkHncImageIO.h
@@ -125,7 +125,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HncImageIO);
+#else
   itkTypeMacro(HncImageIO, itk::ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkHncImageIOFactory.h
+++ b/include/rtkHncImageIOFactory.h
@@ -64,7 +64,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HncImageIOFactory);
+#else
   itkTypeMacro(HncImageIOFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkHndImageIO.h
+++ b/include/rtkHndImageIO.h
@@ -124,7 +124,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HndImageIO);
+#else
   itkTypeMacro(HndImageIO, itk::ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkHndImageIOFactory.h
+++ b/include/rtkHndImageIOFactory.h
@@ -68,7 +68,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(HndImageIOFactory);
+#else
   itkTypeMacro(HndImageIOFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkImagXGeometryReader.h
+++ b/include/rtkImagXGeometryReader.h
@@ -52,7 +52,11 @@ public:
   using GeometryType = ThreeDCircularProjectionGeometry;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImagXGeometryReader);
+#else
   itkTypeMacro(ImagXGeometryReader, itk::LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkImagXImageIO.h
+++ b/include/rtkImagXImageIO.h
@@ -51,7 +51,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImagXImageIO);
+#else
   itkTypeMacro(ImagXImageIO, ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkImagXImageIOFactory.h
+++ b/include/rtkImagXImageIOFactory.h
@@ -62,7 +62,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImagXImageIOFactory);
+#else
   itkTypeMacro(ImagXImageIOFactory, ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkImagXXMLFileReader.h
+++ b/include/rtkImagXXMLFileReader.h
@@ -51,7 +51,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImagXXMLFileReader);
+#else
   itkTypeMacro(ImagXXMLFileReader, itk::XMLReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkImageToVectorImageFilter.h
+++ b/include/rtkImageToVectorImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImageToVectorImageFilter);
+#else
   itkTypeMacro(ImageToVectorImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** When the input and output dimensions are equal, the filter
    * cannot guess the number of channels. Set/Get methods to

--- a/include/rtkImportImageFilter.h
+++ b/include/rtkImportImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ImportImageFilter);
+#else
   itkTypeMacro(ImportImageFilter, ImageSource);
+#endif
 
   /** Index type alias support. An index is used to access pixel values. */
   using IndexType = itk::Index<TImage::ImageDimension>;

--- a/include/rtkInterpolatorWithKnownWeightsImageFilter.h
+++ b/include/rtkInterpolatorWithKnownWeightsImageFilter.h
@@ -76,7 +76,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(InterpolatorWithKnownWeightsImageFilter);
+#else
   itkTypeMacro(InterpolatorWithKnownWeightsImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** The 3D image to be updated.*/
   void

--- a/include/rtkIntersectionOfConvexShapes.h
+++ b/include/rtkIntersectionOfConvexShapes.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(IntersectionOfConvexShapes);
+#else
   itkTypeMacro(IntersectionOfConvexShapes, ConvexShape);
+#endif
 
   /** See rtk::ConvexShape::IsInside. */
   bool

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -96,7 +96,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(IterativeConeBeamReconstructionFilter);
+#else
   itkTypeMacro(IterativeConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Accessors to forward and backprojection types. */
   virtual void

--- a/include/rtkIterativeFDKConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeFDKConeBeamReconstructionFilter.h
@@ -138,7 +138,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(IterativeFDKConeBeamReconstructionFilter);
+#else
   itkTypeMacro(IterativeFDKConeBeamReconstructionFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.h
@@ -238,7 +238,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(JosephBackAttenuatedProjectionImageFilter);
+#else
   itkTypeMacro(JosephBackAttenuatedProjectionImageFilter, JosephBackProjectionImageFilter);
+#endif
 
 protected:
   JosephBackAttenuatedProjectionImageFilter();

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -183,7 +183,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(JosephBackProjectionImageFilter);
+#else
   itkTypeMacro(JosephBackProjectionImageFilter, BackProjectionImageFilter);
+#endif
 
   /** Get/Set the functor that is used to multiply each interpolation value with a volume value */
   TInterpolationWeightMultiplication &

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -294,7 +294,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(JosephForwardAttenuatedProjectionImageFilter);
+#else
   itkTypeMacro(JosephForwardAttenuatedProjectionImageFilter, JosephForwardProjectionImageFilter);
+#endif
 
 protected:
   JosephForwardAttenuatedProjectionImageFilter();

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -190,7 +190,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(JosephForwardProjectionImageFilter);
+#else
   itkTypeMacro(JosephForwardProjectionImageFilter, ForwardProjectionImageFilter);
+#endif
 
   /** Get/Set the functor that is used to multiply each interpolation value with a volume value */
   TInterpolationWeightMultiplication &

--- a/include/rtkLagCorrectionImageFilter.h
+++ b/include/rtkLagCorrectionImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(LagCorrectionImageFilter);
+#else
   itkTypeMacro(LagCorrectionImageFilter, ImageToImageFilter);
+#endif
 
   using ImageRegionType = typename TImage::RegionType;
   using ImageSizeType = typename TImage::SizeType;

--- a/include/rtkLaplacianImageFilter.h
+++ b/include/rtkLaplacianImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(LaplacianImageFilter);
+#else
   itkTypeMacro(LaplacianImageFilter, itk::ImageToImageFilter);
+#endif
 
   void
   SetWeights(const TOutputImage * weights);

--- a/include/rtkLookupTableImageFilter.h
+++ b/include/rtkLookupTableImageFilter.h
@@ -163,7 +163,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(LookupTableImageFilter);
+#else
   itkTypeMacro(LookupTableImageFilter, itk::UnaryFunctorImageFilter);
+#endif
 
   /** Set lookup table. */
   virtual void

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MagnitudeThresholdImageFilter);
+#else
   itkTypeMacro(MagnitudeThresholdImageFilter, ImageToImageFilter);
+#endif
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/include/rtkMaskCollimationImageFilter.h
+++ b/include/rtkMaskCollimationImageFilter.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MaskCollimationImageFilter);
+#else
   itkTypeMacro(MaskCollimationImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, GeometryType);

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -158,7 +158,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MechlemOneStepSpectralReconstructionFilter);
+#else
   itkTypeMacro(MechlemOneStepSpectralReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** Internal type alias and parameters */
   static constexpr unsigned int nBins = TPhotonCounts::PixelType::Dimension;

--- a/include/rtkMultiplyByVectorImageFilter.h
+++ b/include/rtkMultiplyByVectorImageFilter.h
@@ -51,7 +51,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MultiplyByVectorImageFilter);
+#else
   itkTypeMacro(MultiplyByVectorImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** The image containing the weights applied to the temporal components */
   void

--- a/include/rtkNesterovUpdateImageFilter.h
+++ b/include/rtkNesterovUpdateImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(NesterovUpdateImageFilter);
+#else
   itkTypeMacro(NesterovUpdateImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get and Set macro*/
   itkGetMacro(NumberOfIterations, int);

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -149,7 +149,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OSEMConeBeamReconstructionFilter);
+#else
   itkTypeMacro(OSEMConeBeamReconstructionFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkOraGeometryReader.h
+++ b/include/rtkOraGeometryReader.h
@@ -54,7 +54,11 @@ public:
   using MarginVectorType = itk::Vector<double, 4>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OraGeometryReader);
+#else
   itkTypeMacro(OraGeometryReader, itk::LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkOraImageIO.h
+++ b/include/rtkOraImageIO.h
@@ -54,7 +54,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OraImageIO);
+#else
   itkTypeMacro(OraImageIO, itk::MetaImageIO);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
 

--- a/include/rtkOraImageIOFactory.h
+++ b/include/rtkOraImageIOFactory.h
@@ -65,7 +65,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OraImageIOFactory);
+#else
   itkTypeMacro(OraImageIOFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkOraLookupTableImageFilter.h
+++ b/include/rtkOraLookupTableImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OraLookupTableImageFilter);
+#else
   itkTypeMacro(OraLookupTableImageFilter, LookupTableImageFilter);
+#endif
 
   void
   BeforeThreadedGenerateData() override;

--- a/include/rtkOraXMLFileReader.h
+++ b/include/rtkOraXMLFileReader.h
@@ -48,7 +48,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(OraXMLFileReader);
+#else
   itkTypeMacro(OraXMLFileReader, itk::XMLReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkParkerShortScanImageFilter.h
+++ b/include/rtkParkerShortScanImageFilter.h
@@ -66,7 +66,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ParkerShortScanImageFilter);
+#else
   itkTypeMacro(ParkerShortScanImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, GeometryType);

--- a/include/rtkPhaseGatingImageFilter.h
+++ b/include/rtkPhaseGatingImageFilter.h
@@ -45,7 +45,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(PhaseGatingImageFilter);
+#else
   itkTypeMacro(PhaseGatingImageFilter, SubSelectImageFilter);
+#endif
 
   itkSetMacro(PhasesFileName, std::string);
   itkGetMacro(PhasesFileName, std::string);

--- a/include/rtkPhaseReader.h
+++ b/include/rtkPhaseReader.h
@@ -47,7 +47,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(PhaseReader);
+#else
   itkTypeMacro(PhaseReader, itk::CSVFileReaderBase);
+#endif
 
   /** The value type of the dataset. */
   using ValueType = float;

--- a/include/rtkPhasesToInterpolationWeights.h
+++ b/include/rtkPhasesToInterpolationWeights.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(PhasesToInterpolationWeights);
+#else
   itkTypeMacro(PhasesToInterpolationWeights, itk::CSVFileReaderBase);
+#endif
 
   /** DataFrame Object types */
   using Array2DType = itk::Array2D<float>;

--- a/include/rtkPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkPolynomialGainCorrectionImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(PolynomialGainCorrectionImageFilter);
+#else
   itkTypeMacro(PolynomialGainCorrectionImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Dark image, 2D same size of one input projection */
   void

--- a/include/rtkProjectGeometricPhantomImageFilter.h
+++ b/include/rtkProjectGeometricPhantomImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ProjectGeometricPhantomImageFilter);
+#else
   itkTypeMacro(ProjectGeometricPhantomImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to the geometry. */
   itkGetConstObjectMacro(GeometricPhantom, GeometricPhantom);

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -120,7 +120,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ProjectionStackToFourDImageFilter);
+#else
   itkTypeMacro(ProjectionStackToFourDImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Set/Get the 4D image to be updated.*/
   void

--- a/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
+++ b/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
@@ -46,7 +46,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
   itkNewMacro(Self);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ProjectionsDecompositionNegativeLogLikelihood);
+#else
   itkTypeMacro(ProjectionsDecompositionNegativeLogLikelihood, SingleValuedCostFunction);
+#endif
 
   //  enum { SpaceDimension=m_NumberOfMaterials };
 

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -136,7 +136,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ProjectionsReader);
+#else
   itkTypeMacro(ProjectionsReader, itk::ImageSource);
+#endif
 
   /** Some convenient type alias. */
   using OutputImageType = TOutputImage;

--- a/include/rtkQuadricShape.h
+++ b/include/rtkQuadricShape.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(QuadricShape);
+#else
   itkTypeMacro(QuadricShape, ConvexShape);
+#endif
 
   /** See rtk::ConvexShape::IsInside. */
   bool

--- a/include/rtkRayBoxIntersectionImageFilter.h
+++ b/include/rtkRayBoxIntersectionImageFilter.h
@@ -59,7 +59,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(RayBoxIntersectionImageFilter);
+#else
   itkTypeMacro(RayBoxIntersectionImageFilter, RayConvexIntersectionImageFilter);
+#endif
 
   /** Get / Set the constant density of the volume */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkRayConvexIntersectionImageFilter.h
+++ b/include/rtkRayConvexIntersectionImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(RayConvexIntersectionImageFilter);
+#else
   itkTypeMacro(RayConvexIntersectionImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the object pointer to the ConvexShape. */
   itkGetModifiableObjectMacro(ConvexShape, ConvexShape);

--- a/include/rtkRayEllipsoidIntersectionImageFilter.h
+++ b/include/rtkRayEllipsoidIntersectionImageFilter.h
@@ -61,7 +61,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(RayEllipsoidIntersectionImageFilter);
+#else
   itkTypeMacro(RayEllipsoidIntersectionImageFilter, RayConvexIntersectionImageFilter);
+#endif
 
   /** Get / Set the constant density of the volume */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkRayQuadricIntersectionImageFilter.h
+++ b/include/rtkRayQuadricIntersectionImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(RayQuadricIntersectionImageFilter);
+#else
   itkTypeMacro(RayQuadricIntersectionImageFilter, RayConvexIntersectionImageFilter);
+#endif
 
   /** Get / Set the constant density of the volume */
   itkGetMacro(Density, ScalarType);

--- a/include/rtkReconstructImageFilter.h
+++ b/include/rtkReconstructImageFilter.h
@@ -135,7 +135,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ReconstructImageFilter);
+#else
   itkTypeMacro(ReconstructImageFilter, ImageToImageFilter);
+#endif
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TImage::ImageDimension;

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -146,7 +146,11 @@ public:
   SetInputWeights(const TWeightsImage * weights);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(rtkReconstructionConjugateGradientOperator);
+#else
   itkTypeMacro(rtkReconstructionConjugateGradientOperator, ConjugateGradientOperator);
+#endif
 
   using BackProjectionFilterType = rtk::BackProjectionImageFilter<TOutputImage, TOutputImage>;
   using BackProjectionFilterPointer = typename BackProjectionFilterType::Pointer;

--- a/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkRegularizedConjugateGradientConeBeamReconstructionFilter.h
@@ -129,7 +129,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(RegularizedConjugateGradientConeBeamReconstructionFilter);
+#else
   itkTypeMacro(RegularizedConjugateGradientConeBeamReconstructionFilter, itk::ImageToImageFilter);
+#endif
 
   /** The image to be updated.*/
   void

--- a/include/rtkReorderProjectionsImageFilter.h
+++ b/include/rtkReorderProjectionsImageFilter.h
@@ -67,7 +67,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ReorderProjectionsImageFilter);
+#else
   itkTypeMacro(ReorderProjectionsImageFilter, ImageToImageFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(OutputGeometry, GeometryType);

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -172,7 +172,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SARTConeBeamReconstructionFilter);
+#else
   itkTypeMacro(SARTConeBeamReconstructionFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkScatterGlareCorrectionImageFilter.h
+++ b/include/rtkScatterGlareCorrectionImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ScatterGlareCorrectionImageFilter);
+#else
   itkTypeMacro(ScatterGlareCorrectionImageFilter, FFTProjectionsConvolutionImageFilter);
+#endif
 
   itkGetConstMacro(Coefficients, CoefficientVectorType);
   virtual void

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.h
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.h
@@ -50,7 +50,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SelectOneProjectionPerCycleImageFilter);
+#else
   itkTypeMacro(SelectOneProjectionPerCycleImageFilter, SubSelectImageFilter);
+#endif
 
   /** File name of a text file with one phase value between 0 and 1 per line. */
   itkGetMacro(SignalFilename, std::string);

--- a/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
+++ b/include/rtkSeparableQuadraticSurrogateRegularizationImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SeparableQuadraticSurrogateRegularizationImageFilter);
+#else
   itkTypeMacro(SeparableQuadraticSurrogateRegularizationImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Set/Get for the radius */
   itkSetMacro(Radius, typename TImage::RegionType::SizeType);

--- a/include/rtkSheppLoganPhantom.h
+++ b/include/rtkSheppLoganPhantom.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SheppLoganPhantom);
+#else
   itkTypeMacro(SheppLoganPhantom, GeometricPhantom);
+#endif
 
 protected:
   SheppLoganPhantom();

--- a/include/rtkSheppLoganPhantomFilter.h
+++ b/include/rtkSheppLoganPhantomFilter.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SheppLoganPhantomFilter);
+#else
   itkTypeMacro(SheppLoganPhantomFilter, ProjectGeometricPhantomImageFilter);
+#endif
 
 protected:
   SheppLoganPhantomFilter();

--- a/include/rtkSignalToInterpolationWeights.h
+++ b/include/rtkSignalToInterpolationWeights.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SignalToInterpolationWeights);
+#else
   itkTypeMacro(SignalToInterpolationWeights, itk::CSVFileReaderBase);
+#endif
 
   /** DataFrame Object types */
   using Array2DType = itk::Array2D<float>;

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SimplexSpectralProjectionsDecompositionImageFilter);
+#else
   itkTypeMacro(SimplexSpectralProjectionsDecompositionImageFilter, ImageToImageFilter);
+#endif
 
   /** Set/Get the input material-decomposed stack of projections (only used for initialization) */
   void

--- a/include/rtkSingularValueThresholdImageFilter.h
+++ b/include/rtkSingularValueThresholdImageFilter.h
@@ -62,7 +62,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SingularValueThresholdImageFilter);
+#else
   itkTypeMacro(SingularValueThresholdImageFilter, ImageToImageFilter);
+#endif
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/include/rtkSoftThresholdImageFilter.h
+++ b/include/rtkSoftThresholdImageFilter.h
@@ -103,7 +103,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SoftThresholdImageFilter);
+#else
   itkTypeMacro(SoftThresholdImageFilter, UnaryFunctorImageFilter);
+#endif
 
   /** Pixel types. */
   using InputPixelType = typename TInputImage::PixelType;

--- a/include/rtkSoftThresholdTVImageFilter.h
+++ b/include/rtkSoftThresholdTVImageFilter.h
@@ -57,7 +57,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SoftThresholdTVImageFilter);
+#else
   itkTypeMacro(SoftThresholdTVImageFilter, ImageToImageFilter);
+#endif
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -69,7 +69,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SpectralForwardModelImageFilter);
+#else
   itkTypeMacro(SpectralForwardModelImageFilter, InPlaceImageFilter);
+#endif
 
   /** Set/Get the incident spectrum input images */
   void

--- a/include/rtkSplatWithKnownWeightsImageFilter.h
+++ b/include/rtkSplatWithKnownWeightsImageFilter.h
@@ -80,7 +80,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SplatWithKnownWeightsImageFilter);
+#else
   itkTypeMacro(SplatWithKnownWeightsImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** The 4D image to be updated.*/
   void

--- a/include/rtkSubSelectFromListImageFilter.h
+++ b/include/rtkSubSelectFromListImageFilter.h
@@ -44,7 +44,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SubSelectFromListImageFilter);
+#else
   itkTypeMacro(SubSelectFromListImageFilter, SubSelectImageFilter);
+#endif
 
   void
   SetSelectedProjections(std::vector<bool> sprojs);

--- a/include/rtkSubSelectImageFilter.h
+++ b/include/rtkSubSelectImageFilter.h
@@ -73,7 +73,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SubSelectImageFilter);
+#else
   itkTypeMacro(SubSelectImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** The set of projections from which a subset will be extracted */
   void

--- a/include/rtkSumOfSquaresImageFilter.h
+++ b/include/rtkSumOfSquaresImageFilter.h
@@ -52,7 +52,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(SumOfSquaresImageFilter);
+#else
   itkTypeMacro(SumOfSquaresImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Macro to get the SSD */
   itkGetMacro(SumOfSquares, OutputInternalPixelType);

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileReader.h
@@ -59,7 +59,11 @@ public:
   static const unsigned int CurrentVersion = 3;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ThreeDCircularProjectionGeometryXMLFileReader);
+#else
   itkTypeMacro(ThreeDCircularProjectionGeometryXMLFileReader, itk::XMLFileReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
+++ b/include/rtkThreeDCircularProjectionGeometryXMLFileWriter.h
@@ -53,7 +53,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ThreeDCircularProjectionGeometryXMLFileWriter);
+#else
   itkTypeMacro(ThreeDCircularProjectionGeometryXMLFileWriter, itk::XMLWriterBase);
+#endif
 
   /** Test whether a file is writable. */
   int

--- a/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalNuclearVariationDenoisingBPDQImageFilter.h
@@ -130,7 +130,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(TotalNuclearVariationDenoisingBPDQImageFilter);
+#else
   itkTypeMacro(TotalNuclearVariationDenoisingBPDQImageFilter, DenoisingBPDQImageFilter);
+#endif
 
   /** Sub filter type definitions */
   using SingularValueThresholdFilterType = SingularValueThresholdImageFilter<TGradientImage>;

--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.h
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.h
@@ -91,7 +91,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(TotalVariationDenoiseSequenceImageFilter);
+#else
   itkTypeMacro(TotalVariationDenoiseSequenceImageFilter, ImageToImageFilter);
+#endif
 
   /** Set/Get for the TotalVariationDenoisingBPDQImageFilter */
   itkGetMacro(Gamma, double);

--- a/include/rtkTotalVariationDenoisingBPDQImageFilter.h
+++ b/include/rtkTotalVariationDenoisingBPDQImageFilter.h
@@ -126,7 +126,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(TotalVariationDenoisingBPDQImageFilter);
+#else
   itkTypeMacro(TotalVariationDenoisingBPDQImageFilter, DenoisingBPDQImageFilter);
+#endif
 
   /** Sub filter type definitions */
   using MagnitudeThresholdFilterType =

--- a/include/rtkTotalVariationImageFilter.h
+++ b/include/rtkTotalVariationImageFilter.h
@@ -62,7 +62,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(TotalVariationImageFilter);
+#else
   itkTypeMacro(TotalVariationImageFilter, ImageToImageFilter);
+#endif
 
   /** Image related type alias. */
   using InputImagePointer = typename TInputImage::Pointer;

--- a/include/rtkUnwarpSequenceConjugateGradientOperator.h
+++ b/include/rtkUnwarpSequenceConjugateGradientOperator.h
@@ -78,7 +78,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(rtkUnwarpSequenceConjugateGradientOperator);
+#else
   itkTypeMacro(rtkUnwarpSequenceConjugateGradientOperator, ConjugateGradientOperator);
+#endif
 
   using WarpSequenceFilterType = rtk::WarpSequenceImageFilter<TImageSequence, TDVFImageSequence, TImage, TDVFImage>;
 

--- a/include/rtkUnwarpSequenceImageFilter.h
+++ b/include/rtkUnwarpSequenceImageFilter.h
@@ -92,7 +92,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(UnwarpSequenceImageFilter);
+#else
   itkTypeMacro(UnwarpSequenceImageFilter, ImageToImageFilter);
+#endif
 
   using CGOperatorFilterType =
     UnwarpSequenceConjugateGradientOperator<TImageSequence, TDVFImageSequence, TImage, TDVFImage>;

--- a/include/rtkUpsampleImageFilter.h
+++ b/include/rtkUpsampleImageFilter.h
@@ -51,7 +51,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(UpsampleImageFilter);
+#else
   itkTypeMacro(UpsampleImageFilter, ImageToImageFilter);
+#endif
 
   /** Typedef to images */
   using OutputImageType = TOutputImage;

--- a/include/rtkVarianObiGeometryReader.h
+++ b/include/rtkVarianObiGeometryReader.h
@@ -51,7 +51,11 @@ public:
   using FileNamesContainer = std::vector<std::string>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VarianObiGeometryReader);
+#else
   itkTypeMacro(VarianObiGeometryReader, LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkVarianObiRawImageFilter.h
+++ b/include/rtkVarianObiRawImageFilter.h
@@ -111,7 +111,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VarianObiRawImageFilter);
+#else
   itkTypeMacro(VarianObiRawImageFilter, itk::UnaryFunctorImageFilter);
+#endif
 
   itkGetMacro(I0, double);
   itkSetMacro(I0, double);

--- a/include/rtkVarianObiXMLFileReader.h
+++ b/include/rtkVarianObiXMLFileReader.h
@@ -53,7 +53,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VarianObiXMLFileReader);
+#else
   itkTypeMacro(VarianObiXMLFileReader, itk::XMLReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkVarianProBeamGeometryReader.h
+++ b/include/rtkVarianProBeamGeometryReader.h
@@ -51,7 +51,11 @@ public:
   using FileNamesContainer = std::vector<std::string>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VarianProBeamGeometryReader);
+#else
   itkTypeMacro(VarianProBeamGeometryReader, LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkVarianProBeamXMLFileReader.h
+++ b/include/rtkVarianProBeamXMLFileReader.h
@@ -52,7 +52,11 @@ public:
   using Pointer = itk::SmartPointer<Self>;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VarianProBeamXMLFileReader);
+#else
   itkTypeMacro(VarianProBeamXMLFileReader, itk::XMLReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkVectorImageToImageFilter.h
+++ b/include/rtkVectorImageToImageFilter.h
@@ -60,7 +60,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(VectorImageToImageFilter);
+#else
   itkTypeMacro(VectorImageToImageFilter, itk::ImageToImageFilter);
+#endif
 
 protected:
   VectorImageToImageFilter();

--- a/include/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.h
@@ -134,7 +134,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(WarpFourDToProjectionStackImageFilter);
+#else
   itkTypeMacro(WarpFourDToProjectionStackImageFilter, rtk::FourDToProjectionStackImageFilter);
+#endif
 
   using SignalVectorType = std::vector<double>;
 

--- a/include/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/include/rtkWarpProjectionStackToFourDImageFilter.h
@@ -128,7 +128,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(WarpProjectionStackToFourDImageFilter);
+#else
   itkTypeMacro(WarpProjectionStackToFourDImageFilter, ProjectionStackToFourDImageFilter);
+#endif
 
   using SignalVectorType = std::vector<double>;
 

--- a/include/rtkWarpSequenceImageFilter.h
+++ b/include/rtkWarpSequenceImageFilter.h
@@ -127,7 +127,11 @@ public:
 #endif
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(WarpSequenceImageFilter);
+#else
   itkTypeMacro(WarpSequenceImageFilter, IterativeConeBeamReconstructionFilter);
+#endif
 
   /** Set the motion vector field used in input 1 */
   void

--- a/include/rtkWaterPrecorrectionImageFilter.h
+++ b/include/rtkWaterPrecorrectionImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(WaterPrecorrectionImageFilter);
+#else
   itkTypeMacro(WaterPrecorrectionImageFilter, ImageToImageFilter);
+#endif
 
   /** Get / Set the Median window that are going to be used during the operation
    */

--- a/include/rtkWeidingerForwardModelImageFilter.h
+++ b/include/rtkWeidingerForwardModelImageFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(WeidingerForwardModelImageFilter);
+#else
   itkTypeMacro(WeidingerForwardModelImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Convenient parameters extracted from template types */
   static constexpr unsigned int nBins = TPhotonCounts::PixelType::Dimension;

--- a/include/rtkXRadGeometryReader.h
+++ b/include/rtkXRadGeometryReader.h
@@ -50,7 +50,11 @@ public:
   using GeometryType = ThreeDCircularProjectionGeometry;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XRadGeometryReader);
+#else
   itkTypeMacro(XRadGeometryReader, LightProcessObject);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkXRadImageIO.h
+++ b/include/rtkXRadImageIO.h
@@ -54,7 +54,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XRadImageIO);
+#else
   itkTypeMacro(XRadImageIO, ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkXRadImageIOFactory.h
+++ b/include/rtkXRadImageIOFactory.h
@@ -63,7 +63,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XRadImageIOFactory);
+#else
   itkTypeMacro(XRadImageIOFactory, ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkXRadRawToAttenuationImageFilter.h
+++ b/include/rtkXRadRawToAttenuationImageFilter.h
@@ -54,7 +54,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XRadRawToAttenuationImageFilter);
+#else
   itkTypeMacro(XRadRawToAttenuationImageFilter, itk::ImageToImageFilter);
+#endif
 
 protected:
   XRadRawToAttenuationImageFilter();

--- a/include/rtkXimImageIO.h
+++ b/include/rtkXimImageIO.h
@@ -107,7 +107,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XimImageIO);
+#else
   itkTypeMacro(XimImageIO, itk::ImageIOBase);
+#endif
 
   /*-------- This part of the interface deals with reading data. ------ */
   void

--- a/include/rtkXimImageIOFactory.h
+++ b/include/rtkXimImageIOFactory.h
@@ -69,7 +69,11 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(XimImageIOFactory);
+#else
   itkTypeMacro(XimImageIOFactory, itk::ObjectFactoryBase);
+#endif
 
   /** Register one factory of this type  */
   static void

--- a/include/rtkZengBackProjectionImageFilter.h
+++ b/include/rtkZengBackProjectionImageFilter.h
@@ -110,7 +110,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ZengBackProjectionImageFilter);
+#else
   itkTypeMacro(ZengBackProjectionImageFilter, BackProjectionImageFilter);
+#endif
 
   /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
   itkGetMacro(SigmaZero, double);

--- a/include/rtkZengForwardProjectionImageFilter.h
+++ b/include/rtkZengForwardProjectionImageFilter.h
@@ -104,7 +104,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ZengForwardProjectionImageFilter);
+#else
   itkTypeMacro(ZengForwardProjectionImageFilter, ForwardProjectionImageFilter);
+#endif
 
   /** Get / Set the sigma zero of the PSF. Default is 1.5417233052142099 */
   itkGetMacro(SigmaZero, double);


### PR DESCRIPTION
Follows InsightSoftwareConsortium/ITK@2c264ea2ef62e916c6ef947599ce659cc8fce5fe Done with command:
sed -i "s/^\( *\)itkTypeMacro(\([:a-zA-Z0-9]*\), \([;a-zA-Z0-9]*\));/#if ITK_VERSION_MINOR == 3\n\1itkTypeMacro(\2, \3);\n#else\n\1itkOverrideGetNameOfClassMacro(\2);\n#endif/g" *