### PR TITLE
BUG: Fix above array bounds access of image size in rtkamsterdamshroud

### DIFF
--- a/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
+++ b/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
@@ -83,7 +83,7 @@ main(int argc, char * argv[])
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(shroudFilter->GetOutput());
-  writer->SetNumberOfStreamDivisions(shroudFilter->GetOutput()->GetLargestPossibleRegion().GetSize(2));
+  writer->SetNumberOfStreamDivisions(shroudFilter->GetOutput()->GetLargestPossibleRegion().GetSize(1));
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->Update())
 


### PR DESCRIPTION
The bug was detected with gcc and -Wall option which produced the following warning:

/home/srit/src/itk/itk/Modules/Core/Common/include/itkSize.h:356:85: warning: array subscript 2 is above array bounds of ‘const SizeValueType [2]’ {aka ‘const long unsigned int [2]’} [-Warray-bounds]
  356 |   constexpr const_reference operator[](size_type pos) const { return m_InternalArray[pos]; }
      |                                                                      ~~~~~~~~~~~~~~~^
/home/srit/src/itk/itk/Modules/Core/Common/include/itkSize.h:242:40: note: while referencing ‘itk::Size<2>::m_InternalArray’
  242 |   alignas(SizeValueType) SizeValueType m_InternalArray[VDimension];