### PR TITLE
BUG: Fix typo in OutputArgumentWrappingTest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -306,5 +306,5 @@ rtk_add_test(rtkBioscanTest rtkbioscantest.cxx
 if(ITK_WRAP_PYTHON)
   itk_python_add_test(NAME rtkFirstReconstructionPythonTest COMMAND rtkFirstReconstruction.py ${CMAKE_CURRENT_BINARY_DIR}/rtkFirstReconstruction.mha)
   itk_python_add_test(NAME rtkMaximumIntensityPythonTest COMMAND rtkMaximumIntensity.py  ${CMAKE_CURRENT_BINARY_DIR}/rtkFirstReconstruction.mha)
-  itk_python_add_test(NAME rtkOutoutArgumentWrappingTest COMMAND rtkOutoutArgumentWrapping.py)
+  itk_python_add_test(NAME rtkOutputArgumentWrappingTest COMMAND rtkOutputArgumentWrapping.py)
 endif()


### PR DESCRIPTION
PR #684 introduced a silly typo.