### PR TITLE
COMP: Replace itkTypeMacro with itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/rtkFDKVarianceReconstructionFilter.h
+++ b/include/rtkFDKVarianceReconstructionFilter.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FDKVarianceReconstructionFilter, itk::ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FDKVarianceReconstructionFilter);
 
   /** Get / Set the object pointer to projection geometry */
   itkGetModifiableObjectMacro(Geometry, ThreeDCircularProjectionGeometry);

--- a/include/rtkFFTVarianceRampImageFilter.h
+++ b/include/rtkFFTVarianceRampImageFilter.h
@@ -63,7 +63,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FFTVarianceRampImageFilter, FFTConvolutionImageFilter);
+  itkOverrideGetNameOfClassMacro(FFTVarianceRampImageFilter);
 
 protected:
   FFTVarianceRampImageFilter();


### PR DESCRIPTION
The newly added FFTVarianceRampImageFilter and
FDKVarianceReconstructionFilter still had this macro which will be removed in the future (see InsightSoftwareConsortium/ITK@2c264ea2ef62e916c6ef947599ce659cc8fce5fe).