### PR TITLE
Fix wrapping of double & output arguments

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -306,4 +306,5 @@ rtk_add_test(rtkBioscanTest rtkbioscantest.cxx
 if(ITK_WRAP_PYTHON)
   itk_python_add_test(NAME rtkFirstReconstructionPythonTest COMMAND rtkFirstReconstruction.py ${CMAKE_CURRENT_BINARY_DIR}/rtkFirstReconstruction.mha)
   itk_python_add_test(NAME rtkMaximumIntensityPythonTest COMMAND rtkMaximumIntensity.py  ${CMAKE_CURRENT_BINARY_DIR}/rtkFirstReconstruction.mha)
+  itk_python_add_test(NAME rtkOutoutArgumentWrappingTest COMMAND rtkOutoutArgumentWrapping.py)
 endif()

--- a/test/rtkOutputArgumentWrapping.py
+++ b/test/rtkOutputArgumentWrapping.py
@@ -1,0 +1,44 @@
+import itk
+from itk import RTK as rtk
+
+# Test for rtkConvexShape::IsIntersectedByRay
+
+q = rtk.QuadricShape.New()
+
+# Define a sphere of radius 10
+radius = 10
+q.SetA(1)
+q.SetB(1)
+q.SetC(1)
+q.SetJ(-radius**2)
+
+print(q.IsIntersectedByRay([-20, 0, 0], [1, 0, 0]))
+
+# Test for rtk::FieldOfViewImageFilter::ComputeFOVRadius
+
+geometry = rtk.ThreeDCircularProjectionGeometry.New()
+numberOfProjections = 360
+firstAngle = 0
+angularArc = 360
+sid = 600 # source to isocenter distance in mm
+sdd = 1200 # source to detector distance in mm
+isox = 0 # X coordinate on the projection image of isocenter
+isoy = 0 # Y coordinate on the projection image of isocenter
+for x in range(0,numberOfProjections):
+  angle = firstAngle + x * angularArc / numberOfProjections
+  geometry.AddProjection(sid,sdd,angle,isox,isoy)
+
+constantImageSource = rtk.ConstantImageSource[itk.Image[itk.F,3]].New()
+origin = [ -127.5, -127.5, 0. ]
+sizeOutput = [ 256, 256,  numberOfProjections ]
+spacing = [ 1.0, 1.0, 1.0 ]
+constantImageSource.SetOrigin( origin )
+constantImageSource.SetSpacing( spacing )
+constantImageSource.SetSize( sizeOutput )
+constantImageSource.SetConstant(0.0)
+source = constantImageSource.GetOutput()
+
+f = rtk.FieldOfViewImageFilter.New()
+f.SetGeometry(geometry)
+f.SetProjectionsStack(source)
+print(f.ComputeFOVRadius(f.FOVRadiusType_RADIUSINF))

--- a/wrapping/ConvexShape.i
+++ b/wrapping/ConvexShape.i
@@ -1,0 +1,4 @@
+%include "typemaps.i"
+
+// rtkConvexShape::IsIntersectedByRay
+%apply double &OUTPUT {double & nearDist, double & farDist};

--- a/wrapping/FieldOfViewImageFilter.i
+++ b/wrapping/FieldOfViewImageFilter.i
@@ -1,0 +1,4 @@
+%include "typemaps.i"
+
+// rtk::FieldOfViewImageFilter::ComputeFOVRadius
+%apply double &OUTPUT {double & x, double & z, double & r};

--- a/wrapping/rtkConvexShape.wrap
+++ b/wrapping/rtkConvexShape.wrap
@@ -1,1 +1,7 @@
 itk_wrap_simple_class("rtk::ConvexShape" POINTER)
+
+set(ITK_WRAP_PYTHON_SWIG_EXT
+    "%include ConvexShape.i\n${ITK_WRAP_PYTHON_SWIG_EXT}")
+
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/ConvexShape.i"
+    DESTINATION "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}")

--- a/wrapping/rtkFieldOfViewImageFilter.wrap
+++ b/wrapping/rtkFieldOfViewImageFilter.wrap
@@ -1,3 +1,9 @@
 itk_wrap_class("rtk::FieldOfViewImageFilter" POINTER)
   itk_wrap_image_filter("${WRAP_ITK_REAL}" 2 3)
 itk_end_wrap_class()
+
+set(ITK_WRAP_PYTHON_SWIG_EXT
+    "%include FieldOfViewImageFilter.i\n${ITK_WRAP_PYTHON_SWIG_EXT}")
+
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/FieldOfViewImageFilter.i"
+    DESTINATION "${WRAPPER_MASTER_INDEX_OUTPUT_DIR}")


### PR DESCRIPTION
The problem is that in the method `rtkConvexShape::IsIntersectedByRay(const PointType &, const VectorType &, double &, double &)`, the last two parameters are meant to be output values, and thus cannot be used in Python, since there is no way to define a `double &` in Python.

The solution, crafted thanks to the pointers given by @SimonRit and [this comment](https://discourse.itk.org/t/additional-python-types-for-itk-remote-external-modules/2509/8) from @LucasGandel, removes the last two parameters from the method in Python and replaces them with output values (see example below). There might be a better way of achieving the same result, but I am far from fluent in SWIG, so any suggestion of improvement is welcome!

Test script:
```python
import itk
from itk import RTK as rtk

q = rtk.QuadricShape.New()

# Define a sphere of radius 10
radius = 10
q.SetA(1)
q.SetB(1)
q.SetC(1)
q.SetJ(-radius**2)

print(q.IsIntersectedByRay([-20,0,0],[1,0,0]))  # only two parameters
```

Output with the fix:
```
[True, 10.0, 30.0]
```