### PR TITLE
ENH: Create python API for applications

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -1,6 +1,8 @@
-# Command-line examples
+# Command-line applications
 
-RTK provides command line applications that can be built from the C++ code by turning `ON` the `RTK_BUILD_APPLICATIONS` CMake option. A few of these applications have also been translated to Python and integrated in the [Pypi package](https://pypi.org/project/itk-rtk/). The options of each command line application can be listed with the `--help option`.
+RTK provides command line applications which can be built from the C++ code by turning `ON` the `RTK_BUILD_APPLICATIONS` CMake option. A few of these applications have also been translated to Python and integrated in the [Pypi package](https://pypi.org/project/itk-rtk/). The options of each command line application can be listed with the `--help option`.
+
+The following are examples using RTK applications:
 
 ```{toctree}
 :maxdepth: 1
@@ -19,3 +21,47 @@ RTK provides command line applications that can be built from the C++ code by tu
 ```
 
 In [applications/rtktutorialapplication/](https://github.com/RTKConsortium/RTK/blob/master/applications/rtktutorialapplication), you will find a very basic RTK application that can be used as a starting point for building your own new application.
+
+## Using RTK applications in Python
+
+RTK applications which have been translated to Python can also be called from Python in addition to the command line, thus avoiding reloading the RTK package (which is slow) and enabling the flexibility of Python scripting. The Python interface dynamically maps the RTK applications to Python functions. You can use `help(rtk.<application_name>)` to see all required and optional arguments. Note that only file paths are supported as input, ITK images or RTK geometry objects cannot be passed directly.
+
+Each Python application accepts either:
+
+1. **A single positional string argument**: This mimics the command-line usage.
+2. **A list of keyword arguments**: This provides a more Pythonic interface.
+
+```python
+rtk.<application_name>(<arguments>)
+```
+
+For example,
+
+```bash
+rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256
+```
+
+is equivalent to execute from Python
+
+```python
+from itk import RTK as rtk
+
+rtk.rtkfdk(
+    "-p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256"
+)
+```
+
+or
+
+```python
+from itk import RTK as rtk
+
+rtk.rtkfdk(
+    path=".",
+    regexp="projections.mha",
+    output="fdk.mha",
+    geometry="geometry.xml",
+    spacing="2,2,2",
+    dimension=[256,256,256] # You can use a string or a list
+)
+```

--- a/applications/rtkconjugategradient/rtkconjugategradient.py
+++ b/applications/rtkconjugategradient/rtkconjugategradient.py
@@ -5,7 +5,7 @@ import itk
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # argument parsing
     parser = argparse.ArgumentParser(
         description="Reconstructs a 3D volume from a sequence of projections with a conjugate gradient technique",
@@ -47,7 +47,10 @@ def main():
     rtk.add_rtkprojectors_group(parser)
     rtk.add_rtkiterations_group(parser)
 
-    args_info = parser.parse_args()
+    # Parse the command line arguments
+    return parser
+
+def process(args_info: argparse.Namespace):
 
     OutputPixelType = itk.F
     Dimension = 3
@@ -146,6 +149,11 @@ def main():
     writer.SetFileName(args_info.output)
     writer.SetInput(conjugategradient.GetOutput())
     writer.Update()
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
+++ b/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
@@ -5,27 +5,34 @@ import itk
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # Argument parsing
     parser = argparse.ArgumentParser(
         description="Creates an RTK geometry file from an Elekta Synergy acquisition."
     )
 
     parser.add_argument("--verbose", "-v", help="Verbose execution", type=bool)
-    parser.add_argument("--xml", "-x", help="XML file name (starting with XVI5)")
-    parser.add_argument("--output", "-o", help="Output file name")
+    parser.add_argument(
+        "--xml", "-x", help="XML file name (starting with XVI5)", required=True
+    )
+    parser.add_argument("--output", "-o", help="Output file name", required=True)
 
-    args = parser.parse_args()
+    return parser
 
-    if args.xml is None or args.output is None:
-        parser.print_help()
-        sys.exit()
+
+def process(args_info: argparse.Namespace):
 
     reader = rtk.ElektaXVI5GeometryXMLFileReader.New()
-    reader.SetFilename(args.xml)
+    reader.SetFilename(args_info.xml)
     reader.GenerateOutputInformation()
 
-    rtk.write_geometry(reader.GetGeometry(), args.output)
+    rtk.write_geometry(reader.GetGeometry(), args_info.output)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/applications/rtkfdk/FDK3D.sh
+++ b/applications/rtkfdk/FDK3D.sh
@@ -3,10 +3,10 @@ rtksimulatedgeometry -n 180 -o geometry.xml
 # You may add "--arc 200" to make the scan short or "--proj_iso_x 200" to offset the detector
 
 # Create projections of the phantom file
-rtkprojectshepploganphantom -g geometry.xml -o projections.mha --spacing 2 --size 256
+rtkprojectshepploganphantom -g geometry.xml -o projections.mha --spacing 2 --size 200
 
 # Reconstruct
-rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --size 256
+rtkfdk -p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --size 128
 
 # Create a reference volume for comparison
-rtkdrawshepploganphantom --spacing 2 --size 256 -o ref.mha
+rtkdrawshepploganphantom --like fdk.mha -o ref.mha

--- a/applications/rtkorageometry/rtkorageometry.py
+++ b/applications/rtkorageometry/rtkorageometry.py
@@ -4,7 +4,7 @@ import itk
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # Argument parsing
     parser = argparse.ArgumentParser(
         description="Creates an RTK geometry file from a Varian OBI acquisition."
@@ -29,7 +29,11 @@ def main():
         default=0.0,
     )
 
-    args = parser.parse_args()
+    # Parse the command line arguments
+    return parser
+
+
+def process(args: argparse.Namespace):
 
     margin = args.margin
     if type(margin) is float:
@@ -48,6 +52,12 @@ def main():
     reader.UpdateOutputData()
 
     rtk.write_geometry(reader.GetGeometry(), args.output)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.py
+++ b/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.py
@@ -3,7 +3,7 @@ import argparse
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # Argument parsing
     parser = argparse.ArgumentParser(
         description="Computes projections through a 3D Shepp & Logan phantom, according to a geometry"
@@ -33,7 +33,11 @@ def main():
 
     rtk.add_rtk3Doutputimage_group(parser)
 
-    args_info = parser.parse_args()
+    # Parse the command line arguments
+    return parser
+
+
+def process(args_info: argparse.Namespace):
 
     OutputPixelType = itk.F
     Dimension = 3
@@ -88,6 +92,12 @@ def main():
         print("Projecting and writing... ")
 
     itk.imwrite(output, args_info.output)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
@@ -4,7 +4,7 @@ import sys
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # Argument parsing
     parser = argparse.ArgumentParser(
         description="Creates an RTK geometry file from simulated/regular trajectory. See https://docs.openrtk.org/en/latest/documentation/docs/Geometry.html for more information."
@@ -13,8 +13,10 @@ def main():
     parser.add_argument(
         "--verbose", "-v", type=bool, default=False, help="Verbose execution"
     )
-    parser.add_argument("--nproj", "-n", type=int, help="Number of projections")
-    parser.add_argument("--output", "-o", help="Output file name")
+    parser.add_argument(
+        "--nproj", "-n", type=int, help="Number of projections", required=True
+    )
+    parser.add_argument("--output", "-o", help="Output file name", required=True)
     parser.add_argument(
         "--first_angle", "-f", type=float, default=0, help="First angle in degrees"
     )
@@ -64,12 +66,11 @@ def main():
         help="Radius cylinder of cylindrical detector",
     )
 
-    args = parser.parse_args()
+    # Parse the command line arguments
+    return parser
 
-    if args.nproj is None or args.output is None:
-        parser.print_help()
-        sys.exit()
 
+def process(args: argparse.Namespace):
     # Simulated Geometry
     GeometryType = rtk.ThreeDCircularProjectionGeometry
     geometry = GeometryType.New()
@@ -91,6 +92,12 @@ def main():
     geometry.SetRadiusCylindricalDetector(args.rad_cyl)
 
     rtk.write_geometry(geometry, args.output)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/applications/rtkvarianobigeometry/rtkvarianobigeometry.py
+++ b/applications/rtkvarianobigeometry/rtkvarianobigeometry.py
@@ -5,7 +5,7 @@ import itk
 from itk import RTK as rtk
 
 
-def main():
+def build_parser():
     # Argument parsing
     parser = argparse.ArgumentParser(
         description="Creates an RTK geometry file from a Varian OBI acquisition."
@@ -13,21 +13,27 @@ def main():
 
     parser.add_argument("--verbose", "-v", help="Verbose execution", type=bool)
     parser.add_argument(
-        "--xml_file", "-x", help="Varian OBI XML information file on projections"
+        "--xml_file",
+        "-x",
+        help="Varian OBI XML information file on projections",
+        required=True,
     )
-    parser.add_argument("--output", "-o", help="Output file name")
+    parser.add_argument("--output", "-o", help="Output file name", required=True)
     parser.add_argument(
         "--path", "-p", help="Path containing projections", required=True
     )
     parser.add_argument(
-        "--regexp", "-r", help="Regular expression to select projection files in path"
+        "--regexp",
+        "-r",
+        help="Regular expression to select projection files in path",
+        required=True,
     )
 
-    args = parser.parse_args()
+    # Parse the command line arguments
+    return parser
 
-    if args.xml_file is None or args.output is None:
-        parser.print_help()
-        sys.exit()
+
+def process(args: argparse.Namespace):
 
     names = itk.RegularExpressionSeriesFileNames.New()
     names.SetDirectory(args.path)
@@ -39,6 +45,12 @@ def main():
     reader.UpdateOutputData()
 
     rtk.write_geometry(reader.GetGeometry(), args.output)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args_info = parser.parse_args(argv)
+    process(args_info)
 
 
 if __name__ == "__main__":

--- a/wrapping/__init_rtk__.py
+++ b/wrapping/__init_rtk__.py
@@ -3,6 +3,8 @@ import importlib
 
 itk_module = sys.modules["itk"]
 rtk_module = getattr(itk_module, "RTK")
+
+# Import RTK submodules
 rtk_submodules = [
     "itk.rtkinputprojections_group",
     "itk.rtk3Doutputimage_group",
@@ -15,3 +17,23 @@ for mod_name in rtk_submodules:
     for a in dir(mod):
         if a[0] != "_":
             setattr(rtk_module, a, getattr(mod, a))
+
+# Application modules
+_app_modules = [
+    "rtkfdk",
+    "rtkconjugategradient",
+    "rtkelektasynergygeometry",
+    "rtkorageometry",
+    "rtkprojectshepploganphantom",
+    "rtksimulatedgeometry",
+    "rtkvarianobigeometry",
+    "rtkshowgeometry",
+]
+
+# Dynamically access make_application_func from rtkExtras
+rtk_extras = importlib.import_module("itk.rtkExtras")
+make_application_func = getattr(rtk_extras, "make_application_func")
+
+# Dynamically register applications
+for app_name in _app_modules:
+    setattr(rtk_module, app_name, make_application_func(app_name))

--- a/wrapping/rtkExtras.py
+++ b/wrapping/rtkExtras.py
@@ -1,5 +1,12 @@
 import itk
 from itk import RTK as rtk
+import inspect
+import difflib
+from typing import Any, Callable
+import argparse
+import importlib
+import shlex
+
 
 # Write a 3D circular projection geometry to a file.
 def write_geometry(geometry, filename):
@@ -45,4 +52,162 @@ class PercentageProgressCommand:
 
 # Returns a lambda function that parses a comma-separated string and converts each element to the specified type.
 def comma_separated_args(value_type):
-    return lambda value: [value_type(s.strip()) for s in value.split(",")]
+    def parser(value):
+        try:
+            return [value_type(s.strip()) for s in value.split(",")]
+        except ValueError as e:
+            raise argparse.ArgumentTypeError(
+                f"invalid {value_type.__name__} value: {value!r}"
+            )
+
+    return parser
+
+
+def parse_kwargs(parser: argparse.ArgumentParser, func_name: str = None, **kwargs: Any):
+    """
+    Convert kwargs → argv → parsed Namespace.
+    Raises TypeError for unknown keys (with suggestions),
+    ValueError for parsing errors, and TypeError for incorrect types.
+    """
+    # Collect valid destinations and their expected types
+    valid = {
+        action.dest: action.type
+        for action in parser._actions
+        if action.dest and action.dest not in ("help", "version")
+    }
+
+    # Early reject unknown keys
+    for key in kwargs:
+        if key not in valid:
+            matches = difflib.get_close_matches(key, valid.keys(), n=3, cutoff=0.5)
+            name = func_name or parser.prog or "function"
+            msg = f"{name}() got an unexpected keyword argument '{key}'"
+            if matches:
+                msg += f"\nDid you mean: {', '.join(matches)}?"
+            else:
+                msg += f"\nValid arguments are: {', '.join(sorted(valid.keys()))}"
+            raise TypeError(msg)
+
+    # Convert kwargs to argv
+    argv = []
+    for key, val in kwargs.items():
+        flag = f"--{key}" if len(key) > 1 else f"-{key}"
+        if isinstance(val, bool):
+            if val:
+                argv.append(flag)
+        elif isinstance(val, (list, tuple)):
+            for v in val:
+                argv += [flag, str(v)]
+        else:
+            argv += [flag, str(val)]
+
+    return parser.parse_args(argv)
+
+
+def patch_signature(func: Callable[..., Any], parser: argparse.ArgumentParser):
+    """
+    Set func.__signature__ based on parser._actions, so inspect.signature(func)
+    shows the real keyword-only parameters.
+    Required arguments are listed first.
+    """
+    required_params = []
+    optional_params = []
+
+    for action in parser._actions:
+        name = action.dest
+        if not name or name in ("help", "version"):
+            continue
+
+        if getattr(action, "required", False):
+            default = inspect._empty
+            required_params.append(
+                inspect.Parameter(
+                    name=name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    default=default,
+                )
+            )
+        else:
+            if action.default is not None:
+                default = action.default
+            else:
+                default = inspect._empty
+
+            optional_params.append(
+                inspect.Parameter(
+                    name=name,
+                    kind=inspect.Parameter.KEYWORD_ONLY,
+                    default=default,
+                )
+            )
+
+    # Combine required and optional parameters, with required ones first
+    func.__signature__ = inspect.Signature(required_params + optional_params)
+
+
+def make_application_func(app_name):
+    def application_func(*args, **kwargs):
+        # Dynamically import the application's module
+        app_module = importlib.import_module(f"itk.{app_name}")
+
+        main = getattr(app_module, "main", None)
+        process = getattr(app_module, "process", None)
+        build_parser = getattr(app_module, "build_parser", None)
+
+        parser = build_parser()
+
+        # Shell style
+        if len(args) == 1 and isinstance(args[0], str) and not kwargs:
+            argv = shlex.split(args[0])
+            try:
+                return main(argv)
+            except:
+                return
+
+        # Handle positional arguments
+        if len(args) > 0:
+            raise ValueError(f"The positional arguments are not supported. ")
+
+        # Python API style
+        if len(args) == 0:
+            parser = build_parser()
+            parsed = rtk.parse_kwargs(parser, func_name=app_name, **kwargs)
+            return process(parsed)
+
+    # Patch the function's signature using the parser
+    parser = importlib.import_module(f"itk.{app_name}").build_parser()
+    patch_signature(application_func, parser)
+
+    # Update the function's metadata to reflect the application name
+    application_func.__name__ = app_name
+    application_func.__module__ = "itk.RTK"
+
+    # Extract required arguments
+    required_args = []
+    for action in parser._actions:
+        if action.required:
+            arg_name = f"--{action.dest} {action.dest.upper()}"
+            required_args.append(arg_name)
+
+    # Generate shell-style and Python API-style examples
+    shell_example = f'{app_name}("{" ".join(required_args)}")'
+    python_api_example = f'{app_name}({", ".join([f"{arg.dest}={arg.dest.upper()}" for arg in parser._actions if arg.required])})'
+
+    # Get the help text and remove the 'usage:' line(s)
+    help_lines = parser.format_help().splitlines()
+    option_idx = 0
+    for i, line in enumerate(help_lines):
+        if line.strip().startswith("options:"):
+            option_idx = i
+
+    usage_examples = f"""
+-----\n
+Usage:
+    • Shell-style: {shell_example}
+    • Python API:  {python_api_example}
+"""
+    application_func.__doc__ = (
+        parser.description + usage_examples + "\n".join(help_lines[option_idx:])
+    )
+
+    return application_func


### PR DESCRIPTION
**Enable use of applications via the Python API**
Modified rtkfdk to support both CLI usage and direct calls from Python. Now supports:

- rtk.rtkfdk("-p . -r projections.mha -o fdk.mha -g geometry.xml --spacing 2 --dimension 256")
- rtk.rtkfdk(path=".", regexp="projections.mha", output="fdk.mha", geometry="geometry.xml", spacing=2, dimension=256, verbose=True)

Signature is auto-patched for better help and to raise standard Python exceptions instead of argparse errors.