### PR TITLE
Fixed vector length spectral inputs overload

### DIFF
--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.h
@@ -67,6 +67,8 @@ public:
   using DetectorResponseType = vnl_matrix<double>;
   using MaterialAttenuationsType = vnl_matrix<double>;
   using CostFunctionType = ProjectionsDecompositionNegativeLogLikelihood;
+  using DecomposedProjectionsDataType = typename DecomposedProjectionsType::PixelType::ValueType;
+  using MeasuredProjectionsDataType = typename MeasuredProjectionsType::PixelType::ValueType;
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   /** Additional types to overload SetInputIncidentSpectrum */
@@ -83,15 +85,28 @@ public:
 
   /** Set/Get the input material-decomposed stack of projections (only used for initialization) */
   void
-  SetInputDecomposedProjections(const DecomposedProjectionsType * DecomposedProjections);
+  SetInputDecomposedProjections(
+    const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections);
+  template <unsigned int VNumberOfMaterials>
+  void
+  SetInputFixedVectorLengthDecomposedProjections(
+    const itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                     DecomposedProjectionsType::ImageDimension> * DecomposedProjections);
   typename DecomposedProjectionsType::ConstPointer
   GetInputDecomposedProjections();
 
   /** Set/Get the input stack of measured projections (to be decomposed in materials) */
   void
-  SetInputMeasuredProjections(const MeasuredProjectionsType * SpectralProjections);
+  SetInputMeasuredProjections(
+    const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections);
+  template <unsigned int VNumberOfSpectralBins>
+  void
+  SetInputFixedVectorLengthMeasuredProjections(
+    const itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                     MeasuredProjectionsType::ImageDimension> * MeasuredProjections);
   typename MeasuredProjectionsType::ConstPointer
   GetInputMeasuredProjections();
+
 
   /** Set/Get the detector response as an image */
   void

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
@@ -82,14 +82,80 @@ template <typename DecomposedProjectionsType,
           typename DetectorResponseImageType,
           typename MaterialAttenuationsImageType>
 void
-SimplexSpectralProjectionsDecompositionImageFilter<
-  DecomposedProjectionsType,
-  MeasuredProjectionsType,
-  IncidentSpectrumImageType,
-  DetectorResponseImageType,
-  MaterialAttenuationsImageType>::SetInputDecomposedProjections(const DecomposedProjectionsType * DecomposedProjections)
+SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
+                                                   MeasuredProjectionsType,
+                                                   IncidentSpectrumImageType,
+                                                   DetectorResponseImageType,
+                                                   MaterialAttenuationsImageType>::
+  SetInputDecomposedProjections(
+    const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
 {
-  this->SetNthInput(0, const_cast<DecomposedProjectionsType *>(DecomposedProjections));
+  // Attempt to dynamic_cast DecomposedProjections into one of the supported types
+  const DecomposedProjectionsType * ptr = dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
+  if (ptr)
+  {
+    this->SetNthInput(0, const_cast<DecomposedProjectionsType *>(ptr));
+  }
+  else
+  {
+    // Perform all possible dynamic_casts
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 1>, DecomposedProjectionsType::ImageDimension> Type1;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 2>, DecomposedProjectionsType::ImageDimension> Type2;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 3>, DecomposedProjectionsType::ImageDimension> Type3;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 4>, DecomposedProjectionsType::ImageDimension> Type4;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 5>, DecomposedProjectionsType::ImageDimension> Type5;
+    const Type1 * ptr1 = dynamic_cast<const Type1 *>(DecomposedProjections);
+    const Type2 * ptr2 = dynamic_cast<const Type2 *>(DecomposedProjections);
+    const Type3 * ptr3 = dynamic_cast<const Type3 *>(DecomposedProjections);
+    const Type4 * ptr4 = dynamic_cast<const Type4 *>(DecomposedProjections);
+    const Type5 * ptr5 = dynamic_cast<const Type5 *>(DecomposedProjections);
+
+    if (ptr1)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<1>(ptr1);
+    }
+    else if (ptr2)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<2>(ptr2);
+    }
+    else if (ptr3)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<3>(ptr3);
+    }
+    else if (ptr4)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<4>(ptr4);
+    }
+    else if (ptr5)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<5>(ptr5);
+    }
+  }
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
+template <unsigned int VNumberOfMaterials>
+void
+SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
+                                                   MeasuredProjectionsType,
+                                                   IncidentSpectrumImageType,
+                                                   DetectorResponseImageType,
+                                                   MaterialAttenuationsImageType>::
+  SetInputFixedVectorLengthDecomposedProjections(
+    const itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                     DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
+{
+  using ActualInputType = itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                                     DecomposedProjectionsType::ImageDimension>;
+  using CastFilterType = itk::CastImageFilter<ActualInputType, DecomposedProjectionsType>;
+  typename CastFilterType::Pointer castPointer = CastFilterType::New();
+  castPointer->SetInput(DecomposedProjections);
+  castPointer->Update();
+  this->SetNthInput(0, const_cast<DecomposedProjectionsType *>(castPointer->GetOutput()));
 }
 
 template <typename DecomposedProjectionsType,
@@ -98,14 +164,86 @@ template <typename DecomposedProjectionsType,
           typename DetectorResponseImageType,
           typename MaterialAttenuationsImageType>
 void
-SimplexSpectralProjectionsDecompositionImageFilter<
-  DecomposedProjectionsType,
-  MeasuredProjectionsType,
-  IncidentSpectrumImageType,
-  DetectorResponseImageType,
-  MaterialAttenuationsImageType>::SetInputMeasuredProjections(const MeasuredProjectionsType * SpectralProjections)
+SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
+                                                   MeasuredProjectionsType,
+                                                   IncidentSpectrumImageType,
+                                                   DetectorResponseImageType,
+                                                   MaterialAttenuationsImageType>::
+  SetInputMeasuredProjections(
+    const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
 {
-  this->SetInput("MeasuredProjections", const_cast<MeasuredProjectionsType *>(SpectralProjections));
+  // Attempt to dynamic_cast MeasuredProjections into one of the supported types
+  const MeasuredProjectionsType * ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
+  if (ptr)
+  {
+    this->SetInput("MeasuredProjections", const_cast<MeasuredProjectionsType *>(ptr));
+  }
+  else
+  {
+    // Perform all possible dynamic_casts
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 1>, MeasuredProjectionsType::ImageDimension> Type1;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 2>, MeasuredProjectionsType::ImageDimension> Type2;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 3>, MeasuredProjectionsType::ImageDimension> Type3;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 4>, MeasuredProjectionsType::ImageDimension> Type4;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 5>, MeasuredProjectionsType::ImageDimension> Type5;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 6>, MeasuredProjectionsType::ImageDimension> Type6;
+    const Type1 * ptr1 = dynamic_cast<const Type1 *>(MeasuredProjections);
+    const Type2 * ptr2 = dynamic_cast<const Type2 *>(MeasuredProjections);
+    const Type3 * ptr3 = dynamic_cast<const Type3 *>(MeasuredProjections);
+    const Type4 * ptr4 = dynamic_cast<const Type4 *>(MeasuredProjections);
+    const Type5 * ptr5 = dynamic_cast<const Type5 *>(MeasuredProjections);
+    const Type6 * ptr6 = dynamic_cast<const Type6 *>(MeasuredProjections);
+
+    if (ptr1)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<1>(ptr1);
+    }
+    else if (ptr2)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<2>(ptr2);
+    }
+    else if (ptr3)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<3>(ptr3);
+    }
+    else if (ptr4)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<4>(ptr4);
+    }
+    else if (ptr5)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<5>(ptr5);
+    }
+    else if (ptr6)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<6>(ptr6);
+    }
+  }
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
+template <unsigned int VNumberOfSpectralBins>
+void
+SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
+                                                   MeasuredProjectionsType,
+                                                   IncidentSpectrumImageType,
+                                                   DetectorResponseImageType,
+                                                   MaterialAttenuationsImageType>::
+  SetInputFixedVectorLengthMeasuredProjections(
+    const itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                     MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
+{
+  using ActualInputType = itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                                     MeasuredProjectionsType::ImageDimension>;
+  using CastFilterType = itk::CastImageFilter<ActualInputType, MeasuredProjectionsType>;
+  typename CastFilterType::Pointer castPointer = CastFilterType::New();
+  castPointer->SetInput(MeasuredProjections);
+  castPointer->UpdateLargestPossibleRegion();
+  this->SetInput("MeasuredProjections", const_cast<MeasuredProjectionsType *>(castPointer->GetOutput()));
 }
 
 template <typename DecomposedProjectionsType,

--- a/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
+++ b/include/rtkSimplexSpectralProjectionsDecompositionImageFilter.hxx
@@ -90,15 +90,16 @@ SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
   SetInputDecomposedProjections(
     const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
 {
-  // Attempt to dynamic_cast DecomposedProjections into one of the supported types
-  const DecomposedProjectionsType * ptr = dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
-  if (ptr)
+  // Attempt to dynamic_cast DecomposedProjections into the default DecomposedProjectionsType
+  const DecomposedProjectionsType * default_ptr =
+    dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
+  if (default_ptr)
   {
-    this->SetNthInput(0, const_cast<DecomposedProjectionsType *>(ptr));
+    this->SetNthInput(0, const_cast<DecomposedProjectionsType *>(default_ptr));
   }
   else
   {
-    // Perform all possible dynamic_casts
+    // Attempt to dynamic_cast DecomposedProjections into one of the supported fixed vector length types
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 1>, DecomposedProjectionsType::ImageDimension> Type1;
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 2>, DecomposedProjectionsType::ImageDimension> Type2;
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 3>, DecomposedProjectionsType::ImageDimension> Type3;
@@ -129,6 +130,10 @@ SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
     else if (ptr5)
     {
       this->SetInputFixedVectorLengthDecomposedProjections<5>(ptr5);
+    }
+    else
+    {
+      itkWarningMacro("The input does not match any of the supported types, and has been ignored");
     }
   }
 }
@@ -172,15 +177,15 @@ SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
   SetInputMeasuredProjections(
     const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
 {
-  // Attempt to dynamic_cast MeasuredProjections into one of the supported types
-  const MeasuredProjectionsType * ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
-  if (ptr)
+  // Attempt to dynamic_cast MeasuredProjections into the default type MeasuredProjectionsType
+  const MeasuredProjectionsType * default_ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
+  if (default_ptr)
   {
-    this->SetInput("MeasuredProjections", const_cast<MeasuredProjectionsType *>(ptr));
+    this->SetInput("MeasuredProjections", const_cast<MeasuredProjectionsType *>(default_ptr));
   }
   else
   {
-    // Perform all possible dynamic_casts
+    // Attempt to dynamic_cast MeasuredProjections into one of the supported types
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 1>, MeasuredProjectionsType::ImageDimension> Type1;
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 2>, MeasuredProjectionsType::ImageDimension> Type2;
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 3>, MeasuredProjectionsType::ImageDimension> Type3;
@@ -217,6 +222,10 @@ SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionsType,
     else if (ptr6)
     {
       this->SetInputFixedVectorLengthMeasuredProjections<6>(ptr6);
+    }
+    else
+    {
+      itkWarningMacro("The input does not match any of the supported types, and has been ignored");
     }
   }
 }

--- a/include/rtkSpectralForwardModelImageFilter.h
+++ b/include/rtkSpectralForwardModelImageFilter.h
@@ -25,6 +25,7 @@
 
 #include <itkPermuteAxesImageFilter.h>
 #include <itkInPlaceImageFilter.h>
+#include <itkCastImageFilter.h>
 
 namespace rtk
 {
@@ -66,6 +67,8 @@ public:
   using ThresholdsType = itk::VariableLengthVector<double>;
   using DetectorResponseType = vnl_matrix<double>;
   using MaterialAttenuationsType = vnl_matrix<double>;
+  using DecomposedProjectionsDataType = typename DecomposedProjectionsType::PixelType::ValueType;
+  using MeasuredProjectionsDataType = typename MeasuredProjectionsType::PixelType::ValueType;
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   /** Additional types to overload SetInputIncidentSpectrum */
@@ -98,13 +101,25 @@ public:
 
   /** Set/Get the input material-decomposed stack of projections (only used for initialization) */
   void
-  SetInputDecomposedProjections(const DecomposedProjectionsType * DecomposedProjections);
+  SetInputDecomposedProjections(
+    const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections);
+  template <unsigned int VNumberOfMaterials>
+  void
+  SetInputFixedVectorLengthDecomposedProjections(
+    const itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                     DecomposedProjectionsType::ImageDimension> * DecomposedProjections);
   typename DecomposedProjectionsType::ConstPointer
   GetInputDecomposedProjections();
 
   /** Set/Get the input stack of measured projections (to be decomposed in materials) */
   void
-  SetInputMeasuredProjections(const MeasuredProjectionsType * SpectralProjections);
+  SetInputMeasuredProjections(
+    const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections);
+  template <unsigned int VNumberOfSpectralBins>
+  void
+  SetInputFixedVectorLengthMeasuredProjections(
+    const itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                     MeasuredProjectionsType::ImageDimension> * MeasuredProjections);
   typename MeasuredProjectionsType::ConstPointer
   GetInputMeasuredProjections();
 

--- a/include/rtkSpectralForwardModelImageFilter.hxx
+++ b/include/rtkSpectralForwardModelImageFilter.hxx
@@ -63,7 +63,6 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
 #endif
 }
 
-
 template <typename DecomposedProjectionsType,
           typename MeasuredProjectionsType,
           typename IncidentSpectrumImageType,
@@ -78,15 +77,16 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
   SetInputDecomposedProjections(
     const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
 {
-  // Attempt to dynamic_cast DecomposedProjections into one of the supported types
-  const DecomposedProjectionsType * ptr = dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
-  if (ptr)
+  // Attempt to dynamic_cast DecomposedProjections into the default DecomposedProjectionsType
+  const DecomposedProjectionsType * default_ptr =
+    dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
+  if (default_ptr)
   {
-    this->SetInput("DecomposedProjections", const_cast<DecomposedProjectionsType *>(ptr));
+    this->SetInput("DecomposedProjections", const_cast<DecomposedProjectionsType *>(default_ptr));
   }
   else
   {
-    // Perform all possible dynamic_casts
+    // Attempt to dynamic_cast DecomposedProjections into one of the supported fixed vector length types
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 1>, DecomposedProjectionsType::ImageDimension> Type1;
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 2>, DecomposedProjectionsType::ImageDimension> Type2;
     typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 3>, DecomposedProjectionsType::ImageDimension> Type3;
@@ -117,6 +117,10 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
     else if (ptr5)
     {
       this->SetInputFixedVectorLengthDecomposedProjections<5>(ptr5);
+    }
+    else
+    {
+      itkWarningMacro("The input does not match any of the supported types, and has been ignored");
     }
   }
 }
@@ -160,15 +164,15 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
   SetInputMeasuredProjections(
     const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
 {
-  // Attempt to dynamic_cast MeasuredProjections into one of the supported types
-  const MeasuredProjectionsType * ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
-  if (ptr)
+  // Attempt to dynamic_cast MeasuredProjections into the default type MeasuredProjectionsType
+  const MeasuredProjectionsType * default_ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
+  if (default_ptr)
   {
-    this->SetNthInput(0, const_cast<MeasuredProjectionsType *>(ptr));
+    this->SetNthInput(0, const_cast<MeasuredProjectionsType *>(default_ptr));
   }
   else
   {
-    // Perform all possible dynamic_casts
+    // Attempt to dynamic_cast MeasuredProjections into one of the supported types
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 1>, MeasuredProjectionsType::ImageDimension> Type1;
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 2>, MeasuredProjectionsType::ImageDimension> Type2;
     typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 3>, MeasuredProjectionsType::ImageDimension> Type3;
@@ -205,6 +209,10 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
     else if (ptr6)
     {
       this->SetInputFixedVectorLengthMeasuredProjections<6>(ptr6);
+    }
+    else
+    {
+      itkWarningMacro("The input does not match any of the supported types, and has been ignored");
     }
   }
 }

--- a/include/rtkSpectralForwardModelImageFilter.hxx
+++ b/include/rtkSpectralForwardModelImageFilter.hxx
@@ -63,20 +63,175 @@ SpectralForwardModelImageFilter<DecomposedProjectionsType,
 #endif
 }
 
+
 template <typename DecomposedProjectionsType,
           typename MeasuredProjectionsType,
           typename IncidentSpectrumImageType,
           typename DetectorResponseImageType,
           typename MaterialAttenuationsImageType>
 void
-SpectralForwardModelImageFilter<
-  DecomposedProjectionsType,
-  MeasuredProjectionsType,
-  IncidentSpectrumImageType,
-  DetectorResponseImageType,
-  MaterialAttenuationsImageType>::SetInputMeasuredProjections(const MeasuredProjectionsType * SpectralProjections)
+SpectralForwardModelImageFilter<DecomposedProjectionsType,
+                                MeasuredProjectionsType,
+                                IncidentSpectrumImageType,
+                                DetectorResponseImageType,
+                                MaterialAttenuationsImageType>::
+  SetInputDecomposedProjections(
+    const typename itk::ImageBase<DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
 {
-  this->SetNthInput(0, const_cast<MeasuredProjectionsType *>(SpectralProjections));
+  // Attempt to dynamic_cast DecomposedProjections into one of the supported types
+  const DecomposedProjectionsType * ptr = dynamic_cast<const DecomposedProjectionsType *>(DecomposedProjections);
+  if (ptr)
+  {
+    this->SetInput("DecomposedProjections", const_cast<DecomposedProjectionsType *>(ptr));
+  }
+  else
+  {
+    // Perform all possible dynamic_casts
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 1>, DecomposedProjectionsType::ImageDimension> Type1;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 2>, DecomposedProjectionsType::ImageDimension> Type2;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 3>, DecomposedProjectionsType::ImageDimension> Type3;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 4>, DecomposedProjectionsType::ImageDimension> Type4;
+    typedef itk::Image<itk::Vector<DecomposedProjectionsDataType, 5>, DecomposedProjectionsType::ImageDimension> Type5;
+    const Type1 * ptr1 = dynamic_cast<const Type1 *>(DecomposedProjections);
+    const Type2 * ptr2 = dynamic_cast<const Type2 *>(DecomposedProjections);
+    const Type3 * ptr3 = dynamic_cast<const Type3 *>(DecomposedProjections);
+    const Type4 * ptr4 = dynamic_cast<const Type4 *>(DecomposedProjections);
+    const Type5 * ptr5 = dynamic_cast<const Type5 *>(DecomposedProjections);
+
+    if (ptr1)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<1>(ptr1);
+    }
+    else if (ptr2)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<2>(ptr2);
+    }
+    else if (ptr3)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<3>(ptr3);
+    }
+    else if (ptr4)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<4>(ptr4);
+    }
+    else if (ptr5)
+    {
+      this->SetInputFixedVectorLengthDecomposedProjections<5>(ptr5);
+    }
+  }
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
+template <unsigned int VNumberOfMaterials>
+void
+SpectralForwardModelImageFilter<DecomposedProjectionsType,
+                                MeasuredProjectionsType,
+                                IncidentSpectrumImageType,
+                                DetectorResponseImageType,
+                                MaterialAttenuationsImageType>::
+  SetInputFixedVectorLengthDecomposedProjections(
+    const itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                     DecomposedProjectionsType::ImageDimension> * DecomposedProjections)
+{
+  using ActualInputType = itk::Image<itk::Vector<DecomposedProjectionsDataType, VNumberOfMaterials>,
+                                     DecomposedProjectionsType::ImageDimension>;
+  using CastFilterType = itk::CastImageFilter<ActualInputType, DecomposedProjectionsType>;
+  typename CastFilterType::Pointer castPointer = CastFilterType::New();
+  castPointer->SetInput(DecomposedProjections);
+  castPointer->Update();
+  this->SetInput("DecomposedProjections", const_cast<DecomposedProjectionsType *>(castPointer->GetOutput()));
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
+void
+SpectralForwardModelImageFilter<DecomposedProjectionsType,
+                                MeasuredProjectionsType,
+                                IncidentSpectrumImageType,
+                                DetectorResponseImageType,
+                                MaterialAttenuationsImageType>::
+  SetInputMeasuredProjections(
+    const typename itk::ImageBase<MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
+{
+  // Attempt to dynamic_cast MeasuredProjections into one of the supported types
+  const MeasuredProjectionsType * ptr = dynamic_cast<const MeasuredProjectionsType *>(MeasuredProjections);
+  if (ptr)
+  {
+    this->SetNthInput(0, const_cast<MeasuredProjectionsType *>(ptr));
+  }
+  else
+  {
+    // Perform all possible dynamic_casts
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 1>, MeasuredProjectionsType::ImageDimension> Type1;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 2>, MeasuredProjectionsType::ImageDimension> Type2;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 3>, MeasuredProjectionsType::ImageDimension> Type3;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 4>, MeasuredProjectionsType::ImageDimension> Type4;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 5>, MeasuredProjectionsType::ImageDimension> Type5;
+    typedef itk::Image<itk::Vector<MeasuredProjectionsDataType, 6>, MeasuredProjectionsType::ImageDimension> Type6;
+    const Type1 * ptr1 = dynamic_cast<const Type1 *>(MeasuredProjections);
+    const Type2 * ptr2 = dynamic_cast<const Type2 *>(MeasuredProjections);
+    const Type3 * ptr3 = dynamic_cast<const Type3 *>(MeasuredProjections);
+    const Type4 * ptr4 = dynamic_cast<const Type4 *>(MeasuredProjections);
+    const Type5 * ptr5 = dynamic_cast<const Type5 *>(MeasuredProjections);
+    const Type6 * ptr6 = dynamic_cast<const Type6 *>(MeasuredProjections);
+
+    if (ptr1)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<1>(ptr1);
+    }
+    else if (ptr2)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<2>(ptr2);
+    }
+    else if (ptr3)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<3>(ptr3);
+    }
+    else if (ptr4)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<4>(ptr4);
+    }
+    else if (ptr5)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<5>(ptr5);
+    }
+    else if (ptr6)
+    {
+      this->SetInputFixedVectorLengthMeasuredProjections<6>(ptr6);
+    }
+  }
+}
+
+template <typename DecomposedProjectionsType,
+          typename MeasuredProjectionsType,
+          typename IncidentSpectrumImageType,
+          typename DetectorResponseImageType,
+          typename MaterialAttenuationsImageType>
+template <unsigned int VNumberOfSpectralBins>
+void
+SpectralForwardModelImageFilter<DecomposedProjectionsType,
+                                MeasuredProjectionsType,
+                                IncidentSpectrumImageType,
+                                DetectorResponseImageType,
+                                MaterialAttenuationsImageType>::
+  SetInputFixedVectorLengthMeasuredProjections(
+    const itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                     MeasuredProjectionsType::ImageDimension> * MeasuredProjections)
+{
+  using ActualInputType = itk::Image<itk::Vector<MeasuredProjectionsDataType, VNumberOfSpectralBins>,
+                                     MeasuredProjectionsType::ImageDimension>;
+  using CastFilterType = itk::CastImageFilter<ActualInputType, MeasuredProjectionsType>;
+  typename CastFilterType::Pointer castPointer = CastFilterType::New();
+  castPointer->SetInput(MeasuredProjections);
+  castPointer->UpdateLargestPossibleRegion();
+  this->SetNthInput(0, const_cast<MeasuredProjectionsType *>(castPointer->GetOutput()));
 }
 
 template <typename DecomposedProjectionsType,
@@ -158,22 +313,6 @@ SpectralForwardModelImageFilter<
   this->SetInputSecondIncidentSpectrum(m_PermuteSecondFilter->GetOutput());
 }
 #endif
-
-template <typename DecomposedProjectionsType,
-          typename MeasuredProjectionsType,
-          typename IncidentSpectrumImageType,
-          typename DetectorResponseImageType,
-          typename MaterialAttenuationsImageType>
-void
-SpectralForwardModelImageFilter<
-  DecomposedProjectionsType,
-  MeasuredProjectionsType,
-  IncidentSpectrumImageType,
-  DetectorResponseImageType,
-  MaterialAttenuationsImageType>::SetInputDecomposedProjections(const DecomposedProjectionsType * DecomposedProjections)
-{
-  this->SetInput("DecomposedProjections", const_cast<DecomposedProjectionsType *>(DecomposedProjections));
-}
 
 template <typename DecomposedProjectionsType,
           typename MeasuredProjectionsType,

--- a/test/rtkdecomposespectralprojectionstest.cxx
+++ b/test/rtkdecomposespectralprojectionstest.cxx
@@ -49,8 +49,10 @@ main(int argc, char * argv[])
   using MaterialAttenuationsReaderType = itk::ImageFileReader<MaterialAttenuationsImageType>;
 
   // Cast filters to convert between vector image types
-  using CastDecomposedProjectionsFilterType = itk::CastImageFilter<DecomposedProjectionsType, itk::Image<itk::Vector<PixelValueType, 3>, Dimension>>;
-  using CastMeasuredProjectionFilterType = itk::CastImageFilter<MeasuredProjectionsType, itk::Image<itk::Vector<PixelValueType, 6>, Dimension>>;
+  using CastDecomposedProjectionsFilterType =
+    itk::CastImageFilter<DecomposedProjectionsType, itk::Image<itk::Vector<PixelValueType, 3>, Dimension>>;
+  using CastMeasuredProjectionFilterType =
+    itk::CastImageFilter<MeasuredProjectionsType, itk::Image<itk::Vector<PixelValueType, 6>, Dimension>>;
 
   // Read all inputs
   IncidentSpectrumReaderType::Pointer incidentSpectrumReader = IncidentSpectrumReaderType::New();
@@ -235,14 +237,24 @@ main(int argc, char * argv[])
   measuredProjections->SetRegions(region);
   measuredProjections->Allocate();
 
-  typename CastDecomposedProjectionsFilterType::Pointer castDecomposedProjections = CastDecomposedProjectionsFilterType::New();
+  typename CastDecomposedProjectionsFilterType::Pointer castDecomposedProjections =
+    CastDecomposedProjectionsFilterType::New();
   typename CastMeasuredProjectionFilterType::Pointer castMeasuredProjections = CastMeasuredProjectionFilterType::New();
   castDecomposedProjections->SetInput(decomposed);
   castMeasuredProjections->SetInput(measuredProjections);
   forward->SetInputDecomposedProjections(castDecomposedProjections->GetOutput());
   forward->SetInputMeasuredProjections(castMeasuredProjections->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(forward->Update())
+
+  typename CastDecomposedProjectionsFilterType::Pointer castDecomposedProjections2 =
+    CastDecomposedProjectionsFilterType::New();
+  typename CastMeasuredProjectionFilterType::Pointer castMeasuredProjections2 = CastMeasuredProjectionFilterType::New();
+  castDecomposedProjections->SetInput(initialDecomposedProjections);
+  castMeasuredProjections->SetInput(forward->GetOutput());
+  simplex->SetInputDecomposedProjections(castDecomposedProjections->GetOutput());
+  simplex->SetInputMeasuredProjections(castMeasuredProjections->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(simplex->Update())
+
   CheckVectorImageQuality<DecomposedProjectionsType>(simplex->GetOutput(), decomposed, 0.0001, 15, 2.0);
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE


### PR DESCRIPTION
Add support for itk::Image<itk::Vector<float, N>, 3> in SetInputDecomposedProjections and SetInputMeasuredProjections in filters rtkSimplexSpectralProjectionsDecompositionImageFilter and rtkSpectralForwardModelImageFilter.