### PR TITLE
 Standardize Phantom Format to Forbild

### DIFF
--- a/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
+++ b/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
@@ -88,7 +88,6 @@ main(int argc, char * argv[])
   dq->SetOriginOffset(offset);
   dq->SetRotationMatrix(rot);
   dq->SetConfigFile(args_info.phantomfile_arg);
-  dq->SetIsForbildConfigFile(args_info.forbild_flag);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dq->Update())
 
   // Add noise

--- a/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.ggo
+++ b/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.ggo
@@ -8,6 +8,5 @@ option "phantomfile"  - "Parameters of the phantom reference"       string      
 option "noise"        - "Gaussian noise parameter (SD)"             double          no
 option "phantomscale" - "Scaling factor for the phantom dimensions" double multiple no default="1."
 option "offset"       - "3D spatial offset of the phantom center"   double multiple no
-option "forbild"      f "Interpret phantomfile as Forbild file"     flag            off
 option "rotation"     - "Rotation matrix for the phantom"           double multiple no
 

--- a/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.cxx
+++ b/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.cxx
@@ -103,7 +103,6 @@ main(int argc, char * argv[])
   ppc->SetOriginOffset(offset);
   ppc->SetRotationMatrix(rot);
   ppc->SetConfigFile(args_info.phantomfile_arg);
-  ppc->SetIsForbildConfigFile(args_info.forbild_flag);
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(ppc->Update())
 

--- a/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.ggo
+++ b/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.ggo
@@ -8,6 +8,5 @@ option "output"       o "Output projections file name"              string      
 option "phantomfile"  - "Configuration parameteres for the phantom" string          yes
 option "phantomscale" - "Scaling factor for the phantom dimensions" double multiple no default="1."
 option "offset"       - "3D spatial offset of the phantom center"   double multiple no
-option "forbild"      f "Interpret phantomfile as Forbild file"     flag            off
 option "rotation"     - "Rotation matrix for the phantom"           double multiple no
 

--- a/cmake/FindGengetopt.cmake
+++ b/cmake/FindGengetopt.cmake
@@ -71,11 +71,7 @@ macro (WRAP_GGO GGO_SRCS)
 
   set_source_files_properties(${${GGO_SRCS}} PROPERTIES GENERATED TRUE)
   if(CMAKE_COMPILER_IS_GNUCXX)
-    find_program(DEFAULT_GCC gcc)
-    exec_program(${DEFAULT_GCC} ARGS "-dumpversion" OUTPUT_VARIABLE GCCVER)
-    if("${GCCVER}" VERSION_GREATER "4.5.2")
-      set_source_files_properties(${${GGO_SRCS}} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")
-    endif()
+    set_source_files_properties(${${GGO_SRCS}} PROPERTIES COMPILE_FLAGS "-Wno-unused-but-set-variable")
   endif()
   if(MSVC)
     # Disable double to float truncation warning as gengetopt cannot append "f"

--- a/documentation/docs/Phantom.md
+++ b/documentation/docs/Phantom.md
@@ -1,0 +1,59 @@
+# How to Define a Phantom
+
+This guide provides instructions for defining a phantom’s geometry, including volume and surface geometries. Each geometry type and configuration is specified in square brackets:
+
+[type : commands]
+
+The **type** represents the geometry shape (e.g., sphere, box), while **commands** specify the parameters of the shape. By default, all values are zero.
+
+## Volume Geometries
+
+Volume geometries are the building blocks of phantom objects. Here’s how to define various types of volume geometries and apply optional clip planes for custom shapes.
+
+### Volume Geometry Types
+
+- **Sphere**: Defined by radius `r`.
+- **Box**: Defined by edge lengths `dx`, `dy`, `dz`, aligned with the coordinate axes.
+- **Cylinder_x, Cylinder_y, Cylinder_z**: Cylinders aligned with the x, y, or z-axis, with length `l` and radius `r`.
+- **Cylinder**: A cylinder with arbitrary orientation, where `axis(expression, expression, expression)` defines its direction.
+- **Ellipsoid**: Defined by half-axes `dx`, `dy`, `dz`, aligned with coordinate axes.
+- **Ellipsoid_free**: Triaxial ellipsoid with arbitrary axis directions using vectors `a_x`, `a_y`, and `a_z` to define orientation.
+- **Ellipt_Cyl**: Cylinder with elliptical cross-section and arbitrary orientation, defined by length `l` and half-axes `dx`, `dy`.
+- **Cone**: Truncated cone with arbitrary orientation, specified by lengths `l`, and radii `r1`, `r2` at each end.
+- **Tetrahedron**: Defined by four corner points `p1`, `p2`, `p3`, and `p4`.
+
+### Using Clip Planes
+
+All volume geometries can be customized with **clip planes** to trim parts of the shape. Clip planes define which parts of the geometry are included based on specific conditions:
+
+- **Inequality Format**: For example, `x < expression` or `y > expression` to include only points that meet the condition.
+- **Arbitrary Plane**: Defined by a normal vector `r(expression, expression, expression)` and its distance to the origin.
+
+Multiple clip planes can be combined for complex shape intersections.
+
+### Example Volume Geometry Definitions
+
+Here are a few examples of defining volume geometries:
+
+**Without Clip Planes**:
+- `[Sphere: r=4]`: Creates a sphere with radius 4 cm centered at the origin.
+- `[Box: x=1 y=1 z=2 dx=2 dy=2 dz=4]`: Creates a box centered at `(1,1,2)` with dimensions 2x2x4 cm.
+- `[Cylinder: l=10 r=2 axis(1,1,1)]`: Creates a cylinder of length 10 cm and radius 2 cm, pointing in the `(1,1,1)` direction.
+
+**With Clip Planes**:
+- `[Sphere: r=5 x<0 y<0]`: Creates a quarter sphere in the negative x and y regions.
+- `[Box: x=0.5 y=0.5 z=0.5 dx=1 dy=1 dz=1 r(1,1,1)<1/sqrt(3)]`: Creates a box truncated to form a tetrahedron.
+
+## Surface Geometries
+
+Surface geometries define detectors, antiscatter grids, and similar elements. The surface reference point is given by `x`, `y`, `z` or a vector `center(expression, expression, expression)`.
+
+### Types of Surface Geometries
+
+- **Plane_xy, Plane_xz, Plane_yz**: Rectangular planes aligned with the xy, xz, or yz planes.
+- **Plane**: An arbitrary rectangular plane defined by two orthogonal vectors: `norm` for surface normal, and `a_x`, `a_y` for row and column directions.
+- **Cylindrical_z**: Cylindrical detector surface parallel to the z-axis.
+- **Cylindrical**: Cylindrical detector with an arbitrary axis direction.
+- **Spherical**: Spherical detector geometry.
+
+Using these volume and surface geometries, you can construct complex, realistic phantoms for tomography and imaging applications.

--- a/examples/FDK/Code2D.sh
+++ b/examples/FDK/Code2D.sh
@@ -3,10 +3,10 @@ rtksimulatedgeometry -n 180 -o geometry.xml
 
 # Create projections of the phantom file
 # Note the sinogram being 3 pixels wide in the y direction to allow back-projection interpolation in a 2D image
-rtkprojectgeometricphantom -g geometry.xml -o projections.mha --spacing 2 --dimension=512,3,512 --phantomfile SheppLogan-2d.txt --phantomscale=256,1,256
+rtkprojectshepploganphantom -g geometry.xml -o projections.mha --spacing 2 --dimension=512,3,512  --phantomscale=256,1,256
 
 # Reconstruct
 rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256,1,256
 
 # Create a reference volume for comparison
-rtkdrawgeometricphantom --spacing 2 --dimension=256,1,256 --phantomfile SheppLogan-2d.txt -o ref.mha --phantomscale=256,1,256
+rtkdrawshepploganphantom --spacing 2 --dimension=256,1,256 -o ref.mha --phantomscale=256,1,256

--- a/examples/FDK/Code3D.sh
+++ b/examples/FDK/Code3D.sh
@@ -3,10 +3,10 @@ rtksimulatedgeometry -n 180 -o geometry.xml
 # You may add "--arc 200" to make the scan short or "--proj_iso_x 200" to offset the detector
 
 # Create projections of the phantom file
-rtkprojectgeometricphantom -g geometry.xml -o projections.mha --spacing 2 --dimension 256 --phantomfile SheppLogan.txt
+rtkprojectshepploganphantom -g geometry.xml -o projections.mha --spacing 2 --dimension 256
 
 # Reconstruct
 rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256
 
 # Create a reference volume for comparison
-rtkdrawgeometricphantom --spacing 2 --dimension 256 --phantomfile SheppLogan.txt -o ref.mha
+rtkdrawshepploganphantom --spacing 2 --dimension 256 -o ref.mha

--- a/examples/FDK/README.md
+++ b/examples/FDK/README.md
@@ -1,13 +1,15 @@
 # FDK
 
-Reconstruction of the Shepp–Logan phantom using Feldkamp, David and Kress cone-beam reconstruction.
+Reconstruction of a phantom using Feldkamp, David and Kress cone-beam reconstruction.
+
+---
+
+This example uses the Shepp–Logan phantom.
 
 ## 3D
 
 ![sin_3D](SheppLogan-3D-Sinogram.png){w=200px alt="Shepp-Logan 3D sinogram"}
 ![img_3D](SheppLogan-3D.png){w=200px alt="Shepp-Logan 3D image"}
-
-This script uses the file [SheppLogan.txt](https://data.kitware.com/api/v1/item/5b179c938d777f15ebe2020b/download) as input.
 
 ```{literalinclude} Code3D.sh
 ```
@@ -19,7 +21,24 @@ This script uses the file [SheppLogan.txt](https://data.kitware.com/api/v1/item/
 
 The same reconstruction can be performed using the original 2D Shepp-Logan phantom.
 RTK can perform 2D reconstructions through images wide of 1 pixel in the y direction.
-The following script performs the same reconstruction as above in a 2D environment and uses the [2D Shepp-Logan](http://wiki.openrtk.org/images/7/73/SheppLogan-2d.txt) phantom as input.
 
 ```{literalinclude} Code2D.sh
+```
+
+---
+
+If you want to create your own phantom, you can follow the documentation [here](../../documentation/docs/Phantom.md).
+
+```shell
+# Create a simulated geometry
+rtksimulatedgeometry -n 180 -o geometry.xml
+
+# Create projections of the phantom file
+rtkprojectgeometricphantom -g geometry.xml -o projections.mha --spacing 2 --dimension=512,3,512 --phantomfile YourPhantom.txt --phantomscale=256,1,256
+
+# Reconstruct
+rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256,1,256
+
+# Create a reference volume for comparison
+rtkdrawshepploganphantom --spacing 2 --dimension=256,1,256 --phantomfile YourPhantom.txt -o ref.mha --phantomscale=256,1,256
 ```

--- a/include/rtkFFTHilbertImageFilter.hxx
+++ b/include/rtkFFTHilbertImageFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/rtkFFTHilbertImageFilter.hxx
+++ b/include/rtkFFTHilbertImageFilter.hxx
@@ -48,7 +48,6 @@ FFTHilbertImageFilter<TInputImage, TOutputImage, TFFTPrecision>::UpdateFFTProjec
   m_PreviousKernelUpdateSize = s;
 
   const int width = s[0];
-  const int height = s[1];
 
   // Allocate kernel
   SizeType size;

--- a/index.md
+++ b/index.md
@@ -31,4 +31,5 @@ Discussion <https://www.creatis.insa-lyon.fr/mailman/listinfo/rtk-users>
 Issue tracker <https://github.com/RTKConsortium/RTK/issues>
 documentation/docs/README
 documentation/docs/Release
+documentation/docs/Phantom
 ```


### PR DESCRIPTION
Summary: This merge request updates RTK to use only the Forbild phantom format for geometry definitions. All other phantom formats have been deprecated or removed for consistency and simplicity.

Key Changes:
-Remove option SetIsForbildConfigFile in rtkprojectgeometricphantom and rtkdrawgeometricphantom
-Create documentation on how to create a Phantom in the forbild format.
-Adapt FDK example with new forbild phantom format

