### PR TITLE
BUG: Change ITKPythonPackage tag for MacOS CI

### DIFF
--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -4,7 +4,7 @@ on: [push,pull_request]
 
 env:
   itk-wheel-tag: 'v5.4.0'
-  itk-python-package-tag: 'dea15f87cb2f023e716faf2a811937bef3b105e3'
+  itk-python-package-tag: '45cfd02a22661731ca5b155f210cfa2f887d50e7'
   itk-python-package-org: 'SimonRit'
   itk-module-deps: "RTKConsortium/ITKCudaCommon@cae7c93c2f6d4c5b3cb5f6e5ce4a97686e626bf7"
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -11,6 +11,6 @@ jobs:
     with:
       cmake-options: '-DRTK_BUILD_APPLICATIONS:BOOL=OFF'
       itk-python-package-org: 'SimonRit'
-      itk-python-package-tag: 'dea15f87cb2f023e716faf2a811937bef3b105e3'
+      itk-python-package-tag: '45cfd02a22661731ca5b155f210cfa2f887d50e7'
     secrets:
       pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The new tag incorporates a fix for using GNU tar on MacOS, see SimonRit/ITKPythonPackage@d84bea5d5d697e91f456f13e71b32a82d5da5e60.