### PR TITLE
ENH: Deduce CUDACOMMON_VERSION_MAJOR from its CMake existence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,8 +233,13 @@ else()
   itk_module_impl()
 endif()
 
-# Propagate cmake options in a header file
-# Must be done after the external module configuration to make sure CudaCommon_SOURCE_DIR is defined
+if(RTK_USE_CUDA)
+  # CUDACOMMON_VERSION_MAJOR is defined by CudaCommon starting with version 2
+  if(NOT DEFINED CUDACOMMON_VERSION_MAJOR)
+      set(CUDACOMMON_VERSION_MAJOR 1)
+  endif()
+endif()
+
 configure_file(${RTK_SOURCE_DIR}/rtkConfiguration.h.in
   ${RTK_BINARY_DIR}/rtkConfiguration.h)
 

--- a/include/rtkCudaBackProjectionImageFilter.hxx
+++ b/include/rtkCudaBackProjectionImageFilter.hxx
@@ -76,7 +76,7 @@ CudaBackProjectionImageFilter<ImageType>::GPUGenerateData()
   volumeSize[1] = this->GetOutput()->GetBufferedRegion().GetSize()[1];
   volumeSize[2] = this->GetOutput()->GetBufferedRegion().GetSize()[2];
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * stackGPUPointer = (float *)(this->GetInput(1)->GetCudaDataManager()->GetGPUBufferPointer());

--- a/include/rtkCudaConjugateGradientImageFilter.hxx
+++ b/include/rtkCudaConjugateGradientImageFilter.hxx
@@ -56,7 +56,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
   R_k->CopyInformation(this->GetOutput());
 
   // Copy the input to the output (X_0 = input)
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   DataType * pin = (DataType *)(this->GetX()->GetCudaDataManager()->GetGPUBufferPointer());
   DataType * pX = (DataType *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #  else
@@ -75,7 +75,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
   typename TImage::Pointer AOut = this->m_A->GetOutput();
   AOut->DisconnectPipeline();
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   DataType * pR = (DataType *)(R_k->GetCudaDataManager()->GetGPUBufferPointer());
   DataType * pB = (DataType *)(this->GetB()->GetCudaDataManager()->GetGPUBufferPointer());
   DataType * pAOut = (DataType *)(AOut->GetCudaDataManager()->GetGPUBufferPointer());
@@ -93,7 +93,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
   // Transfer it back to the CPU memory
   this->GetB()->GetCudaDataManager()->GetCPUBufferPointer();
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   DataType * pP = (DataType *)(P_k->GetCudaDataManager()->GetGPUBufferPointer());
 #  else
   DataType * pP = *(DataType **)(P_k->GetCudaDataManager()->GetGPUBufferPointer());
@@ -112,7 +112,7 @@ CudaConjugateGradientImageFilter<TImage>::GPUGenerateData()
     AOut = this->m_A->GetOutput();
     AOut->DisconnectPipeline();
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
     pX = (DataType *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
     pR = (DataType *)(R_k->GetCudaDataManager()->GetGPUBufferPointer());
     pP = (DataType *)(P_k->GetCudaDataManager()->GetGPUBufferPointer());

--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
@@ -74,7 +74,7 @@ CudaFFTProjectionsConvolutionImageFilter<TParentImageFilter>::PadInputImageRegio
   sz_i.y = inBuffRegion.GetSize()[1];
   sz_i.z = inBuffRegion.GetSize()[2];
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(paddedImage->GetCudaDataManager()->GetGPUBufferPointer());
 #  else
@@ -137,7 +137,7 @@ CudaFFTProjectionsConvolutionImageFilter<TParentImageFilter>::GPUGenerateData()
   kernelDimension.y = this->m_KernelFFT->GetBufferedRegion().GetSize()[1];
   CUDA_fft_convolution(inputDimension,
                        kernelDimension,
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
                        (float *)(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
                        (float2 *)(this->m_KernelFFTCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
 #  else

--- a/include/rtkCudaForwardProjectionImageFilter.hxx
+++ b/include/rtkCudaForwardProjectionImageFilter.hxx
@@ -91,7 +91,7 @@ CudaForwardProjectionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
   volumeSize[1] = this->GetInput(1)->GetBufferedRegion().GetSize()[1];
   volumeSize[2] = this->GetInput(1)->GetBufferedRegion().GetSize()[2];
 
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pvol = (float *)(this->GetInput(1)->GetCudaDataManager()->GetGPUBufferPointer());

--- a/include/rtkCudaWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.hxx
@@ -54,7 +54,7 @@ CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpect
     projectionSize[d] = this->GetInputMaterialProjections()->GetBufferedRegion().GetSize()[d];
 
     // Pointers to inputs and outputs
-#  ifdef CUDACOMMON_VERSION_MAJOR
+#  if CUDACOMMON_VERSION_MAJOR > 1
   float * pMatProj = (float *)(this->GetInputMaterialProjections()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pPhoCount = (float *)(this->GetInputPhotonCounts()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pSpectrum = (float *)(this->GetInputSpectrum()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/rtkConfiguration.h.in
+++ b/rtkConfiguration.h.in
@@ -35,10 +35,14 @@ using ThreadIdType = itk::ThreadIdType;
 #  define SLAB_SIZE @RTK_CUDA_PROJECTIONS_SLAB_SIZE@
 #endif
 
-// CudaCommon_SOURCE_DIR and cudaCommonConfiguration.h were introduced in CudaCommon 2.0
-#cmakedefine CudaCommon_SOURCE_DIR
-#ifdef CudaCommon_SOURCE_DIR
-#  include <cudaCommonConfiguration.h>
+// CUDACOMMON_VERSION_MAJOR and cudaCommonConfiguration.h were introduced in CudaCommon 2.
+// Below is a temporary fix until CudaCommon version 2 is released
+#ifdef RTK_USE_CUDA
+#  define CUDACOMMON_VERSION_MAJOR @CUDACOMMON_VERSION_MAJOR@
+#  if CUDACOMMON_VERSION_MAJOR > 1
+#    undef CUDACOMMON_VERSION_MAJOR
+#    include <cudaCommonConfiguration.h>
+#  endif
 #endif
 
 #define RTK_BINARY_DIR "@RTK_BINARY_DIR@"

--- a/src/rtkCudaAverageOutOfROIImageFilter.cxx
+++ b/src/rtkCudaAverageOutOfROIImageFilter.cxx
@@ -33,7 +33,7 @@ rtk::CudaAverageOutOfROIImageFilter ::GPUGenerateData()
     size[i] = this->GetOutput()->GetBufferedRegion().GetSize()[i];
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * proi = (float *)(this->GetROI()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaConstantVolumeSeriesSource.cxx
+++ b/src/rtkCudaConstantVolumeSeriesSource.cxx
@@ -33,7 +33,7 @@ rtk::CudaConstantVolumeSeriesSource ::GPUGenerateData()
     outputSize[i] = this->GetOutput()->GetRequestedRegion().GetSize()[i];
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * pout = *(float **)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaConstantVolumeSource.cxx
+++ b/src/rtkCudaConstantVolumeSource.cxx
@@ -33,7 +33,7 @@ rtk::CudaConstantVolumeSource ::GPUGenerateData()
     outputSize[i] = this->GetOutput()->GetRequestedRegion().GetSize()[i];
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * pout = *(float **)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaCropImageFilter.cxx
+++ b/src/rtkCudaCropImageFilter.cxx
@@ -50,7 +50,7 @@ CudaCropImageFilter ::GPUGenerateData()
     itkExceptionMacro(<< "CudaCropImageFilter assumes that requested and buffered regions are equal.");
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaCyclicDeformationImageFilter.cxx
+++ b/src/rtkCudaCyclicDeformationImageFilter.cxx
@@ -44,7 +44,7 @@ rtk::CudaCyclicDeformationImageFilter ::GPUGenerateData()
     }
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaDisplacedDetectorImageFilter.cxx
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cxx
@@ -34,13 +34,13 @@ CudaDisplacedDetectorImageFilter ::GPUGenerateData()
   overlapRegion.Crop(this->GetInput()->GetBufferedRegion());
 
   // Put the two data pointers at the same location
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * inBuffer = static_cast<float *>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * inBuffer = *static_cast<float **>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   inBuffer += this->GetInput()->ComputeOffset(overlapRegion.GetIndex());
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * outBuffer = static_cast<float *>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * outBuffer = *static_cast<float **>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaFDKBackProjectionImageFilter.cxx
+++ b/src/rtkCudaFDKBackProjectionImageFilter.cxx
@@ -69,7 +69,7 @@ CudaFDKBackProjectionImageFilter ::GPUGenerateData()
   volumeSize[1] = this->GetOutput()->GetBufferedRegion().GetSize()[1];
   volumeSize[2] = this->GetOutput()->GetBufferedRegion().GetSize()[2];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * stackGPUPointer = (float *)(this->GetInput(1)->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaFDKWeightProjectionFilter.cxx
+++ b/src/rtkCudaFDKWeightProjectionFilter.cxx
@@ -107,13 +107,13 @@ CudaFDKWeightProjectionFilter ::GPUGenerateData()
   }
 
   // Put the two data pointers at the same location
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * inBuffer = static_cast<float *>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * inBuffer = *static_cast<float **>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   inBuffer += this->GetInput()->ComputeOffset(this->GetInput()->GetRequestedRegion().GetIndex());
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * outBuffer = static_cast<float *>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * outBuffer = *static_cast<float **>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaForwardWarpImageFilter.cxx
+++ b/src/rtkCudaForwardWarpImageFilter.cxx
@@ -90,7 +90,7 @@ CudaForwardWarpImageFilter ::GPUGenerateData()
     ++itDVF;
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pinVol = (float *)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
   float * poutVol = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pinxDVF = (float *)(xCompDVF->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaInterpolateImageFilter.cxx
+++ b/src/rtkCudaInterpolateImageFilter.cxx
@@ -32,7 +32,7 @@ rtk::CudaInterpolateImageFilter ::GPUGenerateData()
   inputSize.z = this->GetInputVolumeSeries()->GetBufferedRegion().GetSize()[2];
   inputSize.w = this->GetInputVolumeSeries()->GetBufferedRegion().GetSize()[3];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pvolseries = (float *)(this->GetInputVolumeSeries()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pvol = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaLagCorrectionImageFilter.cxx
+++ b/src/rtkCudaLagCorrectionImageFilter.cxx
@@ -34,7 +34,7 @@ CudaLagCorrectionImageFilter ::GPUGenerateData()
   // overlapRegion.Crop(this->GetInput()->GetBufferedRegion());
 
   // Put the two data pointers at the same location
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   unsigned short * inBuffer =
     static_cast<unsigned short *>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
@@ -42,7 +42,7 @@ CudaLagCorrectionImageFilter ::GPUGenerateData()
     *static_cast<unsigned short **>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   inBuffer += this->GetInput()->ComputeOffset(overlapRegion.GetIndex());
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   unsigned short * outBuffer =
     static_cast<unsigned short *>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaLaplacianImageFilter.cxx
+++ b/src/rtkCudaLaplacianImageFilter.cxx
@@ -46,7 +46,7 @@ rtk::CudaLaplacianImageFilter ::GPUGenerateData()
     }
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaLastDimensionTVDenoisingImageFilter.cxx
+++ b/src/rtkCudaLastDimensionTVDenoisingImageFilter.cxx
@@ -53,7 +53,7 @@ rtk::CudaLastDimensionTVDenoisingImageFilter ::GPUGenerateData()
     }
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaParkerShortScanImageFilter.cxx
+++ b/src/rtkCudaParkerShortScanImageFilter.cxx
@@ -30,13 +30,13 @@ void
 CudaParkerShortScanImageFilter ::GPUGenerateData()
 {
   // Put the two data pointers at the same location
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * inBuffer = static_cast<float *>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * inBuffer = *static_cast<float **>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   inBuffer += this->GetInput()->ComputeOffset(this->GetInput()->GetRequestedRegion().GetIndex());
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * outBuffer = static_cast<float *>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float * outBuffer = *static_cast<float **>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaPolynomialGainCorrectionImageFilter.cxx
+++ b/src/rtkCudaPolynomialGainCorrectionImageFilter.cxx
@@ -33,7 +33,7 @@ CudaPolynomialGainCorrectionImageFilter ::GPUGenerateData()
   OutputImageRegionType overlapRegion = this->GetOutput()->GetRequestedRegion();
 
   // Put the two data pointers at the same location
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   unsigned short * inBuffer =
     static_cast<unsigned short *>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
@@ -41,14 +41,14 @@ CudaPolynomialGainCorrectionImageFilter ::GPUGenerateData()
     *static_cast<unsigned short **>(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   inBuffer += this->GetInput()->ComputeOffset(overlapRegion.GetIndex());
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * outBuffer = static_cast<float *>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else
   float *          outBuffer = *static_cast<float **>(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #endif
   outBuffer += this->GetOutput()->ComputeOffset(this->GetOutput()->GetRequestedRegion().GetIndex());
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   unsigned short * darkBuffer = static_cast<unsigned short *>(m_DarkImage->GetCudaDataManager()->GetGPUBufferPointer());
 
   float * gainBuffer = static_cast<float *>(m_GainImage->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaRayCastBackProjectionImageFilter.cxx
+++ b/src/rtkCudaRayCastBackProjectionImageFilter.cxx
@@ -84,7 +84,7 @@ CudaRayCastBackProjectionImageFilter ::GPUGenerateData()
   volumeSize[1] = this->GetOutput()->GetRequestedRegion().GetSize()[1];
   volumeSize[2] = this->GetOutput()->GetRequestedRegion().GetSize()[2];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pproj = (float *)(this->GetInput(1)->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaSplatImageFilter.cxx
+++ b/src/rtkCudaSplatImageFilter.cxx
@@ -32,7 +32,7 @@ rtk::CudaSplatImageFilter ::GPUGenerateData()
   outputSize.z = this->GetOutput()->GetLargestPossibleRegion().GetSize()[2];
   outputSize.w = this->GetOutput()->GetLargestPossibleRegion().GetSize()[3];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pvolseries = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pvol = (float *)(this->GetInputVolume()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaTotalVariationDenoisingBPDQImageFilter.cxx
+++ b/src/rtkCudaTotalVariationDenoisingBPDQImageFilter.cxx
@@ -47,7 +47,7 @@ rtk::CudaTotalVariationDenoisingBPDQImageFilter ::GPUGenerateData()
     }
   }
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
 #else

--- a/src/rtkCudaWarpBackProjectionImageFilter.cxx
+++ b/src/rtkCudaWarpBackProjectionImageFilter.cxx
@@ -191,7 +191,7 @@ CudaWarpBackProjectionImageFilter ::GPUGenerateData()
   }
 
   // Load the required images onto the GPU (handled by the CudaDataManager)
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pDVF = (float *)(this->GetDisplacementField()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaWarpForwardProjectionImageFilter.cxx
+++ b/src/rtkCudaWarpForwardProjectionImageFilter.cxx
@@ -190,7 +190,7 @@ CudaWarpForwardProjectionImageFilter ::GPUGenerateData()
   inputDVFSize[1] = this->GetDisplacementField()->GetBufferedRegion().GetSize()[1];
   inputDVFSize[2] = this->GetDisplacementField()->GetBufferedRegion().GetSize()[2];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pin = (float *)(this->GetInputProjectionStack()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pout = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pvol = (float *)(this->GetInputVolume()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/src/rtkCudaWarpImageFilter.cxx
+++ b/src/rtkCudaWarpImageFilter.cxx
@@ -64,7 +64,7 @@ CudaWarpImageFilter ::GPUGenerateData()
   outputVolumeSize[1] = this->GetOutput()->GetBufferedRegion().GetSize()[1];
   outputVolumeSize[2] = this->GetOutput()->GetBufferedRegion().GetSize()[2];
 
-#ifdef CUDACOMMON_VERSION_MAJOR
+#if CUDACOMMON_VERSION_MAJOR > 1
   float * pinVol = (float *)(this->GetInput(0)->GetCudaDataManager()->GetGPUBufferPointer());
   float * poutVol = (float *)(this->GetOutput()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pDVF = (float *)(this->GetDisplacementField()->GetCudaDataManager()->GetGPUBufferPointer());

--- a/wrapping/itkCudaImageRTK.wrap
+++ b/wrapping/itkCudaImageRTK.wrap
@@ -1,11 +1,10 @@
 if(RTK_USE_CUDA)
-
-  if(CudaCommon_SOURCE_DIR)
+  if(CUDACOMMON_VERSION_MAJOR>1)
     configure_file("${CudaCommon_SOURCE_DIR}/wrapping/CudaImage.i.init" "${CMAKE_CURRENT_BINARY_DIR}/CudaImageRTK.i" @ONLY)
   endif()
 
   function(wrap_CudaImage_swig_ext type px_type)
-    if(CudaCommon_SOURCE_DIR)
+    if(CUDACOMMON_VERSION_MAJOR>1)
       set(CudaImageTypes ${type})
       set(PixelType ${px_type})
       configure_file(${CudaCommon_SOURCE_DIR}/wrapping/CudaImage.i.in ${CMAKE_CURRENT_BINARY_DIR}/CudaImageRTK.i.temp @ONLY)
@@ -43,7 +42,7 @@ if(RTK_USE_CUDA)
 
   itk_end_wrap_class()
 
-  if(CudaCommon_SOURCE_DIR)
+  if(CudaCommon_VERSION_MAJOR>1)
     # Add library files to be included at a submodule level and copy them into
     # ITK's wrapping typedef directory.
     # Another approach is to add CudaImage.i to the WRAPPER_SWIG_LIBRARY_FILES list


### PR DESCRIPTION
If CudaCommon does not set CUDACOMMON_VERSION_MAJOR, it is inferred to be 1 and written in the rtkConfiguration.h file. This is a temporary solution until CudaCommon v2 is released.