### PR TITLE
ENH: Add option to compute the Cramer-Rao Lower Bound.

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -89,6 +89,7 @@ add_subdirectory(rtkmaskcollimation)
 add_subdirectory(rtkspectraldenoiseprojections)
 add_subdirectory(rtkprojectionmatrix)
 add_subdirectory(rtkvectorconjugategradient)
+add_subdirectory(rtkdualenergyforwardmodel)
 
 add_subdirectory(rtkcheckimagequality)
 

--- a/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
+++ b/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
@@ -134,9 +134,7 @@ main(int argc, char * argv[])
   // If requested, write the variances
   if (args_info.variances_given)
   {
-    writer->SetInput(forward->GetOutput(1));
-    writer->SetFileName(args_info.variances_arg);
-    writer->Update();
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutputVariances(), args_info.variances_arg))
   }
 
   return EXIT_SUCCESS;

--- a/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
+++ b/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
@@ -32,7 +32,6 @@ main(int argc, char * argv[])
 
   using PixelValueType = float;
   constexpr unsigned int Dimension = 3;
-
   using DecomposedProjectionType = itk::VectorImage<PixelValueType, Dimension>;
   using SpectralProjectionsType = itk::VectorImage<PixelValueType, Dimension>;
   using IncidentSpectrumImageType = itk::VectorImage<PixelValueType, Dimension - 1>;
@@ -110,11 +109,20 @@ main(int argc, char * argv[])
   forward->SetMaterialAttenuations(materialAttenuations);
   forward->SetThresholds(thresholds);
   forward->SetIsSpectralCT(true);
+  if (args_info.cramer_rao_given)
+    forward->SetComputeCramerRaoLowerBound(true);
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(forward->Update())
 
   // Write output
   TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutput(), args_info.output_arg))
+
+  // If requested, write the variance
+  if (args_info.cramer_rao_given)
+  {
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutputCramerRaoLowerBound(), args_info.cramer_rao_arg))
+  }
+
 
   return EXIT_SUCCESS;
 }

--- a/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
+++ b/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
@@ -111,16 +111,24 @@ main(int argc, char * argv[])
   forward->SetIsSpectralCT(true);
   if (args_info.cramer_rao_given)
     forward->SetComputeCramerRaoLowerBound(true);
+  if (args_info.variances_given)
+    forward->SetComputeVariances(true);
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(forward->Update())
 
   // Write output
   TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutput(), args_info.output_arg))
 
-  // If requested, write the variance
+  // If requested, write the Cramer-Rao lower bound
   if (args_info.cramer_rao_given)
   {
     TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutputCramerRaoLowerBound(), args_info.cramer_rao_arg))
+  }
+
+  // If requested, write the variance
+  if (args_info.variances_given)
+  {
+    TRY_AND_EXIT_ON_ITK_EXCEPTION(itk::WriteImage(forward->GetOutputVariances(), args_info.variances_arg))
   }
 
 

--- a/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.ggo
+++ b/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.ggo
@@ -9,3 +9,4 @@ option "detector"   d "Detector response file"                                  
 option "incident"   - "Incident spectrum file"                                            string                       yes
 option "attenuations" a "Material attenuations file"                                      string                       yes
 option "thresholds" t "Lower threshold of bins, expressed in pulse height"                double                       yes multiple
+option "cramer_rao" - "File name for the output Cramer Rao Lower Bound (estimation of the variance in the material decomposed images)"  string   no

--- a/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.ggo
+++ b/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.ggo
@@ -10,3 +10,4 @@ option "incident"   - "Incident spectrum file"                                  
 option "attenuations" a "Material attenuations file"                                      string                       yes
 option "thresholds" t "Lower threshold of bins, expressed in pulse height"                double                       yes multiple
 option "cramer_rao" - "File name for the output Cramer Rao Lower Bound (estimation of the variance in the material decomposed images)"  string   no
+option "variances"  - "Output variances of photon counts, file name"                      string                       no

--- a/include/rtkDualEnergyNegativeLogLikelihood.h
+++ b/include/rtkDualEnergyNegativeLogLikelihood.h
@@ -108,10 +108,8 @@ public:
     vnl_vector<double> variances = GetVariances(parameters);
 
     long double measure = 0;
-    // TODO: Improve this estimation
-    // We assume that the variance of the integrated energy is equal to the mean
     // From equation (5) of "Cramer-Rao lower bound of basis image noise in multiple-energy x-ray imaging",
-    // PMB 2009, Roessl et al, we replace the variance with the mean
+    // PMB 2009, Roessl et al.
 
     // Compute the negative log likelihood from the expectedEnergies
     for (unsigned int i = 0; i < this->m_NumberOfMaterials; i++)

--- a/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
+++ b/include/rtkProjectionsDecompositionNegativeLogLikelihood.h
@@ -107,6 +107,20 @@ public:
   }
 
   virtual itk::VariableLengthVector<float>
+  GetCramerRaoLowerBound()
+  {
+    // Return the inverses of the diagonal components (i.e. the inverse variances, to be used directly in WLS
+    // reconstruction)
+    itk::VariableLengthVector<double> diag;
+    diag.SetSize(m_NumberOfMaterials);
+    diag.Fill(0);
+
+    for (unsigned int mat = 0; mat < m_NumberOfMaterials; mat++)
+      diag[mat] = m_Fischer.GetInverse()[mat][mat];
+    return diag;
+  }
+
+  virtual itk::VariableLengthVector<float>
   GetFischerMatrix()
   {
     // Return the whole Fischer information matrix

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -109,6 +109,9 @@ public:
   typename MaterialAttenuationsImageType::ConstPointer
   GetMaterialAttenuations();
 
+  typename DecomposedProjectionsType::ConstPointer
+  GetOutputCramerRaoLowerBound();
+
   itkSetMacro(Thresholds, ThresholdsType);
   itkGetMacro(Thresholds, ThresholdsType);
 
@@ -126,6 +129,9 @@ public:
 
   itkSetMacro(ComputeVariances, bool);
   itkGetMacro(ComputeVariances, bool);
+
+  itkSetMacro(ComputeCramerRaoLowerBound, bool);
+  itkGetMacro(ComputeCramerRaoLowerBound, bool);
 
 protected:
   SpectralForwardModelImageFilter();
@@ -165,8 +171,9 @@ protected:
   unsigned int m_NumberOfIterations;
   unsigned int m_NumberOfMaterials;
   bool         m_OptimizeWithRestarts;
-  bool         m_IsSpectralCT;     // If not, it is dual energy CT
-  bool         m_ComputeVariances; // Only implemented for dual energy CT
+  bool         m_IsSpectralCT;               // If not, it is dual energy CT
+  bool         m_ComputeVariances;           // Only implemented for dual energy CT
+  bool         m_ComputeCramerRaoLowerBound; // Only implemented for spectral CT
 
 }; // end of class
 

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -112,6 +112,9 @@ public:
   typename DecomposedProjectionsType::ConstPointer
   GetOutputCramerRaoLowerBound();
 
+  typename MeasuredProjectionsType::ConstPointer
+  GetOutputVariances();
+
   itkSetMacro(Thresholds, ThresholdsType);
   itkGetMacro(Thresholds, ThresholdsType);
 

--- a/include/rtkSpectralForwardModelImageFilter.hxx
+++ b/include/rtkSpectralForwardModelImageFilter.hxx
@@ -261,6 +261,21 @@ template <typename DecomposedProjectionsType,
           typename IncidentSpectrumImageType,
           typename DetectorResponseImageType,
           typename MaterialAttenuationsImageType>
+typename MeasuredProjectionsType::ConstPointer
+SpectralForwardModelImageFilter<DecomposedProjectionsType,
+                                MeasuredProjectionsType,
+                                IncidentSpectrumImageType,
+                                DetectorResponseImageType,
+                                MaterialAttenuationsImageType>::GetOutputVariances()
+{
+  return static_cast<const MeasuredProjectionsType *>(this->GetOutput(1));
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
 itk::DataObject::Pointer
 SpectralForwardModelImageFilter<DecomposedProjectionsType,
                                 MeasuredProjectionsType,
@@ -494,8 +509,16 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
     // If requested, store the variances into output(1)
     if (m_ComputeVariances)
     {
-      output1It.Set(
-        itk::VariableLengthVector<double>(cost->GetVariances(in).data_block(), this->m_NumberOfSpectralBins));
+      if (m_IsSpectralCT)
+      {
+        // For spectral CT, Poisson noise is assumed therefore the variances is equal to the photon counts.
+        output1It.Set(outputPixel);
+      }
+      else
+      {
+        output1It.Set(
+          itk::VariableLengthVector<double>(cost->GetVariances(in).data_block(), this->m_NumberOfSpectralBins));
+      }
       ++output1It;
     }
 


### PR DESCRIPTION
Add option to obtain the Cramer-Rao Lower Bound (CRLB) when computing the photon counts using rtkSpectralForwardModelImageFilter. The CRLB corresponds to the lower bound of the variance of any unbiased estimator. Therefore, it could be used to estimate the variance that would be obtained after material decomposition.