### PR TITLE
ENH: Make Elekta XVI _Frames.xml reader robust to encountered typos

### DIFF
--- a/src/rtkElektaXVI5GeometryXMLFileReader.cxx
+++ b/src/rtkElektaXVI5GeometryXMLFileReader.cxx
@@ -56,7 +56,9 @@ void
 ElektaXVI5GeometryXMLFileReader::EndElement(const char * name)
 {
   if (itksys::SystemTools::Strucmp(name, "GantryAngle") == 0 ||
-      itksys::SystemTools::Strucmp(name, "Angle") == 0) // Second one for backward compatibility
+      itksys::SystemTools::Strucmp(name, "Angle") == 0 ||      // For backward compatibility
+      itksys::SystemTools::Strucmp(name, "antryAngle") == 0 || // Seen in anonymized _Frames.xml files
+      itksys::SystemTools::Strucmp(name, "Gantryngle") == 0)   // Seen in anonymized _Frames.xml files
   {
     m_GantryAngle = std::stod(this->m_CurCharacterData.c_str());
     if (m_GantryAngle < 0)
@@ -65,10 +67,12 @@ ElektaXVI5GeometryXMLFileReader::EndElement(const char * name)
 
   // Regarding PanelOffset, XVI5 specifies position of the center(UCentre, VCentre) instead of offset.
   // Therefore, negation is required to get classical m_ProjectionOffsetX and m_ProjectionOffsetY values.
-  if (itksys::SystemTools::Strucmp(name, "UCentre") == 0)
+  if (itksys::SystemTools::Strucmp(name, "UCentre") == 0 ||
+      itksys::SystemTools::Strucmp(name, "Uentre") == 0) // Seen in anonymized _Frames.xml files
     m_ProjectionOffsetX = std::stod(this->m_CurCharacterData.c_str()) * -1.0;
 
-  if (itksys::SystemTools::Strucmp(name, "VCentre") == 0)
+  if (itksys::SystemTools::Strucmp(name, "VCentre") == 0 ||
+      itksys::SystemTools::Strucmp(name, "Ventre") == 0) // Seen in anonymized _Frames.xml files
   {
     m_ProjectionOffsetY = std::stod(this->m_CurCharacterData.c_str()) * -1.0;
   }


### PR DESCRIPTION
These typos have been encountered in an anonymized dataset from UMC Utrecht.