### PR TITLE
STYLE: Replace additional itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`

### DIFF
--- a/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetP_kPlusOneImageFilter.h
@@ -49,7 +49,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientGetP_kPlusOneImageFilter);
+#else
   itkTypeMacro(ConjugateGradientGetP_kPlusOneImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Functions to set the inputs */
   void

--- a/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetR_kPlusOneImageFilter.h
@@ -50,7 +50,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientGetR_kPlusOneImageFilter);
+#else
   itkTypeMacro(ConjugateGradientGetR_kPlusOneImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Functions to set the inputs */
   void

--- a/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
+++ b/include/rtkConjugateGradientGetX_kPlusOneImageFilter.h
@@ -49,7 +49,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ConjugateGradientGetX_kPlusOneImageFilter);
+#else
   itkTypeMacro(ConjugateGradientGetX_kPlusOneImageFilter, itk::ImageToImageFilter);
+#endif
 
   /** Functions to set the inputs */
   void

--- a/include/rtkElektaXVI5GeometryXMLFileReader.h
+++ b/include/rtkElektaXVI5GeometryXMLFileReader.h
@@ -61,7 +61,11 @@ public:
   static const unsigned int CurrentVersion = 2;
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(ElektaXVI5GeometryXMLFileReader);
+#else
   itkTypeMacro(ElektaXVI5GeometryXMLFileReader, itk::XMLFileReader);
+#endif
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/rtkI0EstimationProjectionFilter.h
+++ b/include/rtkI0EstimationProjectionFilter.h
@@ -58,7 +58,11 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(I0EstimationProjectionFilter, ImageToImageFilter);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(I0EstimationProjectionFilter);
+#else
+  itkTypeMacro(I0EstimationProjectionFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Some convenient type alias. */
   using InputImageType = TInputImage;

--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.h
@@ -98,7 +98,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(LUTbasedVariableI0RawToAttenuationImageFilter);
+#else
   itkTypeMacro(LUTbasedVariableI0RawToAttenuationImageFilter, LookupTableImageFilter);
+#endif
 
   /** Air level I0
    */

--- a/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
+++ b/include/rtkLastDimensionL0GradientDenoisingImageFilter.h
@@ -56,7 +56,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(LastDimensionL0GradientDenoisingImageFilter);
+#else
   itkTypeMacro(LastDimensionL0GradientDenoisingImageFilter, itk::InPlaceImageFilter);
+#endif
 
   /** Get / Set the threshold. Default is 0.001 */
   itkGetMacro(Lambda, double);

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -55,7 +55,7 @@ public:
 #ifdef itkOverrideGetNameOfClassMacro
   itkOverrideGetNameOfClassMacro(MagnitudeThresholdImageFilter);
 #else
-  itkTypeMacro(MagnitudeThresholdImageFilter, ImageToImageFilter);
+  itkTypeMacro(MagnitudeThresholdImageFilter, itk::ImageToImageFilter);
 #endif
 
   /** Extract some information from the image types.  Dimensionality

--- a/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -111,8 +111,12 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter);
+#else
   itkTypeMacro(MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter,
                FourDConjugateGradientConeBeamReconstructionFilter);
+#endif
 
   /** Neither the Forward nor the Back projection filters can be set by the user */
   void

--- a/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
@@ -172,8 +172,11 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MotionCompensatedFourDROOSTERConeBeamReconstructionFilter,
-               rtk::FourDROOSTERConeBeamReconstructionFilter);
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MotionCompensatedFourDROOSTERConeBeamReconstructionFilter);
+#else
+  itkTypeMacro(MotionCompensatedFourDROOSTERConeBeamReconstructionFilter, FourDROOSTERConeBeamReconstructionFilter);
+#endif
 
   using MotionCompensatedFourDCGFilterType =
     rtk::MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>;

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -150,8 +150,12 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(MotionCompensatedFourDReconstructionConjugateGradientOperator);
+#else
   itkTypeMacro(MotionCompensatedFourDReconstructionConjugateGradientOperator,
                FourDReconstructionConjugateGradientOperator);
+#endif
 
   /** The forward and back projection filters cannot be set by the user */
   void

--- a/include/rtkReg1DExtractShroudSignalImageFilter.h
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.h
@@ -58,7 +58,12 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(Reg1DExtractShroudSignalImageFilter);
+#else
   itkTypeMacro(Reg1DExtractShroudSignalImageFilter, itk::ImageToImageFilter);
+#endif
+
 
 protected:
   Reg1DExtractShroudSignalImageFilter();

--- a/include/rtkSchlomka2008NegativeLogLikelihood.h
+++ b/include/rtkSchlomka2008NegativeLogLikelihood.h
@@ -51,8 +51,16 @@ public:
   using Superclass = rtk::ProjectionsDecompositionNegativeLogLikelihood;
   using Pointer = itk::SmartPointer<Self>;
   using ConstPointer = itk::SmartPointer<const Self>;
+
+  /** Method for creation through the object factory. */
   itkNewMacro(Self);
-  itkTypeMacro(Schlomka2008NegativeLogLikelihood, rtk::ProjectionsDecompositionNegativeLogLikelihood);
+
+  /** Run-time type information (and related methods) */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(Schlomka2008NegativeLogLikelihood);
+#else
+  itkTypeMacro(Schlomka2008NegativeLogLikelihood, ProjectionsDecompositionNegativeLogLikelihood);
+#endif
 
   using ParametersType = Superclass::ParametersType;
   using DerivativeType = Superclass::DerivativeType;


### PR DESCRIPTION
Some were missed by regular expression in
eb90fb42b9dca3fe8be373e2b7c9724e4c3b6156 due to missing digits and _