### PR TITLE
ENH: Do not use SmartPointer in Set function for wrapping

### DIFF
--- a/include/rtkADMMTotalVariationConjugateGradientOperator.h
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.h
@@ -142,11 +142,11 @@ public:
 
   /** Set the backprojection filter*/
   void
-  SetBackProjectionFilter(const BackProjectionFilterPointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
   /** Set the forward projection filter*/
   void
-  SetForwardProjectionFilter(const ForwardProjectionFilterPointer _arg);
+  SetForwardProjectionFilter(ForwardProjectionFilterType * _arg);
 
   /** Pass the geometry to all filters needing it */
   itkSetObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
+++ b/include/rtkADMMTotalVariationConjugateGradientOperator.hxx
@@ -66,7 +66,7 @@ ADMMTotalVariationConjugateGradientOperator<TOutputImage,
 template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConjugateGradientOperator<TOutputImage, TGradientOutputImage>::SetBackProjectionFilter(
-  const typename BackProjectionFilterType::Pointer _arg)
+  BackProjectionFilterType * _arg)
 {
   if (m_BackProjectionFilter != _arg)
     this->Modified();
@@ -76,7 +76,7 @@ ADMMTotalVariationConjugateGradientOperator<TOutputImage, TGradientOutputImage>:
 template <typename TOutputImage, typename TGradientOutputImage>
 void
 ADMMTotalVariationConjugateGradientOperator<TOutputImage, TGradientOutputImage>::SetForwardProjectionFilter(
-  const typename ForwardProjectionFilterType::Pointer _arg)
+  ForwardProjectionFilterType * _arg)
 {
   if (m_ForwardProjectionFilter != _arg)
     this->Modified();

--- a/include/rtkADMMWaveletsConjugateGradientOperator.h
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.h
@@ -128,15 +128,15 @@ public:
 
   /** Set the backprojection filter*/
   void
-  SetBackProjectionFilter(const BackProjectionFilterPointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
   /** Set the forward projection filter*/
   void
-  SetForwardProjectionFilter(const ForwardProjectionFilterPointer _arg);
+  SetForwardProjectionFilter(ForwardProjectionFilterType * _arg);
 
   /** Set the geometry of both m_BackProjectionFilter and m_ForwardProjectionFilter */
   void
-  SetGeometry(const ThreeDCircularProjectionGeometry::Pointer _arg);
+  SetGeometry(ThreeDCircularProjectionGeometry * _arg);
 
   /** Set the regularization parameter */
   itkSetMacro(Beta, float);

--- a/include/rtkADMMWaveletsConjugateGradientOperator.hxx
+++ b/include/rtkADMMWaveletsConjugateGradientOperator.hxx
@@ -53,8 +53,7 @@ ADMMWaveletsConjugateGradientOperator<TOutputImage>::ADMMWaveletsConjugateGradie
 
 template <typename TOutputImage>
 void
-ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetBackProjectionFilter(
-  const typename BackProjectionFilterType::Pointer _arg)
+ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetBackProjectionFilter(BackProjectionFilterType * _arg)
 {
   if (m_BackProjectionFilter != _arg)
     this->Modified();
@@ -63,8 +62,7 @@ ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetBackProjectionFilter(
 
 template <typename TOutputImage>
 void
-ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetForwardProjectionFilter(
-  const typename ForwardProjectionFilterType::Pointer _arg)
+ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetForwardProjectionFilter(ForwardProjectionFilterType * _arg)
 {
   if (m_ForwardProjectionFilter != _arg)
     this->Modified();
@@ -74,9 +72,9 @@ ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetForwardProjectionFilter(
 
 template <typename TOutputImage>
 void
-ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetGeometry(const ThreeDCircularProjectionGeometry::Pointer _arg)
+ADMMWaveletsConjugateGradientOperator<TOutputImage>::SetGeometry(ThreeDCircularProjectionGeometry * _arg)
 {
-  m_BackProjectionFilter->SetGeometry(_arg.GetPointer());
+  m_BackProjectionFilter->SetGeometry(_arg);
   m_ForwardProjectionFilter->SetGeometry(_arg);
   m_DisplacedDetectorFilter->SetGeometry(_arg);
 }

--- a/include/rtkConjugateGradientImageFilter.h
+++ b/include/rtkConjugateGradientImageFilter.h
@@ -54,7 +54,6 @@ public:
   using Superclass = itk::InPlaceImageFilter<OutputImageType, OutputImageType>;
   using Pointer = itk::SmartPointer<Self>;
   using ConjugateGradientOperatorType = ConjugateGradientOperator<OutputImageType>;
-  using ConjugateGradientOperatorPointerType = typename ConjugateGradientOperatorType::Pointer;
   using OutputImagePointer = typename OutputImageType::Pointer;
 
   /** Method for creation through the object factory. */
@@ -72,7 +71,7 @@ public:
   itkSetMacro(NumberOfIterations, int);
 
   void
-  SetA(ConjugateGradientOperatorPointerType _arg);
+  SetA(ConjugateGradientOperatorType * _arg);
 
   /** The input image to be updated.*/
   void
@@ -101,7 +100,7 @@ protected:
   void
   GenerateOutputInformation() override;
 
-  ConjugateGradientOperatorPointerType m_A;
+  ConjugateGradientOperatorType * m_A;
 
   int m_NumberOfIterations;
 };

--- a/include/rtkConjugateGradientImageFilter.hxx
+++ b/include/rtkConjugateGradientImageFilter.hxx
@@ -67,7 +67,7 @@ ConjugateGradientImageFilter<OutputImageType>::GetB()
 
 template <typename OutputImageType>
 void
-ConjugateGradientImageFilter<OutputImageType>::SetA(ConjugateGradientOperatorPointerType _arg)
+ConjugateGradientImageFilter<OutputImageType>::SetA(ConjugateGradientOperatorType * _arg)
 {
   this->m_A = _arg;
   this->Modified();

--- a/include/rtkFDKConeBeamReconstructionFilter.h
+++ b/include/rtkFDKConeBeamReconstructionFilter.h
@@ -120,7 +120,7 @@ public:
    * created before calling this set function. */
   itkGetMacro(BackProjectionFilter, BackProjectionFilterPointer);
   virtual void
-  SetBackProjectionFilter(const BackProjectionFilterPointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
 protected:
   FDKConeBeamReconstructionFilter();

--- a/include/rtkFDKConeBeamReconstructionFilter.hxx
+++ b/include/rtkFDKConeBeamReconstructionFilter.hxx
@@ -159,7 +159,7 @@ FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::Gener
 template <class TInputImage, class TOutputImage, class TFFTPrecision>
 void
 FDKConeBeamReconstructionFilter<TInputImage, TOutputImage, TFFTPrecision>::SetBackProjectionFilter(
-  const BackProjectionFilterPointer _arg)
+  BackProjectionFilterType * _arg)
 {
   itkDebugMacro("setting BackProjectionFilter to " << _arg);
   if (this->m_BackProjectionFilter != _arg)

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -200,11 +200,11 @@ public:
 
   /** Pass the backprojection filter to ProjectionStackToFourD*/
   void
-  SetBackProjectionFilter(const typename BackProjectionFilterType::Pointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
   /** Pass the forward projection filter to FourDToProjectionStack */
   void
-  SetForwardProjectionFilter(const typename ForwardProjectionFilterType::Pointer _arg);
+  SetForwardProjectionFilter(ForwardProjectionFilterType * _arg);
 
   /** Pass the geometry to all filters needing it */
   itkSetConstObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -77,7 +77,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
 template <typename VolumeSeriesType, typename ProjectionStackType>
 void
 FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>::SetBackProjectionFilter(
-  const typename BackProjectionFilterType::Pointer _arg)
+  BackProjectionFilterType * _arg)
 {
   m_BackProjectionFilter = _arg;
   this->Modified();
@@ -86,7 +86,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
 template <typename VolumeSeriesType, typename ProjectionStackType>
 void
 FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackType>::SetForwardProjectionFilter(
-  const typename ForwardProjectionFilterType::Pointer _arg)
+  ForwardProjectionFilterType * _arg)
 {
   m_ForwardProjectionFilter = _arg;
   this->Modified();

--- a/include/rtkFourDToProjectionStackImageFilter.h
+++ b/include/rtkFourDToProjectionStackImageFilter.h
@@ -141,11 +141,10 @@ public:
 
   /** Set the ForwardProjection filter */
   void
-  SetForwardProjectionFilter(const typename ForwardProjectionFilterType::Pointer _arg);
+  SetForwardProjectionFilter(ForwardProjectionFilterType * _arg);
 
   /** Pass the geometry to SingleProjectionToFourDFilter */
-  virtual void
-  SetGeometry(GeometryType::Pointer _arg);
+  itkSetObjectMacro(Geometry, GeometryType);
 
   /** Pass the interpolation weights to SingleProjectionToFourDFilter */
   void

--- a/include/rtkFourDToProjectionStackImageFilter.hxx
+++ b/include/rtkFourDToProjectionStackImageFilter.hxx
@@ -74,7 +74,7 @@ FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::GetInp
 template <typename ProjectionStackType, typename VolumeSeriesType>
 void
 FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::SetForwardProjectionFilter(
-  const typename ForwardProjectionFilterType::Pointer _arg)
+  ForwardProjectionFilterType * _arg)
 {
   m_ForwardProjectionFilter = _arg;
 }
@@ -84,13 +84,6 @@ void
 FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::SetWeights(const itk::Array2D<float> _arg)
 {
   m_Weights = _arg;
-}
-
-template <typename ProjectionStackType, typename VolumeSeriesType>
-void
-FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::SetGeometry(GeometryType::Pointer _arg)
-{
-  m_Geometry = _arg;
 }
 
 template <typename VolumeSeriesType, typename ProjectionStackType>

--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -47,7 +47,7 @@ namespace rtk
  */
 template <class TConstantImageSourceType, class TArgsInfo>
 void
-SetConstantImageSourceFromGgo(typename TConstantImageSourceType::Pointer source, const TArgsInfo & args_info)
+SetConstantImageSourceFromGgo(TConstantImageSourceType * source, const TArgsInfo & args_info)
 {
   using ImageType = typename TConstantImageSourceType::OutputImageType;
 
@@ -175,7 +175,7 @@ GetProjectionsFileNamesFromGgo(const TArgsInfo & args_info)
 
 template <class TProjectionsReaderType, class TArgsInfo>
 void
-SetProjectionsReaderFromGgo(typename TProjectionsReaderType::Pointer reader, const TArgsInfo & args_info)
+SetProjectionsReaderFromGgo(TProjectionsReaderType * reader, const TArgsInfo & args_info)
 {
   const std::vector<std::string> fileNames = GetProjectionsFileNamesFromGgo(args_info);
 

--- a/include/rtkLookupTableImageFilter.h
+++ b/include/rtkLookupTableImageFilter.h
@@ -65,7 +65,7 @@ public:
     return m_LookupTablePointer;
   }
   void
-  SetLookupTable(LookupTablePointer lut)
+  SetLookupTable(LookupTableType * lut)
   {
     m_LookupTablePointer = lut;
     m_LookupTableDataPointer = lut->GetBufferPointer();

--- a/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkMotionCompensatedFourDReconstructionConjugateGradientOperator.h
@@ -159,12 +159,12 @@ public:
 
   /** The forward and back projection filters cannot be set by the user */
   void
-  SetForwardProjectionFilter(const typename Superclass::ForwardProjectionFilterType::Pointer itkNotUsed(_arg))
+  SetForwardProjectionFilter(typename Superclass::ForwardProjectionFilterType * itkNotUsed(_arg))
   {
     itkExceptionMacro(<< "ForwardProjection cannot be changed");
   }
   void
-  SetBackProjectionFilter(const typename Superclass::BackProjectionFilterType::Pointer itkNotUsed(_arg))
+  SetBackProjectionFilter(typename Superclass::BackProjectionFilterType * itkNotUsed(_arg))
   {
     itkExceptionMacro(<< "BackProjection cannot be changed");
   }

--- a/include/rtkPolynomialGainCorrectionImageFilter.h
+++ b/include/rtkPolynomialGainCorrectionImageFilter.h
@@ -75,12 +75,12 @@ public:
 
   /** Dark image, 2D same size of one input projection */
   void
-  SetDarkImage(const InputImagePointer darkImage);
+  SetDarkImage(InputImageType * darkImage);
 
   /** Weights, matrix A from reference paper
    *  3D image: 2D x order. */
   void
-  SetGainCoefficients(const OutputImagePointer gain);
+  SetGainCoefficients(OutputImageType * gain);
 
   /* if K==0, the filter is bypassed */
   itkSetMacro(K, float);

--- a/include/rtkPolynomialGainCorrectionImageFilter.hxx
+++ b/include/rtkPolynomialGainCorrectionImageFilter.hxx
@@ -32,14 +32,14 @@ PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>::PolynomialGainCo
 
 template <class TInputImage, class TOutputImage>
 void
-PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>::SetDarkImage(const InputImagePointer darkImage)
+PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>::SetDarkImage(InputImageType * darkImage)
 {
   m_DarkImage = darkImage;
 }
 
 template <class TInputImage, class TOutputImage>
 void
-PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>::SetGainCoefficients(const OutputImagePointer gain)
+PolynomialGainCorrectionImageFilter<TInputImage, TOutputImage>::SetGainCoefficients(OutputImageType * gain)
 {
   m_GainImage = gain;
 }

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -167,7 +167,7 @@ public:
 
   /** Pass the backprojection filter to SingleProjectionToFourDFilter */
   void
-  SetBackProjectionFilter(const typename BackProjectionFilterType::Pointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
   /** Pass the geometry to SingleProjectionToFourDFilter */
   itkSetConstObjectMacro(Geometry, GeometryType);

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -73,7 +73,7 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
 template <typename VolumeSeriesType, typename ProjectionStackType, typename TFFTPrecision>
 void
 ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPrecision>::SetBackProjectionFilter(
-  const typename BackProjectionFilterType::Pointer _arg)
+  BackProjectionFilterType * _arg)
 {
   m_BackProjectionFilter = _arg;
   this->Modified();

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -175,11 +175,11 @@ public:
 
   /** Set the backprojection filter*/
   void
-  SetBackProjectionFilter(const BackProjectionFilterPointer _arg);
+  SetBackProjectionFilter(BackProjectionFilterType * _arg);
 
   /** Set the forward projection filter*/
   void
-  SetForwardProjectionFilter(const ForwardProjectionFilterPointer _arg);
+  SetForwardProjectionFilter(ForwardProjectionFilterType * _arg);
 
   /** Set the support mask, if any, for support constraint in reconstruction */
   void

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -132,7 +132,7 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
 ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWeightsImage>::SetBackProjectionFilter(
-  const typename BackProjectionFilterType::Pointer _arg)
+  BackProjectionFilterType * _arg)
 {
   m_BackProjectionFilter = _arg;
 }
@@ -140,7 +140,7 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
 template <typename TOutputImage, typename TSingleComponentImage, typename TWeightsImage>
 void
 ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWeightsImage>::SetForwardProjectionFilter(
-  const typename ForwardProjectionFilterType::Pointer _arg)
+  ForwardProjectionFilterType * _arg)
 {
   m_ForwardProjectionFilter = _arg;
 }

--- a/include/rtkWarpFourDToProjectionStackImageFilter.h
+++ b/include/rtkWarpFourDToProjectionStackImageFilter.h
@@ -144,7 +144,7 @@ public:
 
   /** The forward projection filter cannot be set by the user */
   void
-  SetForwardProjectionFilter(const typename Superclass::ForwardProjectionFilterType::Pointer itkNotUsed(_arg))
+  SetForwardProjectionFilter(typename Superclass::ForwardProjectionFilterType * itkNotUsed(_arg))
   {
     itkExceptionMacro(<< "ForwardProjection cannot be changed");
   }

--- a/include/rtkWarpProjectionStackToFourDImageFilter.h
+++ b/include/rtkWarpProjectionStackToFourDImageFilter.h
@@ -138,7 +138,7 @@ public:
 
   /** The back projection filter cannot be set by the user */
   void
-  SetBackProjectionFilter(const typename Superclass::BackProjectionFilterType::Pointer itkNotUsed(_arg))
+  SetBackProjectionFilter(typename Superclass::BackProjectionFilterType * itkNotUsed(_arg))
   {
     itkExceptionMacro(<< "BackProjection cannot be changed");
   }


### PR DESCRIPTION
All instances have been found with
grep -rE Set.*Pointer.* include/*h

Fixes #637 