### PR TITLE
STYLE: Remove unused verbosity flags

### DIFF
--- a/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.ggo
+++ b/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.ggo
@@ -1,6 +1,5 @@
 purpose "Creates an RTK geometry file from an Elekta Synergy acquisition."
 
-option "verbose"   v "Verbose execution"                    flag   off
 option "config"    - "Config file"                          string no
 option "image_db"  i "Image table filename (prior to XVI5)" string no
 option "frame_db"  f "Frame table filename (prior to XVI5)" string no

--- a/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
+++ b/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
@@ -9,7 +9,6 @@ def main():
   parser = argparse.ArgumentParser(description=
     "Creates an RTK geometry file from an Elekta Synergy acquisition.")
 
-  parser.add_argument('--verbose', '-v', help='Verbose execution', type=bool)
   parser.add_argument('--xml', '-x', help='XML file name (starting with XVI5)')
   parser.add_argument('--output', '-o', help='Output file name')
 

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.ggo
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.ggo
@@ -1,6 +1,5 @@
 purpose "Creates an RTK geometry file from simulated/regular trajectory. See https://docs.openrtk.org/en/latest/documentation/docs/Geometry.html for more information."
 
-option "verbose"     v "Verbose execution"                                                    flag   off
 option "config"      - "Config file"                                                          string no
 
 option "output"      o "Output file name"                                                     string yes

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
@@ -10,7 +10,6 @@ def main():
 
   parser.add_argument('--nproj', '-n', type=int, help='Number of projections')
   parser.add_argument('--output', '-o', help='Output file name')
-  parser.add_argument('--verbose', '-v', type=bool, default=False, help='Verbose execution')
   parser.add_argument('--first_angle', '-f', type=float, default=0, help='First angle in degrees')
   parser.add_argument('--arc', '-a', type=float, default=360, help='Angular arc covevered by the acquisition in degrees')
   parser.add_argument('--sdd', type=float, default=1536, help='Source to detector distance (mm)')


### PR DESCRIPTION
Remove the verbosity flags that do not do anything. This is not backward-compatible. Fixes #696.