### PR TITLE
COMP: Remove CMake warning related to ITK_USE_CONCEPT_CHECKING

### DIFF
--- a/documentation/Doxygen/doxygen.config.in
+++ b/documentation/Doxygen/doxygen.config.in
@@ -2167,7 +2167,6 @@ PREDEFINED             = "itkNotUsed(x)=" \
                          "size_t=vcl_size_t" \
                          "ITK_USE_FFTWD" \
                          "ITK_USE_FFTWF" \
-                         "ITK_USE_CONCEPT_CHECKING" \
                          "itkMacro_h" \
                          "ITK_LEGACY_REMOVE" \
                          "ITK_FUTURE_LEGACY_REMOVE" \

--- a/include/rtkElektaSynergyRawLookupTableImageFilter.h
+++ b/include/rtkElektaSynergyRawLookupTableImageFilter.h
@@ -62,10 +62,8 @@ public:
   /** Runtime information support. */
   itkOverrideGetNameOfClassMacro(ElektaSynergyRawLookupTableImageFilter);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(SameTypeCheck, (itk::Concept::SameType<InputImagePixelType, unsigned short>));
-#endif
 
 protected:
   ElektaSynergyRawLookupTableImageFilter();

--- a/include/rtkFFTProjectionsConvolutionImageFilter.h
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.h
@@ -113,9 +113,7 @@ public:
     }
   }
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   itkConceptMacro(ImageDimensionCheck, (itk::Concept::SameDimensionOrMinusOne<Self::InputImageDimension, 3>));
-#endif
 
 protected:
   FFTProjectionsConvolutionImageFilter();

--- a/include/rtkForwardDifferenceGradientImageFilter.h
+++ b/include/rtkForwardDifferenceGradientImageFilter.h
@@ -129,12 +129,10 @@ public:
   void
   OverrideBoundaryCondition(itk::ImageBoundaryCondition<TInputImage> * boundaryCondition);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(InputConvertibleToOutputCheck, (itk::Concept::Convertible<InputPixelType, OutputValueType>));
   itkConceptMacro(OutputHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<OutputValueType>));
   // End concept checking
-#endif
 
   /** The UseImageDirection flag determines whether image derivatives are
    * computed with respect to the image grid or with respect to the physical

--- a/include/rtkMagnitudeThresholdImageFilter.h
+++ b/include/rtkMagnitudeThresholdImageFilter.h
@@ -79,12 +79,10 @@ public:
   /** Superclass type alias. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(InputHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<typename InputPixelType::ValueType>));
   itkConceptMacro(RealTypeHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<RealType>));
   /** End concept checking */
-#endif
 
   itkGetMacro(Threshold, TRealType);
   itkSetMacro(Threshold, TRealType);

--- a/include/rtkSingularValueThresholdImageFilter.h
+++ b/include/rtkSingularValueThresholdImageFilter.h
@@ -89,12 +89,10 @@ public:
   /** Superclass type alias. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(InputHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<typename InputPixelType::ValueType>));
   itkConceptMacro(RealTypeHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<RealType>));
   /** End concept checking */
-#endif
 
   itkGetMacro(Threshold, TRealType);
   itkSetMacro(Threshold, TRealType);

--- a/include/rtkSoftThresholdImageFilter.h
+++ b/include/rtkSoftThresholdImageFilter.h
@@ -116,14 +116,12 @@ public:
   virtual void
   SetThreshold(const InputPixelType threshold);
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(OutputEqualityComparableCheck, (itk::Concept::EqualityComparable<OutputPixelType>));
   itkConceptMacro(InputPixelTypeComparable, (itk::Concept::Comparable<InputPixelType>));
   itkConceptMacro(InputOStreamWritableCheck, (itk::Concept::OStreamWritable<InputPixelType>));
   itkConceptMacro(OutputOStreamWritableCheck, (itk::Concept::OStreamWritable<OutputPixelType>));
   /** End concept checking */
-#endif
 
 protected:
   SoftThresholdImageFilter();

--- a/include/rtkSoftThresholdTVImageFilter.h
+++ b/include/rtkSoftThresholdTVImageFilter.h
@@ -79,11 +79,9 @@ public:
   /** Superclass type alias. */
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
   itkConceptMacro(InputHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<typename InputPixelType::ValueType>));
   /** End concept checking */
-#endif
 
   itkGetMacro(Threshold, float);
   itkSetMacro(Threshold, float);

--- a/include/rtkTotalVariationImageFilter.h
+++ b/include/rtkTotalVariationImageFilter.h
@@ -104,11 +104,9 @@ public:
   DataObjectPointer
   MakeOutput(DataObjectPointerArraySizeType output) override;
 
-#ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro(InputHasNumericTraitsCheck, (itk::Concept::HasNumericTraits<PixelType>));
   // End concept checking
-#endif
 
   /** Use the image spacing information in calculations. Use this option if you
    *  want derivatives in physical space. Default is UseImageSpacingOn. */


### PR DESCRIPTION
The warning has been introduced by
InsightSoftwareConsortium/ITK@9e582fd86c04cd003566d4d9907cd0a15f51111f