### PR TITLE
COMP: Fix the compilation of the new FFTHilbertImageFilter

### DIFF
--- a/include/rtkFFTHilbertImageFilter.h
+++ b/include/rtkFFTHilbertImageFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,7 +42,7 @@ class ITK_EXPORT FFTHilbertImageFilter
   : public rtk::FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FFTHilbertImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FFTHilbertImageFilter);
 
   /** Standard class type alias. */
   using Self = FFTHilbertImageFilter;
@@ -83,7 +83,11 @@ public:
   }
 
   /** Runtime information support. */
+#ifdef itkOverrideGetNameOfClassMacro
+  itkOverrideGetNameOfClassMacro(FFTHilbertImageFilter);
+#else
   itkTypeMacro(FFTHilbertImageFilter, FFTProjectionsConvolutionImageFilter);
+#endif
 
 protected:
   FFTHilbertImageFilter() = default;


### PR DESCRIPTION
PR #371 has been merged without properly checking that the code had been updated to ITK's latest changes. The following patches have been applied:
eb90fb42b9dca3fe8be373e2b7c9724e4c3b6156 STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro` 86d1e83d5341a6a7a85400d550d4759b46653522 ENH: Bump ITK and change http to https 8ac7f0b2870ad9f6d9179c4b638bbd3b3bc1c8b5 STYLE: Call ITK_DISALLOW_COPY_AND_MOVE, not ITK_DISALLOW_COPY_AND_ASSIGN