### PR TITLE
COMP: Fix locally defined but not used warning

### DIFF
--- a/test/rtkmaximumintensityprojectiontest.cxx
+++ b/test/rtkmaximumintensityprojectiontest.cxx
@@ -26,8 +26,6 @@ main(int, char **)
   constexpr unsigned int Dimension = 3;
   using OutputPixelType = float;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
-
-  using VectorType = itk::Vector<double, 3>;
   constexpr unsigned int NumberOfProjectionImages = 1;
 
   // Constant image sources


### PR DESCRIPTION
The warning was:

Modules/Remote/RTK/test/rtkmaximumintensityprojectiontest.cxx:30:9: warning: typedef ‘using VectorType = struct itk::Vector<double, 3>’ locally defined but not used [-Wunused-local-typedefs]