### PR TITLE
COMP: Remove unused variable and typedef warnings in Zeng test

### DIFF
--- a/test/rtkzengforwardprojectiontest.cxx
+++ b/test/rtkzengforwardprojectiontest.cxx
@@ -32,7 +32,6 @@ main(int, char **)
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 #endif
 
-  using VectorType = itk::Vector<double, 3>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
 #else
@@ -90,7 +89,7 @@ main(int, char **)
 
   using DEIFType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
   DEIFType::Pointer    volInput = DEIFType::New();
-  DEIFType::VectorType axis_vol, center_vol, center_att, axis_att;
+  DEIFType::VectorType axis_vol, center_vol;
   axis_vol[0] = 32;
   axis_vol[1] = 32;
   axis_vol[2] = 32;


### PR DESCRIPTION
The warnings were:
Modules/Remote/RTK/test/rtkzengforwardprojectiontest.cxx:93:46: warning: unused variable ‘center_att’ [-Wunused-variable]
Modules/Remote/RTK/test/rtkzengforwardprojectiontest.cxx:93:58: warning: unused variable ‘axis_att’ [-Wunused-variable]
Modules/Remote/RTK/test/rtkzengforwardprojectiontest.cxx:35:9: warning: typedef ‘using VectorType = struct itk::Vector<double, 3>’ locally defined but not used [-Wunused-local-typedefs]