### PR TITLE
ENH: Rename lp_solve library according to ITK's conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ if(NOT ITK_SOURCE_DIR)
   # Add third party to RTK build targets.
   # This must be done after RTK has been loaded by ITK to make sure
   # ${itk-module} variables are defined for RTK.
-  itk_module_target_export(lpsolve55)
+  itk_module_target(lpsolve55)
 
   if(${ITK_VERSION} VERSION_LESS 5.3)
     ## Set the default target properties for RTK
@@ -234,6 +234,33 @@ if(NOT ITK_SOURCE_DIR)
 else()
   itk_module_impl()
 endif()
+
+# Install lpsolve headers
+install(FILES ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_bit.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_crash.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_explicit.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_fortify.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_Hash.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_lib.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_matrix.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_MDO.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_mipbb.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_MPS.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_presolve.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_price.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_pricePSE.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_report.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_rlp.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_scale.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_simplex.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_solveDLL.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_SOS.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_types.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_utils.h
+              ${RTK_SOURCE_DIR}/utilities/lp_solve/lp_wlp.h
+        DESTINATION ${RTK_INSTALL_INCLUDE_DIR}/lpsolve
+        COMPONENT Development)
+target_include_directories(lpsolve55 PUBLIC $<INSTALL_INTERFACE:${RTK_INSTALL_INCLUDE_DIR}/lpsolve>)
 
 # Install configuration file
 install(FILES ${RTK_BINARY_DIR}/rtkConfiguration.h DESTINATION ${RTK_INSTALL_INCLUDE_DIR})

--- a/utilities/lp_solve/CMakeLists.txt
+++ b/utilities/lp_solve/CMakeLists.txt
@@ -35,31 +35,6 @@ add_library(lpsolve55
 	yacc_read.c
 )
 
-set_property(TARGET lpsolve55 PROPERTY PUBLIC_HEADER
-	lp_bit.h
-	lp_crash.h
-	lp_explicit.h
-	lp_fortify.h
-	lp_Hash.h
-	lp_lib.h
-	lp_matrix.h
-	lp_MDO.h
-	lp_mipbb.h
-	lp_MPS.h
-	lp_presolve.h
-	lp_price.h
-	lp_pricePSE.h
-	lp_report.h
-	lp_rlp.h
-	lp_scale.h
-	lp_simplex.h
-	lp_solveDLL.h
-	lp_SOS.h
-	lp_types.h
-	lp_utils.h
-	lp_wlp.h
-)
-
 include_directories(
 	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
 	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/shared>"
@@ -102,24 +77,5 @@ if (NOT ITK_SOURCE_DIR)
   # When building externally we must do this after including ITKModuleExternal.
   # See RTK/CMakeLists.txt.
 else()
-  itk_module_target_export(lpsolve55)
-endif()
-
-#=========================================================
-if(NOT RTK_INSTALL_NO_LIBRARIES)
-  target_include_directories(lpsolve55 PUBLIC $<INSTALL_INTERFACE:${RTK_INSTALL_INCLUDE_DIR}/lpsolve>)
-
-  # External modules use their own targets.
-  set(_install_targets RTKTargets)
-  if(ITK_SOURCE_DIR)
-    # Remote modules use ITKTargets.cmake
-    set(_install_targets ITKTargets)
-  endif()
-
-  install(TARGETS lpsolve55 EXPORT ${_install_targets}
-    RUNTIME DESTINATION ${RTK_INSTALL_RUNTIME_DIR} COMPONENT Runtime
-    LIBRARY DESTINATION ${RTK_INSTALL_LIB_DIR} COMPONENT RuntimeLibraries
-    ARCHIVE DESTINATION ${RTK_INSTALL_ARCHIVE_DIR} COMPONENT Development
-    PUBLIC_HEADER DESTINATION "${RTK_INSTALL_INCLUDE_DIR}/lpsolve"
-  )
+  itk_module_target(lpsolve55)
 endif()


### PR DESCRIPTION
Solves #548 and InsightSoftwareConsortium/ITK#4031. lp_solve headers are now installed manually following ITK modules.