### PR TITLE
Rename spectral inputs

### DIFF
--- a/applications/rtkspectralonestep/rtkspectralonestep.cxx
+++ b/applications/rtkspectralonestep/rtkspectralonestep.cxx
@@ -188,7 +188,7 @@ rtkspectralonestep(const args_info_rtkspectralonestep & args_info)
   SetForwardProjectionFromGgo(args_info, mechlemOneStep.GetPointer());
   SetBackProjectionFromGgo(args_info, mechlemOneStep.GetPointer());
   mechlemOneStep->SetInputMaterialVolumes(input);
-  mechlemOneStep->SetInputSpectrum(incidentSpectrum);
+  mechlemOneStep->SetInputIncidentSpectrum(incidentSpectrum);
   mechlemOneStep->SetBinnedDetectorResponse(drm);
   mechlemOneStep->SetMaterialAttenuations(materialAttenuationsMatrix);
   mechlemOneStep->SetNumberOfIterations(args_info.niterations_arg);
@@ -201,7 +201,7 @@ rtkspectralonestep(const args_info_rtkspectralonestep & args_info)
     mechlemOneStep->SetSupportMask(supportmask);
   if (args_info.regul_spatial_weights_given)
     mechlemOneStep->SetSpatialRegularizationWeights(spatialRegulWeighs);
-  mechlemOneStep->SetInputPhotonCounts(photonCounts);
+  mechlemOneStep->SetInputMeasuredProjections(photonCounts);
   mechlemOneStep->SetGeometry(geometry);
   if (args_info.projection_weights_given)
     mechlemOneStep->SetProjectionWeights(projectionWeights);

--- a/include/rtkCudaWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.hxx
@@ -41,7 +41,8 @@ CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjection
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GPUGenerateData()
+CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GPUGenerateData()
 {
   this->AllocateOutputs();
 
@@ -71,21 +72,26 @@ CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjection
 #  endif
 
   // Run the forward projection with a slab of SLAB_SIZE or less projections
-  CUDA_WeidingerForwardModel(
-    projectionSize,
-    this->m_MaterialAttenuations.data_block(),
-    this->m_BinnedDetectorResponse.data_block(),
-    pMatProj,
-    pPhoCount,
-    pSpectrum,
-    pProjOnes,
-    pOut1,
-    pOut2,
-    CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::nBins,
-    nEnergies,
-    CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::nMaterials,
-    this->m_NumberOfProjectionsInIncidentSpectrum,
-    this->GetInputMeasuredProjections()->GetBufferedRegion().GetIndex(Dimension - 1));
+  CUDA_WeidingerForwardModel(projectionSize,
+                             this->m_MaterialAttenuations.data_block(),
+                             this->m_BinnedDetectorResponse.data_block(),
+                             pMatProj,
+                             pPhoCount,
+                             pSpectrum,
+                             pProjOnes,
+                             pOut1,
+                             pOut2,
+                             CudaWeidingerForwardModelImageFilter<TDecomposedProjections,
+                                                                  TMeasuredProjections,
+                                                                  TIncidentSpectrum,
+                                                                  TProjections>::nBins,
+                             nEnergies,
+                             CudaWeidingerForwardModelImageFilter<TDecomposedProjections,
+                                                                  TMeasuredProjections,
+                                                                  TIncidentSpectrum,
+                                                                  TProjections>::nMaterials,
+                             this->m_NumberOfProjectionsInIncidentSpectrum,
+                             this->GetInputMeasuredProjections()->GetBufferedRegion().GetIndex(Dimension - 1));
 }
 
 } // end namespace rtk

--- a/include/rtkCudaWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkCudaWeidingerForwardModelImageFilter.hxx
@@ -34,37 +34,37 @@
 namespace rtk
 {
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   CudaWeidingerForwardModelImageFilter()
 {}
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::GPUGenerateData()
+CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GPUGenerateData()
 {
   this->AllocateOutputs();
 
-  const unsigned int Dimension = TMaterialProjections::ImageDimension;
+  const unsigned int Dimension = TDecomposedProjections::ImageDimension;
   unsigned int       nEnergies = this->m_MaterialAttenuations.rows();
 
   // Get the size of the input projections in a Cuda-convenient format
   int projectionSize[Dimension];
   for (unsigned int d = 0; d < Dimension; d++)
-    projectionSize[d] = this->GetInputMaterialProjections()->GetBufferedRegion().GetSize()[d];
+    projectionSize[d] = this->GetInputDecomposedProjections()->GetBufferedRegion().GetSize()[d];
 
   // Pointers to inputs and outputs
 #  ifdef CUDACOMMON_VERSION_MAJOR
-  float * pMatProj = (float *)(this->GetInputMaterialProjections()->GetCudaDataManager()->GetGPUBufferPointer());
-  float * pPhoCount = (float *)(this->GetInputPhotonCounts()->GetCudaDataManager()->GetGPUBufferPointer());
-  float * pSpectrum = (float *)(this->GetInputSpectrum()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pMatProj = (float *)(this->GetInputDecomposedProjections()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pPhoCount = (float *)(this->GetInputMeasuredProjections()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pSpectrum = (float *)(this->GetInputIncidentSpectrum()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pProjOnes = (float *)(this->GetInputProjectionsOfOnes()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pOut1 = (float *)(this->GetOutput1()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pOut2 = (float *)(this->GetOutput2()->GetCudaDataManager()->GetGPUBufferPointer());
 #  else
-  float * pMatProj = *(float **)(this->GetInputMaterialProjections()->GetCudaDataManager()->GetGPUBufferPointer());
-  float * pPhoCount = *(float **)(this->GetInputPhotonCounts()->GetCudaDataManager()->GetGPUBufferPointer());
-  float * pSpectrum = *(float **)(this->GetInputSpectrum()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pMatProj = *(float **)(this->GetInputDecomposedProjections()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pPhoCount = *(float **)(this->GetInputMeasuredProjections()->GetCudaDataManager()->GetGPUBufferPointer());
+  float * pSpectrum = *(float **)(this->GetInputIncidentSpectrum()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pProjOnes = *(float **)(this->GetInputProjectionsOfOnes()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pOut1 = *(float **)(this->GetOutput1()->GetCudaDataManager()->GetGPUBufferPointer());
   float * pOut2 = *(float **)(this->GetOutput2()->GetCudaDataManager()->GetGPUBufferPointer());
@@ -81,11 +81,11 @@ CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpect
     pProjOnes,
     pOut1,
     pOut2,
-    CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::nBins,
+    CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::nBins,
     nEnergies,
-    CudaWeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::nMaterials,
-    this->m_NumberOfProjectionsInSpectrum,
-    this->GetInputPhotonCounts()->GetBufferedRegion().GetIndex(Dimension - 1));
+    CudaWeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::nMaterials,
+    this->m_NumberOfProjectionsInIncidentSpectrum,
+    this->GetInputMeasuredProjections()->GetBufferedRegion().GetIndex(Dimension - 1));
 }
 
 } // end namespace rtk

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.h
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.h
@@ -192,9 +192,10 @@ public:
 
 #if !defined(ITK_WRAPPING_PARSER)
 #  ifdef RTK_USE_CUDA
-  typedef typename std::conditional<std::is_same<TOutputImage, CPUOutputImageType>::value,
-                                    WeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>,
-                                    CudaWeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>>::type
+  typedef typename std::conditional<
+    std::is_same<TOutputImage, CPUOutputImageType>::value,
+    WeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>,
+    CudaWeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>>::type
     WeidingerForwardModelType;
   typedef
     typename std::conditional<std::is_same<TOutputImage, CPUOutputImageType>::value,
@@ -206,7 +207,8 @@ public:
                                     CudaBackProjectionImageFilter<HessiansImageType>>::type
     CudaHessiansBackProjectionImageFilterType;
 #  else
-  using WeidingerForwardModelType = WeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>;
+  using WeidingerForwardModelType =
+    WeidingerForwardModelImageFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>;
   using CudaSingleComponentForwardProjectionImageFilterType =
     JosephForwardProjectionImageFilter<SingleComponentImageType, SingleComponentImageType>;
   using CudaHessiansBackProjectionImageFilterType = BackProjectionImageFilter<HessiansImageType, HessiansImageType>;
@@ -307,28 +309,28 @@ protected:
 
 #if !defined(ITK_WRAPPING_PARSER)
   /** Member pointers to the filters used internally (for convenience)*/
-  typename ExtractMeasuredProjectionsFilterType::Pointer           m_ExtractMeasuredProjectionsFilter;
-  typename AddFilterType::Pointer                                  m_AddGradients;
-  typename SingleComponentForwardProjectionFilterType::Pointer     m_SingleComponentForwardProjectionFilter;
-  typename MaterialProjectionsSourceType::Pointer                  m_ProjectionsSource;
-  typename SingleComponentImageSourceType::Pointer                 m_SingleComponentProjectionsSource;
-  typename SingleComponentImageSourceType::Pointer                 m_SingleComponentVolumeSource;
-  typename GradientsSourceType::Pointer                            m_GradientsSource;
-  typename HessiansSourceType::Pointer                             m_HessiansSource;
-  typename WeidingerForwardModelType::Pointer                      m_WeidingerForward;
-  typename SQSRegularizationType::Pointer                          m_SQSRegul;
-  typename AddMatrixAndDiagonalFilterType::Pointer                 m_AddHessians;
-  typename NewtonFilterType::Pointer                               m_NewtonFilter;
-  typename NesterovFilterType::Pointer                             m_NesterovFilter;
-  typename ForwardProjectionFilterType::Pointer                    m_ForwardProjectionFilter;
-  typename GradientsBackProjectionFilterType::Pointer              m_GradientsBackProjectionFilter;
-  typename HessiansBackProjectionFilterType::Pointer               m_HessiansBackProjectionFilter;
-  typename MultiplyFilterType::Pointer                             m_MultiplySupportFilter;
-  typename MultiplyGradientFilterType::Pointer                     m_MultiplyRegulGradientsFilter;
-  typename MultiplyGradientFilterType::Pointer                     m_MultiplyRegulHessiansFilter;
-  typename MultiplyGradientFilterType::Pointer                     m_MultiplyGradientToBeBackprojectedFilter;
-  typename ReorderMeasuredProjectionsFilterType::Pointer           m_ReorderMeasuredProjectionsFilter;
-  typename ReorderProjectionsWeightsFilterType::Pointer            m_ReorderProjectionsWeightsFilter;
+  typename ExtractMeasuredProjectionsFilterType::Pointer       m_ExtractMeasuredProjectionsFilter;
+  typename AddFilterType::Pointer                              m_AddGradients;
+  typename SingleComponentForwardProjectionFilterType::Pointer m_SingleComponentForwardProjectionFilter;
+  typename MaterialProjectionsSourceType::Pointer              m_ProjectionsSource;
+  typename SingleComponentImageSourceType::Pointer             m_SingleComponentProjectionsSource;
+  typename SingleComponentImageSourceType::Pointer             m_SingleComponentVolumeSource;
+  typename GradientsSourceType::Pointer                        m_GradientsSource;
+  typename HessiansSourceType::Pointer                         m_HessiansSource;
+  typename WeidingerForwardModelType::Pointer                  m_WeidingerForward;
+  typename SQSRegularizationType::Pointer                      m_SQSRegul;
+  typename AddMatrixAndDiagonalFilterType::Pointer             m_AddHessians;
+  typename NewtonFilterType::Pointer                           m_NewtonFilter;
+  typename NesterovFilterType::Pointer                         m_NesterovFilter;
+  typename ForwardProjectionFilterType::Pointer                m_ForwardProjectionFilter;
+  typename GradientsBackProjectionFilterType::Pointer          m_GradientsBackProjectionFilter;
+  typename HessiansBackProjectionFilterType::Pointer           m_HessiansBackProjectionFilter;
+  typename MultiplyFilterType::Pointer                         m_MultiplySupportFilter;
+  typename MultiplyGradientFilterType::Pointer                 m_MultiplyRegulGradientsFilter;
+  typename MultiplyGradientFilterType::Pointer                 m_MultiplyRegulHessiansFilter;
+  typename MultiplyGradientFilterType::Pointer                 m_MultiplyGradientToBeBackprojectedFilter;
+  typename ReorderMeasuredProjectionsFilterType::Pointer       m_ReorderMeasuredProjectionsFilter;
+  typename ReorderProjectionsWeightsFilterType::Pointer        m_ReorderProjectionsWeightsFilter;
 #endif
 
   /** The inputs of this filter have the same type but not the same meaning

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -66,33 +66,35 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
     itk::NumericTraits<typename TOutputImage::PixelType::ValueType>::ZeroValue());
   m_SingleComponentVolumeSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType::ValueType>::One);
   m_GradientsSource->SetConstant(
-    itk::NumericTraits<typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
-                         GradientsImageType::PixelType>::ZeroValue());
+    itk::NumericTraits<
+      typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+        GradientsImageType::PixelType>::ZeroValue());
   m_HessiansSource->SetConstant(
-    itk::NumericTraits<typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
-                         HessiansImageType::PixelType>::ZeroValue());
+    itk::NumericTraits<
+      typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+        HessiansImageType::PixelType>::ZeroValue());
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetInputMaterialVolumes(
-  const TOutputImage * materialVolumes)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetInputMaterialVolumes(const TOutputImage * materialVolumes)
 {
   this->SetNthInput(0, const_cast<TOutputImage *>(materialVolumes));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetInputMeasuredProjections(
-  const TMeasuredProjections * measuredProjections)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetInputMeasuredProjections(const TMeasuredProjections * measuredProjections)
 {
   this->SetNthInput(1, const_cast<TMeasuredProjections *>(measuredProjections));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetInputIncidentSpectrum(
-  const TIncidentSpectrum * incidentSpectrum)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetInputIncidentSpectrum(const TIncidentSpectrum * incidentSpectrum)
 {
   this->SetNthInput(2, const_cast<TIncidentSpectrum *>(incidentSpectrum));
 }
@@ -125,8 +127,8 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetSpatialRegularizationWeights(
-  const SingleComponentImageType * regweights)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetSpatialRegularizationWeights(const SingleComponentImageType * regweights)
 {
   this->SetNthInput(4, const_cast<SingleComponentImageType *>(regweights));
 }
@@ -141,21 +143,24 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 typename TOutputImage::ConstPointer
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetInputMaterialVolumes()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GetInputMaterialVolumes()
 {
   return static_cast<const TOutputImage *>(this->itk::ProcessObject::GetInput(0));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 typename TMeasuredProjections::ConstPointer
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetInputMeasuredProjections()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GetInputMeasuredProjections()
 {
   return static_cast<const TMeasuredProjections *>(this->itk::ProcessObject::GetInput(1));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 typename TIncidentSpectrum::ConstPointer
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetInputIncidentSpectrum()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GetInputIncidentSpectrum()
 {
   return static_cast<const TIncidentSpectrum *>(this->itk::ProcessObject::GetInput(2));
 }
@@ -163,7 +168,8 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 #ifdef ITK_FUTURE_LEGACY_REMOVE
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 typename TMeasuredProjections::ConstPointer
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetInputPhotonCounts()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GetInputPhotonCounts()
 {
   return this->GetInputMeasuredProjections();
 }
@@ -177,25 +183,27 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 #endif
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
-typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SingleComponentImageType::
-  ConstPointer
+typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SingleComponentImageType::ConstPointer
   MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetSupportMask()
 {
   return static_cast<const SingleComponentImageType *>(this->itk::ProcessObject::GetInput(3));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
-typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SingleComponentImageType::
-  ConstPointer
-  MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetSpatialRegularizationWeights()
+typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SingleComponentImageType::ConstPointer
+  MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+    GetSpatialRegularizationWeights()
 {
   return static_cast<const SingleComponentImageType *>(this->itk::ProcessObject::GetInput(4));
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
-typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SingleComponentImageType::
-  ConstPointer
-  MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GetProjectionWeights()
+typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SingleComponentImageType::ConstPointer
+  MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+    GetProjectionWeights()
 {
   return static_cast<const SingleComponentImageType *>(this->itk::ProcessObject::GetInput(5));
 }
@@ -207,8 +215,9 @@ typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProje
     InstantiateSingleComponentForwardProjectionFilter(int fwtype)
 {
   // Define the type of image to be back projected
-  using TSingleComponent = typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
-    SingleComponentImageType;
+  using TSingleComponent =
+    typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+      SingleComponentImageType;
 
   // Declare the pointer
   typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
@@ -239,8 +248,9 @@ typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProje
     InstantiateHessiansBackProjectionFilter(int bptype)
 {
   // Define the type of image to be back projected
-  using THessians =
-    typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::HessiansImageType;
+  using THessians = typename MechlemOneStepSpectralReconstructionFilter<TOutputImage,
+                                                                        TMeasuredProjections,
+                                                                        TIncidentSpectrum>::HessiansImageType;
 
   // Declare the pointer
   typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
@@ -271,23 +281,24 @@ typename MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProje
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetMaterialAttenuations(
-  const MaterialAttenuationsType & matAtt)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetMaterialAttenuations(const MaterialAttenuationsType & matAtt)
 {
   m_WeidingerForward->SetMaterialAttenuations(matAtt);
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::SetBinnedDetectorResponse(
-  const BinnedDetectorResponseType & detResp)
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  SetBinnedDetectorResponse(const BinnedDetectorResponseType & detResp)
 {
   m_WeidingerForward->SetBinnedDetectorResponse(detResp);
 }
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::VerifyPreconditions() const
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::VerifyPreconditions()
+  const
 {
   this->Superclass::VerifyPreconditions();
 
@@ -297,7 +308,8 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GenerateInputRequestedRegion()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GenerateInputRequestedRegion()
 {
   // Input 0 is the material volumes we update
   typename TOutputImage::Pointer inputPtr0 = const_cast<TOutputImage *>(this->GetInputMaterialVolumes().GetPointer());
@@ -306,13 +318,15 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
   inputPtr0->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
 
   // Input 1 is the photon counts
-  typename TMeasuredProjections::Pointer inputPtr1 = const_cast<TMeasuredProjections *>(this->GetInputMeasuredProjections().GetPointer());
+  typename TMeasuredProjections::Pointer inputPtr1 =
+    const_cast<TMeasuredProjections *>(this->GetInputMeasuredProjections().GetPointer());
   if (!inputPtr1)
     return;
   inputPtr1->SetRequestedRegion(inputPtr1->GetLargestPossibleRegion());
 
   // Input 2 is the incident spectrum
-  typename TIncidentSpectrum::Pointer inputPtr2 = const_cast<TIncidentSpectrum *>(this->GetInputIncidentSpectrum().GetPointer());
+  typename TIncidentSpectrum::Pointer inputPtr2 =
+    const_cast<TIncidentSpectrum *>(this->GetInputIncidentSpectrum().GetPointer());
   if (!inputPtr2)
     return;
   inputPtr2->SetRequestedRegion(inputPtr2->GetLargestPossibleRegion());
@@ -338,7 +352,8 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
 
 template <class TOutputImage, class TMeasuredProjections, class TIncidentSpectrum>
 void
-MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::GenerateOutputInformation()
+MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, TIncidentSpectrum>::
+  GenerateOutputInformation()
 {
   typename TMeasuredProjections::RegionType largest = this->GetInputMeasuredProjections()->GetLargestPossibleRegion();
   m_NumberOfProjections = largest.GetSize()[TMeasuredProjections::ImageDimension - 1];
@@ -526,10 +541,12 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
       for (int i = 0; i < m_NumberOfProjectionsInSubset[subset]; i += NProjPerExtract)
       {
         // Set the extract filter's region
-        typename TMeasuredProjections::RegionType extractionRegion = this->GetInputMeasuredProjections()->GetLargestPossibleRegion();
+        typename TMeasuredProjections::RegionType extractionRegion =
+          this->GetInputMeasuredProjections()->GetLargestPossibleRegion();
         extractionRegion.SetSize(TMeasuredProjections::ImageDimension - 1,
                                  std::min(NProjPerExtract, m_NumberOfProjectionsInSubset[subset] - i));
-        extractionRegion.SetIndex(TMeasuredProjections::ImageDimension - 1, subset * m_NumberOfProjectionsPerSubset + i);
+        extractionRegion.SetIndex(TMeasuredProjections::ImageDimension - 1,
+                                  subset * m_NumberOfProjectionsPerSubset + i);
         m_ExtractMeasuredProjectionsFilter->SetExtractionRegion(extractionRegion);
         m_ExtractMeasuredProjectionsFilter->UpdateOutputInformation();
 

--- a/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
+++ b/include/rtkMechlemOneStepSpectralReconstructionFilter.hxx
@@ -397,9 +397,9 @@ MechlemOneStepSpectralReconstructionFilter<TOutputImage, TMeasuredProjections, T
   m_SingleComponentForwardProjectionFilter->SetInput(0, m_SingleComponentProjectionsSource->GetOutput());
   m_SingleComponentForwardProjectionFilter->SetInput(1, m_SingleComponentVolumeSource->GetOutput());
 
-  m_WeidingerForward->SetInputMaterialProjections(m_ForwardProjectionFilter->GetOutput());
-  m_WeidingerForward->SetInputPhotonCounts(m_ExtractMeasuredProjectionsFilter->GetOutput());
-  m_WeidingerForward->SetInputSpectrum(this->GetInputIncidentSpectrum());
+  m_WeidingerForward->SetInputDecomposedProjections(m_ForwardProjectionFilter->GetOutput());
+  m_WeidingerForward->SetInputMeasuredProjections(m_ExtractMeasuredProjectionsFilter->GetOutput());
+  m_WeidingerForward->SetInputIncidentSpectrum(this->GetInputIncidentSpectrum());
   m_WeidingerForward->SetInputProjectionsOfOnes(m_SingleComponentForwardProjectionFilter->GetOutput());
 
   m_GradientsBackProjectionFilter->SetInput(0, m_GradientsSource->GetOutput());

--- a/include/rtkWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkWeidingerForwardModelImageFilter.hxx
@@ -26,8 +26,8 @@ namespace rtk
 //
 // Constructor
 //
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   WeidingerForwardModelImageFilter()
 {
   this->SetNumberOfRequiredInputs(4);
@@ -36,71 +36,121 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
   this->SetNthOutput(1, this->MakeOutput(1));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
-  SetInputMaterialProjections(const TMaterialProjections * materialProjections)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputDecomposedProjections(const TDecomposedProjections * decomposedProjections)
 {
-  this->SetNthInput(0, const_cast<TMaterialProjections *>(materialProjections));
+  this->SetNthInput(0, const_cast<TDecomposedProjections *>(decomposedProjections));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::SetInputPhotonCounts(
-  const TPhotonCounts * photonCounts)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputMeasuredProjections(
+  const TMeasuredProjections * measuredProjections)
 {
-  this->SetNthInput(1, const_cast<TPhotonCounts *>(photonCounts));
+  this->SetNthInput(1, const_cast<TMeasuredProjections *>(measuredProjections));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::SetInputSpectrum(
-  const TSpectrum * spectrum)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputIncidentSpectrum(
+  const TIncidentSpectrum * incidentSpectrum)
 {
-  this->SetNthInput(2, const_cast<TSpectrum *>(spectrum));
+  this->SetNthInput(2, const_cast<TIncidentSpectrum *>(incidentSpectrum));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+#ifdef ITK_FUTURE_LEGACY_REMOVED
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+  WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputMaterialProjections(const TDecomposedProjections * decomposedProjections)
+{
+  this->SetInputDecomposedProjections(decomposedProjections);
+}
+
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+void
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputPhotonCounts(
+  const TMeasuredProjections * measuredProjections)
+{
+  this->SetInputMeasuredProjections(measuredProjections);
+}
+
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+void
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputSpectrum(
+  const TIncidentSpectrum * incidentSpectrum)
+{
+  this->SetInputIncidentSpectrum(incidentSpectrum);
+}
+#endif
+
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+void
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   SetInputProjectionsOfOnes(const TProjections * projectionsOfOnes)
 {
   this->SetNthInput(3, const_cast<TProjections *>(projectionsOfOnes));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-typename TMaterialProjections::ConstPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TDecomposedProjections::ConstPointer
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetInputDecomposedProjections()
+{
+  return static_cast<const TDecomposedProjections *>(this->itk::ProcessObject::GetInput(0));
+}
+
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TMeasuredProjections::ConstPointer
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputMeasuredProjections()
+{
+  return static_cast<const TMeasuredProjections *>(this->itk::ProcessObject::GetInput(1));
+}
+
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TIncidentSpectrum::ConstPointer
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputIncidentSpectrum()
+{
+  return static_cast<const TIncidentSpectrum *>(this->itk::ProcessObject::GetInput(2));
+}
+
+#ifdef ITK_FUTURE_LEGACY_REMOVED
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TDecomposedProjections::ConstPointer
+  WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   GetInputMaterialProjections()
 {
-  return static_cast<const TMaterialProjections *>(this->itk::ProcessObject::GetInput(0));
+  return this->GetInputDecomposedProjections();
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-typename TPhotonCounts::ConstPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::GetInputPhotonCounts()
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TMeasuredProjections::ConstPointer
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputPhotonCounts()
 {
-  return static_cast<const TPhotonCounts *>(this->itk::ProcessObject::GetInput(1));
+  return this->GetInputMeasuredProjections();
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-typename TSpectrum::ConstPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::GetInputSpectrum()
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename TIncidentSpectrum::ConstPointer
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputSpectrum()
 {
-  return static_cast<const TSpectrum *>(this->itk::ProcessObject::GetInput(2));
+  return this->GetInputIncidentSpectrum();
 }
+#endif
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TProjections::ConstPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   GetInputProjectionsOfOnes()
 {
   return static_cast<const TProjections *>(this->itk::ProcessObject::GetInput(3));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 itk::ProcessObject::DataObjectPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::MakeOutput(
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::MakeOutput(
   itk::ProcessObject::DataObjectPointerArraySizeType idx)
 {
   itk::DataObject::Pointer output;
@@ -121,31 +171,31 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
   return output.GetPointer();
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 itk::ProcessObject::DataObjectPointer
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::MakeOutput(
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::MakeOutput(
   const itk::ProcessObject::DataObjectIdentifierType & idx)
 {
   return Superclass::MakeOutput(idx);
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-typename WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::TOutputImage1 *
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::GetOutput1()
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::TOutputImage1 *
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetOutput1()
 {
   return dynamic_cast<TOutputImage1 *>(this->itk::ProcessObject::GetOutput(0));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
-typename WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::TOutputImage2 *
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::GetOutput2()
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
+typename WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::TOutputImage2 *
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetOutput2()
 {
   return dynamic_cast<TOutputImage2 *>(this->itk::ProcessObject::GetOutput(1));
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   SetBinnedDetectorResponse(const BinnedDetectorResponseType & detResp)
 {
   bool modified = false;
@@ -175,9 +225,9 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
   }
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::SetMaterialAttenuations(
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetMaterialAttenuations(
   const MaterialAttenuationsType & matAtt)
 {
   bool modified = false;
@@ -207,9 +257,9 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
   }
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   GenerateInputRequestedRegion()
 {
   // Call the superclass' implementation of this method
@@ -223,10 +273,10 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
       << "In rtkWeidingerForwardModelImageFilter: requested regions for outputs 1 and 2 should be identical");
 
   // Get pointers to the inputs
-  typename TMaterialProjections::Pointer input1Ptr =
-    const_cast<TMaterialProjections *>(this->GetInputMaterialProjections().GetPointer());
-  typename TPhotonCounts::Pointer input2Ptr = const_cast<TPhotonCounts *>(this->GetInputPhotonCounts().GetPointer());
-  typename TSpectrum::Pointer     input3Ptr = const_cast<TSpectrum *>(this->GetInputSpectrum().GetPointer());
+  typename TDecomposedProjections::Pointer input1Ptr =
+    const_cast<TDecomposedProjections *>(this->GetInputDecomposedProjections().GetPointer());
+  typename TMeasuredProjections::Pointer input2Ptr = const_cast<TMeasuredProjections *>(this->GetInputMeasuredProjections().GetPointer());
+  typename TIncidentSpectrum::Pointer     input3Ptr = const_cast<TIncidentSpectrum *>(this->GetInputIncidentSpectrum().GetPointer());
   typename TProjections::Pointer input4Ptr = const_cast<TProjections *>(this->GetInputProjectionsOfOnes().GetPointer());
 
   // The first and second input must have the same requested region as the outputs
@@ -239,56 +289,56 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
   // dimension may be an integer multiple of projections to treat, e.g., even
   // and odd projections for fast-switching.
   // Compute the requested region for the spectrum
-  typename TSpectrum::RegionType spectrumRegion = input3Ptr->GetLargestPossibleRegion();
-  for (unsigned int d = 0; d < TSpectrum::ImageDimension - 1; d++)
+  typename TIncidentSpectrum::RegionType spectrumRegion = input3Ptr->GetLargestPossibleRegion();
+  for (unsigned int d = 0; d < TIncidentSpectrum::ImageDimension - 1; d++)
   {
     spectrumRegion.SetIndex(d + 1, outputRequested1.GetIndex()[d]);
     spectrumRegion.SetSize(d + 1, outputRequested1.GetSize()[d]);
   }
-  const itk::SizeValueType nRowsSpectrum = input3Ptr->GetLargestPossibleRegion().GetSize(TSpectrum::ImageDimension - 1);
-  const itk::SizeValueType nRowsPhotonCounts =
-    input2Ptr->GetLargestPossibleRegion().GetSize(TPhotonCounts::ImageDimension - 2);
-  if (nRowsSpectrum % nRowsPhotonCounts != 0)
+  const itk::SizeValueType nRowsIncidentSpectrum = input3Ptr->GetLargestPossibleRegion().GetSize(TIncidentSpectrum::ImageDimension - 1);
+  const itk::SizeValueType nRowsMeasuredProjections =
+    input2Ptr->GetLargestPossibleRegion().GetSize(TMeasuredProjections::ImageDimension - 2);
+  if (nRowsIncidentSpectrum % nRowsMeasuredProjections != 0)
     itkGenericExceptionMacro("The number of rows of the spectrum must be equal to the number of rows of the input "
                              "projections times an integer number of projections");
-  m_NumberOfProjectionsInSpectrum = nRowsSpectrum / nRowsPhotonCounts;
-  spectrumRegion.SetSize(TSpectrum::ImageDimension - 1,
-                         spectrumRegion.GetSize(TSpectrum::ImageDimension - 1) +
-                           nRowsPhotonCounts * (m_NumberOfProjectionsInSpectrum - 1));
+  m_NumberOfProjectionsInIncidentSpectrum = nRowsIncidentSpectrum / nRowsMeasuredProjections;
+  spectrumRegion.SetSize(TIncidentSpectrum::ImageDimension - 1,
+                         spectrumRegion.GetSize(TIncidentSpectrum::ImageDimension - 1) +
+                           nRowsMeasuredProjections * (m_NumberOfProjectionsInIncidentSpectrum - 1));
 
   // Set the requested region for the spectrum
   input3Ptr->SetRequestedRegion(spectrumRegion);
 }
 
-template <class TMaterialProjections, class TPhotonCounts, class TSpectrum, class TProjections>
+template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   DynamicThreadedGenerateData(const typename TOutputImage1::RegionType & outputRegionForThread)
 {
   // Create the region corresponding to outputRegionForThread for the spectrum input
-  typename TSpectrum::RegionType spectrumRegion = this->GetInputSpectrum()->GetLargestPossibleRegion();
-  for (unsigned int d = 0; d < TSpectrum::ImageDimension - 1; d++)
+  typename TIncidentSpectrum::RegionType spectrumRegion = this->GetInputIncidentSpectrum()->GetLargestPossibleRegion();
+  for (unsigned int d = 0; d < TIncidentSpectrum::ImageDimension - 1; d++)
   {
     spectrumRegion.SetIndex(d + 1, outputRegionForThread.GetIndex()[d]);
     spectrumRegion.SetSize(d + 1, outputRegionForThread.GetSize()[d]);
   }
-  const itk::SizeValueType nRowsPhotonCounts =
-    this->GetOutput2()->GetLargestPossibleRegion().GetSize(TPhotonCounts::ImageDimension - 2);
+  const itk::SizeValueType nRowsMeasuredProjections =
+    this->GetOutput2()->GetLargestPossibleRegion().GetSize(TMeasuredProjections::ImageDimension - 2);
   itk::IndexValueType spectrumProjIndex =
-    outputRegionForThread.GetIndex()[TPhotonCounts::ImageDimension - 1] % m_NumberOfProjectionsInSpectrum;
-  spectrumRegion.SetIndex(TSpectrum::ImageDimension - 1,
-                          spectrumRegion.GetIndex(TSpectrum::ImageDimension - 1) +
-                            nRowsPhotonCounts * spectrumProjIndex);
+    outputRegionForThread.GetIndex()[TMeasuredProjections::ImageDimension - 1] % m_NumberOfProjectionsInIncidentSpectrum;
+  spectrumRegion.SetIndex(TIncidentSpectrum::ImageDimension - 1,
+                          spectrumRegion.GetIndex(TIncidentSpectrum::ImageDimension - 1) +
+                            nRowsMeasuredProjections * spectrumProjIndex);
 
   unsigned int nEnergies = spectrumRegion.GetSize()[0];
 
   // Create iterators for all inputs and outputs
   itk::ImageRegionIterator<TOutputImage1>             out1It(this->GetOutput1(), outputRegionForThread);
   itk::ImageRegionIterator<TOutputImage2>             out2It(this->GetOutput2(), outputRegionForThread);
-  itk::ImageRegionConstIterator<TMaterialProjections> projIt(this->GetInputMaterialProjections(),
+  itk::ImageRegionConstIterator<TDecomposedProjections> projIt(this->GetInputDecomposedProjections(),
                                                              outputRegionForThread);
-  itk::ImageRegionConstIterator<TPhotonCounts> photonCountsIt(this->GetInputPhotonCounts(), outputRegionForThread);
-  itk::ImageRegionConstIterator<TSpectrum>     spectrumIt(this->GetInputSpectrum(), spectrumRegion);
+  itk::ImageRegionConstIterator<TMeasuredProjections> MeasuredProjectionsIt(this->GetInputMeasuredProjections(), outputRegionForThread);
+  itk::ImageRegionConstIterator<TIncidentSpectrum>     spectrumIt(this->GetInputIncidentSpectrum(), spectrumRegion);
   itk::ImageRegionConstIterator<TProjections>  projOfOnesIt(this->GetInputProjectionsOfOnes(), outputRegionForThread);
 
   // Declare intermediate variables
@@ -310,10 +360,10 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
     if (spectrumIt.IsAtEnd())
     {
       spectrumProjIndex++;
-      spectrumProjIndex %= m_NumberOfProjectionsInSpectrum;
-      spectrumRegion.SetIndex(TSpectrum::ImageDimension - 1,
-                              outputRegionForThread.GetIndex()[TPhotonCounts::ImageDimension - 2] +
-                                nRowsPhotonCounts * spectrumProjIndex);
+      spectrumProjIndex %= m_NumberOfProjectionsInIncidentSpectrum;
+      spectrumRegion.SetIndex(TIncidentSpectrum::ImageDimension - 1,
+                              outputRegionForThread.GetIndex()[TMeasuredProjections::ImageDimension - 2] +
+                                nRowsMeasuredProjections * spectrumProjIndex);
       spectrumIt.SetRegion(spectrumRegion);
       spectrumIt.GoToBegin();
     }
@@ -340,7 +390,7 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
 
     // Get intermediate variables used in the computation of the first output
     for (unsigned int r = 0; r < nBins; r++)
-      oneMinusRatios[r] = 1 - (photonCountsIt.Get()[r] / expectedCounts[r]);
+      oneMinusRatios[r] = 1 - (MeasuredProjectionsIt.Get()[r] / expectedCounts[r]);
 
     // Form an intermediate variable used for the gradient of the cost function,
     // (the derivation of the exponential implies that a m_MaterialAttenuations
@@ -396,7 +446,7 @@ WeidingerForwardModelImageFilter<TMaterialProjections, TPhotonCounts, TSpectrum,
     ++out1It;
     ++out2It;
     ++projIt;
-    ++photonCountsIt;
+    ++MeasuredProjectionsIt;
     ++projOfOnesIt;
   }
 }

--- a/include/rtkWeidingerForwardModelImageFilter.hxx
+++ b/include/rtkWeidingerForwardModelImageFilter.hxx
@@ -46,16 +46,16 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputMeasuredProjections(
-  const TMeasuredProjections * measuredProjections)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputMeasuredProjections(const TMeasuredProjections * measuredProjections)
 {
   this->SetNthInput(1, const_cast<TMeasuredProjections *>(measuredProjections));
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputIncidentSpectrum(
-  const TIncidentSpectrum * incidentSpectrum)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputIncidentSpectrum(const TIncidentSpectrum * incidentSpectrum)
 {
   this->SetNthInput(2, const_cast<TIncidentSpectrum *>(incidentSpectrum));
 }
@@ -63,7 +63,7 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 #ifdef ITK_FUTURE_LEGACY_REMOVED
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-  WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   SetInputMaterialProjections(const TDecomposedProjections * decomposedProjections)
 {
   this->SetInputDecomposedProjections(decomposedProjections);
@@ -71,16 +71,16 @@ void
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputPhotonCounts(
-  const TMeasuredProjections * measuredProjections)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputPhotonCounts(const TMeasuredProjections * measuredProjections)
 {
   this->SetInputMeasuredProjections(measuredProjections);
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetInputSpectrum(
-  const TIncidentSpectrum * incidentSpectrum)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetInputSpectrum(const TIncidentSpectrum * incidentSpectrum)
 {
   this->SetInputIncidentSpectrum(incidentSpectrum);
 }
@@ -104,14 +104,16 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TMeasuredProjections::ConstPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputMeasuredProjections()
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetInputMeasuredProjections()
 {
   return static_cast<const TMeasuredProjections *>(this->itk::ProcessObject::GetInput(1));
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TIncidentSpectrum::ConstPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputIncidentSpectrum()
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetInputIncidentSpectrum()
 {
   return static_cast<const TIncidentSpectrum *>(this->itk::ProcessObject::GetInput(2));
 }
@@ -119,7 +121,7 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 #ifdef ITK_FUTURE_LEGACY_REMOVED
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TDecomposedProjections::ConstPointer
-  WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
   GetInputMaterialProjections()
 {
   return this->GetInputDecomposedProjections();
@@ -127,14 +129,16 @@ typename TDecomposedProjections::ConstPointer
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TMeasuredProjections::ConstPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputPhotonCounts()
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetInputPhotonCounts()
 {
   return this->GetInputMeasuredProjections();
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 typename TIncidentSpectrum::ConstPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetInputSpectrum()
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetInputSpectrum()
 {
   return this->GetInputIncidentSpectrum();
 }
@@ -150,8 +154,8 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 itk::ProcessObject::DataObjectPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::MakeOutput(
-  itk::ProcessObject::DataObjectPointerArraySizeType idx)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  MakeOutput(itk::ProcessObject::DataObjectPointerArraySizeType idx)
 {
   itk::DataObject::Pointer output;
 
@@ -173,22 +177,30 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 itk::ProcessObject::DataObjectPointer
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::MakeOutput(
-  const itk::ProcessObject::DataObjectIdentifierType & idx)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  MakeOutput(const itk::ProcessObject::DataObjectIdentifierType & idx)
 {
   return Superclass::MakeOutput(idx);
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
-typename WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::TOutputImage1 *
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetOutput1()
+typename WeidingerForwardModelImageFilter<TDecomposedProjections,
+                                          TMeasuredProjections,
+                                          TIncidentSpectrum,
+                                          TProjections>::TOutputImage1 *
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetOutput1()
 {
   return dynamic_cast<TOutputImage1 *>(this->itk::ProcessObject::GetOutput(0));
 }
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
-typename WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::TOutputImage2 *
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::GetOutput2()
+typename WeidingerForwardModelImageFilter<TDecomposedProjections,
+                                          TMeasuredProjections,
+                                          TIncidentSpectrum,
+                                          TProjections>::TOutputImage2 *
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  GetOutput2()
 {
   return dynamic_cast<TOutputImage2 *>(this->itk::ProcessObject::GetOutput(1));
 }
@@ -227,8 +239,8 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
 
 template <class TDecomposedProjections, class TMeasuredProjections, class TIncidentSpectrum, class TProjections>
 void
-WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::SetMaterialAttenuations(
-  const MaterialAttenuationsType & matAtt)
+WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>::
+  SetMaterialAttenuations(const MaterialAttenuationsType & matAtt)
 {
   bool modified = false;
 
@@ -275,8 +287,10 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
   // Get pointers to the inputs
   typename TDecomposedProjections::Pointer input1Ptr =
     const_cast<TDecomposedProjections *>(this->GetInputDecomposedProjections().GetPointer());
-  typename TMeasuredProjections::Pointer input2Ptr = const_cast<TMeasuredProjections *>(this->GetInputMeasuredProjections().GetPointer());
-  typename TIncidentSpectrum::Pointer     input3Ptr = const_cast<TIncidentSpectrum *>(this->GetInputIncidentSpectrum().GetPointer());
+  typename TMeasuredProjections::Pointer input2Ptr =
+    const_cast<TMeasuredProjections *>(this->GetInputMeasuredProjections().GetPointer());
+  typename TIncidentSpectrum::Pointer input3Ptr =
+    const_cast<TIncidentSpectrum *>(this->GetInputIncidentSpectrum().GetPointer());
   typename TProjections::Pointer input4Ptr = const_cast<TProjections *>(this->GetInputProjectionsOfOnes().GetPointer());
 
   // The first and second input must have the same requested region as the outputs
@@ -295,7 +309,8 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
     spectrumRegion.SetIndex(d + 1, outputRequested1.GetIndex()[d]);
     spectrumRegion.SetSize(d + 1, outputRequested1.GetSize()[d]);
   }
-  const itk::SizeValueType nRowsIncidentSpectrum = input3Ptr->GetLargestPossibleRegion().GetSize(TIncidentSpectrum::ImageDimension - 1);
+  const itk::SizeValueType nRowsIncidentSpectrum =
+    input3Ptr->GetLargestPossibleRegion().GetSize(TIncidentSpectrum::ImageDimension - 1);
   const itk::SizeValueType nRowsMeasuredProjections =
     input2Ptr->GetLargestPossibleRegion().GetSize(TMeasuredProjections::ImageDimension - 2);
   if (nRowsIncidentSpectrum % nRowsMeasuredProjections != 0)
@@ -324,8 +339,8 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
   }
   const itk::SizeValueType nRowsMeasuredProjections =
     this->GetOutput2()->GetLargestPossibleRegion().GetSize(TMeasuredProjections::ImageDimension - 2);
-  itk::IndexValueType spectrumProjIndex =
-    outputRegionForThread.GetIndex()[TMeasuredProjections::ImageDimension - 1] % m_NumberOfProjectionsInIncidentSpectrum;
+  itk::IndexValueType spectrumProjIndex = outputRegionForThread.GetIndex()[TMeasuredProjections::ImageDimension - 1] %
+                                          m_NumberOfProjectionsInIncidentSpectrum;
   spectrumRegion.SetIndex(TIncidentSpectrum::ImageDimension - 1,
                           spectrumRegion.GetIndex(TIncidentSpectrum::ImageDimension - 1) +
                             nRowsMeasuredProjections * spectrumProjIndex);
@@ -333,13 +348,14 @@ WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, T
   unsigned int nEnergies = spectrumRegion.GetSize()[0];
 
   // Create iterators for all inputs and outputs
-  itk::ImageRegionIterator<TOutputImage1>             out1It(this->GetOutput1(), outputRegionForThread);
-  itk::ImageRegionIterator<TOutputImage2>             out2It(this->GetOutput2(), outputRegionForThread);
+  itk::ImageRegionIterator<TOutputImage1>               out1It(this->GetOutput1(), outputRegionForThread);
+  itk::ImageRegionIterator<TOutputImage2>               out2It(this->GetOutput2(), outputRegionForThread);
   itk::ImageRegionConstIterator<TDecomposedProjections> projIt(this->GetInputDecomposedProjections(),
-                                                             outputRegionForThread);
-  itk::ImageRegionConstIterator<TMeasuredProjections> MeasuredProjectionsIt(this->GetInputMeasuredProjections(), outputRegionForThread);
-  itk::ImageRegionConstIterator<TIncidentSpectrum>     spectrumIt(this->GetInputIncidentSpectrum(), spectrumRegion);
-  itk::ImageRegionConstIterator<TProjections>  projOfOnesIt(this->GetInputProjectionsOfOnes(), outputRegionForThread);
+                                                               outputRegionForThread);
+  itk::ImageRegionConstIterator<TMeasuredProjections>   MeasuredProjectionsIt(this->GetInputMeasuredProjections(),
+                                                                            outputRegionForThread);
+  itk::ImageRegionConstIterator<TIncidentSpectrum>      spectrumIt(this->GetInputIncidentSpectrum(), spectrumRegion);
+  itk::ImageRegionConstIterator<TProjections> projOfOnesIt(this->GetInputProjectionsOfOnes(), outputRegionForThread);
 
   // Declare intermediate variables
   vnl_vector<dataType>                           spectrum(nEnergies);

--- a/test/rtkdecomposespectralprojectionstest.cxx
+++ b/test/rtkdecomposespectralprojectionstest.cxx
@@ -37,7 +37,7 @@ main(int argc, char * argv[])
 
   using DecomposedProjectionType = itk::VectorImage<PixelValueType, Dimension>;
 
-  using SpectralProjectionsType = itk::VectorImage<PixelValueType, Dimension>;
+  using MeasuredProjectionsType = itk::VectorImage<PixelValueType, Dimension>;
 
   using IncidentSpectrumImageType = itk::VectorImage<PixelValueType, Dimension - 1>;
   using IncidentSpectrumReaderType = itk::ImageFileReader<IncidentSpectrumImageType>;
@@ -157,10 +157,10 @@ main(int argc, char * argv[])
   }
 
   // Generate a set of zero-filled photon count projections
-  SpectralProjectionsType::Pointer photonCounts = SpectralProjectionsType::New();
-  photonCounts->CopyInformation(decomposed);
-  photonCounts->SetVectorLength(6);
-  photonCounts->Allocate();
+  MeasuredProjectionsType::Pointer measuredProjections = MeasuredProjectionsType::New();
+  measuredProjections->CopyInformation(decomposed);
+  measuredProjections->SetVectorLength(6);
+  measuredProjections->Allocate();
 
   // Generate the thresholds vector
   itk::VariableLengthVector<unsigned int> thresholds;
@@ -175,10 +175,10 @@ main(int argc, char * argv[])
 
   // Apply the forward model to the multi-material projections
   using SpectralForwardFilterType =
-    rtk::SpectralForwardModelImageFilter<DecomposedProjectionType, SpectralProjectionsType, IncidentSpectrumImageType>;
+    rtk::SpectralForwardModelImageFilter<DecomposedProjectionType, MeasuredProjectionsType, IncidentSpectrumImageType>;
   SpectralForwardFilterType::Pointer forward = SpectralForwardFilterType::New();
   forward->SetInputDecomposedProjections(decomposed);
-  forward->SetInputMeasuredProjections(photonCounts);
+  forward->SetInputMeasuredProjections(measuredProjections);
   forward->SetInputIncidentSpectrum(incidentSpectrumReader->GetOutput());
   forward->SetDetectorResponse(detectorResponseReader->GetOutput());
   forward->SetMaterialAttenuations(materialAttenuationsReader->GetOutput());
@@ -202,7 +202,7 @@ main(int argc, char * argv[])
 
   // Create and set the simplex filter to perform the decomposition
   using SimplexFilterType = rtk::SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionType,
-                                                                                    SpectralProjectionsType,
+                                                                                    MeasuredProjectionsType,
                                                                                     IncidentSpectrumImageType>;
   SimplexFilterType::Pointer simplex = SimplexFilterType::New();
   simplex->SetInputDecomposedProjections(initialDecomposedProjections);

--- a/test/rtkspectralonesteptest.cxx
+++ b/test/rtkspectralonesteptest.cxx
@@ -286,8 +286,8 @@ main(int argc, char * argv[])
   MechlemType::Pointer mechlemOneStep = MechlemType::New();
   mechlemOneStep->SetForwardProjectionFilter(MechlemType::FP_JOSEPH); // Joseph
   mechlemOneStep->SetInputMaterialVolumes(materialVolumeSource->GetOutput());
-  mechlemOneStep->SetInputPhotonCounts(composePhotonCounts->GetOutput());
-  mechlemOneStep->SetInputSpectrum(incidentSpectrumReader->GetOutput());
+  mechlemOneStep->SetInputMeasuredProjections(composePhotonCounts->GetOutput());
+  mechlemOneStep->SetInputIncidentSpectrum(incidentSpectrumReader->GetOutput());
   mechlemOneStep->SetBinnedDetectorResponse(drm);
   mechlemOneStep->SetMaterialAttenuations(materialAttenuationsMatrix);
   mechlemOneStep->SetGeometry(geometry);

--- a/test/rtkweidingerforwardmodeltest.cxx
+++ b/test/rtkweidingerforwardmodeltest.cxx
@@ -23,10 +23,11 @@ main(int argc, char * argv[])
   if (argc < 9)
   {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0]
-              << " decomposedProjections.mha measuredProjections.mha incidentSpectrum.mha projections.mha DetectorResponse.csv "
-                 "materialAttenuations.csv out1.mha out2.mha"
-              << std::endl;
+    std::cerr
+      << argv[0]
+      << " decomposedProjections.mha measuredProjections.mha incidentSpectrum.mha projections.mha DetectorResponse.csv "
+         "materialAttenuations.csv out1.mha out2.mha"
+      << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -99,8 +100,8 @@ main(int argc, char * argv[])
       materialAttenuations[r][c] = csvReader->GetOutput()->GetData(r, c);
 
   // Create the filter
-  using WeidingerForwardModelType =
-    rtk::WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>;
+  using WeidingerForwardModelType = rtk::
+    WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>;
   WeidingerForwardModelType::Pointer weidingerForward = WeidingerForwardModelType::New();
 
   // Set its inputs


### PR DESCRIPTION
Made input names consistent throughout all spectral filters, tests and applications. Modified type names, variable names and Set/Get input functions. 
The new names are :
o	MaterialVolumes : reconstructed volumes, decomposed into materials
o	DecomposedProjections : projections, decomposed into materials
o	MeasuredProjections : projections, either binned photon counts (spectral) or regular integrated energy but with two different incident spectra (dual-energy)
o	IncidentSpectrum
o	MaterialAttenuations
