### PR TITLE
STYLE: Modernize c++ code by using auto over multiple lines

### DIFF
--- a/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
+++ b/applications/rtkdualenergyforwardmodel/rtkdualenergyforwardmodel.cxx
@@ -82,8 +82,7 @@ main(int argc, char * argv[])
   }
   else
   {
-    rtk::ConstantImageSource<DetectorResponseImageType>::Pointer detectorSource =
-      rtk::ConstantImageSource<DetectorResponseImageType>::New();
+    auto detectorSource = rtk::ConstantImageSource<DetectorResponseImageType>::New();
     detectorSource->SetSize(itk::MakeSize(1, MaximumEnergy));
     detectorSource->SetConstant(1.0);
     detectorSource->Update();

--- a/applications/rtkdualenergysimplexdecomposition/rtkdualenergysimplexdecomposition.cxx
+++ b/applications/rtkdualenergysimplexdecomposition/rtkdualenergysimplexdecomposition.cxx
@@ -87,8 +87,7 @@ main(int argc, char * argv[])
   }
   else
   {
-    rtk::ConstantImageSource<DetectorResponseImageType>::Pointer detectorSource =
-      rtk::ConstantImageSource<DetectorResponseImageType>::New();
+    auto detectorSource = rtk::ConstantImageSource<DetectorResponseImageType>::New();
     detectorSource->SetSize(itk::MakeSize(1, MaximumEnergy));
     detectorSource->SetConstant(1.0);
     detectorSource->Update();

--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -76,8 +76,7 @@ main(int argc, char * argv[])
   }
 
   // OSEM reconstruction filter
-  rtk::OSEMConeBeamReconstructionFilter<OutputImageType>::Pointer osem =
-    rtk::OSEMConeBeamReconstructionFilter<OutputImageType>::New();
+  auto osem = rtk::OSEMConeBeamReconstructionFilter<OutputImageType>::New();
 
   // Set the forward and back projection filters
   SetForwardProjectionFromGgo(args_info, osem.GetPointer());

--- a/applications/rtksart/rtksart.cxx
+++ b/applications/rtksart/rtksart.cxx
@@ -89,8 +89,7 @@ main(int argc, char * argv[])
   }
 
   // SART reconstruction filter
-  rtk::SARTConeBeamReconstructionFilter<OutputImageType>::Pointer sart =
-    rtk::SARTConeBeamReconstructionFilter<OutputImageType>::New();
+  auto sart = rtk::SARTConeBeamReconstructionFilter<OutputImageType>::New();
 
   // Set the forward and back projection filters
   SetForwardProjectionFromGgo(args_info, sart.GetPointer());

--- a/include/rtkProjectionsReader.hxx
+++ b/include/rtkProjectionsReader.hxx
@@ -71,8 +71,7 @@
     auto reader = ReaderType::New();                                                                                \
     m_RawDataReader = reader;                                                                                       \
     using VectorComponentSelectionType = itk::VectorIndexSelectionCastImageFilter<InputImageType, OutputImageType>; \
-    typename VectorComponentSelectionType::Pointer vectorComponentSelectionFilter =                                 \
-      VectorComponentSelectionType::New();                                                                          \
+    auto vectorComponentSelectionFilter = VectorComponentSelectionType::New();                                      \
     if (m_VectorComponent < numberOfComponents)                                                                     \
       vectorComponentSelectionFilter->SetIndex(m_VectorComponent);                                                  \
     else                                                                                                            \

--- a/include/rtkWarpSequenceImageFilter.hxx
+++ b/include/rtkWarpSequenceImageFilter.hxx
@@ -92,9 +92,8 @@ WarpSequenceImageFilter<TImageSequence, TDVFImageSequence, TImage, TDVFImage>::G
     m_DVFInterpolatorFilter = CudaCyclicDeformationImageFilterType::New();
   }
 
-  auto                                              linearInterpolator = LinearInterpolatorType::New();
-  typename NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-    NearestNeighborInterpolatorType::New();
+  auto linearInterpolator = LinearInterpolatorType::New();
+  auto nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
 
   if (m_UseNearestNeighborInterpolationInWarping)
     m_WarpFilter->SetInterpolator(nearestNeighborInterpolator);

--- a/test/rtkcroptest.cxx
+++ b/test/rtkcroptest.cxx
@@ -21,8 +21,8 @@ main(int, char **)
   using CropImageFilter = rtk::CudaCropImageFilter;
   auto crop = CropImageFilter::New();
   crop->SetInput(image);
-  crop->SetUpperBoundaryCropSize(itk::MakeSize(1, 1, 1));
-  crop->SetLowerBoundaryCropSize(itk::MakeSize(10, 10, 10));
+  crop->SetLowerBoundaryCropSize(itk::MakeSize(1, 1, 1));
+  crop->SetUpperBoundaryCropSize(itk::MakeSize(10, 10, 10));
 
   try
   {

--- a/test/rtkdecomposespectralprojectionstest.cxx
+++ b/test/rtkdecomposespectralprojectionstest.cxx
@@ -219,8 +219,7 @@ main(int argc, char * argv[])
   measuredProjections->SetRegions(region);
   measuredProjections->Allocate();
 
-  typename CastDecomposedProjectionsFilterType::Pointer castDecomposedProjections =
-    CastDecomposedProjectionsFilterType::New();
+  auto castDecomposedProjections = CastDecomposedProjectionsFilterType::New();
   auto castMeasuredProjections = CastMeasuredProjectionFilterType::New();
   castDecomposedProjections->SetInput(decomposed);
   castMeasuredProjections->SetInput(measuredProjections);
@@ -228,8 +227,7 @@ main(int argc, char * argv[])
   forward->SetInputMeasuredProjections(castMeasuredProjections->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(forward->Update())
 
-  typename CastDecomposedProjectionsFilterType::Pointer castDecomposedProjections2 =
-    CastDecomposedProjectionsFilterType::New();
+  auto castDecomposedProjections2 = CastDecomposedProjectionsFilterType::New();
   auto castMeasuredProjections2 = CastMeasuredProjectionFilterType::New();
   castDecomposedProjections->SetInput(initialDecomposedProjections);
   castMeasuredProjections->SetInput(forward->GetOutput());

--- a/test/rtkforwardprojectiontest.cxx
+++ b/test/rtkforwardprojectiontest.cxx
@@ -38,7 +38,6 @@ main(int, char **)
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 #endif
 
-  using VectorType = itk::Vector<double, 3>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
 #else

--- a/test/rtkgeometryfiletest.cxx
+++ b/test/rtkgeometryfiletest.cxx
@@ -11,8 +11,7 @@ WriteReadAndCheck(GeometryType * geometry)
   const char   fileName[] = "rtkgeometryfiletest.out";
   const double epsilon = 1e-13;
 
-  rtk::ThreeDCircularProjectionGeometryXMLFileWriter::Pointer xmlWriter =
-    rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
+  auto xmlWriter = rtk::ThreeDCircularProjectionGeometryXMLFileWriter::New();
   xmlWriter->SetFilename(fileName);
   xmlWriter->SetObject(geometry);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(xmlWriter->WriteFile())

--- a/test/rtkimporttest.cxx
+++ b/test/rtkimporttest.cxx
@@ -110,8 +110,7 @@ main(int, char **)
   volSize.Fill(10);
   volRegion.SetSize(volSize);
 
-  rtk::ImportImageFilter<itk::Image<unsigned int, 2>>::Pointer vol =
-    rtk::ImportImageFilter<itk::Image<unsigned int, 2>>::New();
+  auto vol = rtk::ImportImageFilter<itk::Image<unsigned int, 2>>::New();
   vol->SetRegion(volRegion);
   vol->SetSpacing(itk::MakeVector(1.0, 1.0));
   vol->SetImportPointer(vec_uint_2d, 10 * 10, false);
@@ -121,8 +120,7 @@ main(int, char **)
   std::cout << "\n\nTest PASSED! " << std::endl;
 
 #ifdef USE_CUDA
-  rtk::ImportImageFilter<itk::CudaImage<unsigned int, 2>>::Pointer volCuda =
-    rtk::ImportImageFilter<itk::CudaImage<unsigned int, 2>>::New();
+  auto volCuda = rtk::ImportImageFilter<itk::CudaImage<unsigned int, 2>>::New();
   volCuda->SetRegion(volRegion);
   volCuda->SetSpacing(itk::MakeVector(1.0, 1.0));
   volCuda->SetImportPointer(vec_uint_2d, 10 * 10, false);
@@ -157,8 +155,7 @@ main(int, char **)
   std::cout << "\n\nTest PASSED! " << std::endl;
 
 #ifdef USE_CUDA
-  rtk::ImportImageFilter<itk::CudaImage<int, 2>>::Pointer volIntCuda =
-    rtk::ImportImageFilter<itk::CudaImage<int, 2>>::New();
+  auto volIntCuda = rtk::ImportImageFilter<itk::CudaImage<int, 2>>::New();
   volIntCuda->SetRegion(volIntRegion);
   volIntCuda->SetSpacing(itk::MakeVector(1.0, 1.0));
   volIntCuda->SetImportPointer(vec_int_2d, 10 * 10, false);
@@ -193,8 +190,7 @@ main(int, char **)
   std::cout << "\n\nTest PASSED! " << std::endl;
 
 #ifdef USE_CUDA
-  rtk::ImportImageFilter<itk::CudaImage<float, 2>>::Pointer volFloatCuda =
-    rtk::ImportImageFilter<itk::CudaImage<float, 2>>::New();
+  auto volFloatCuda = rtk::ImportImageFilter<itk::CudaImage<float, 2>>::New();
   volFloatCuda->SetRegion(volFloatRegion);
   volFloatCuda->SetSpacing(itk::MakeVector(1.0, 1.0));
   volFloatCuda->SetImportPointer(vec_float_2d, 10 * 10, false);
@@ -219,8 +215,7 @@ main(int, char **)
   volDoubleSize.Fill(10);
   volDoubleRegion.SetSize(volDoubleSize);
 
-  rtk::ImportImageFilter<itk::Image<double, 2>>::Pointer volDouble =
-    rtk::ImportImageFilter<itk::Image<double, 2>>::New();
+  auto volDouble = rtk::ImportImageFilter<itk::Image<double, 2>>::New();
   volDouble->SetRegion(volDoubleRegion);
   volDouble->SetSpacing(itk::MakeVector(1.0, 1.0));
   volDouble->SetImportPointer(vec_double_2d, 10 * 10, false);
@@ -230,8 +225,7 @@ main(int, char **)
   std::cout << "\n\nTest PASSED! " << std::endl;
 
 #ifdef USE_CUDA
-  rtk::ImportImageFilter<itk::CudaImage<double, 2>>::Pointer volDoubleCuda =
-    rtk::ImportImageFilter<itk::CudaImage<double, 2>>::New();
+  auto volDoubleCuda = rtk::ImportImageFilter<itk::CudaImage<double, 2>>::New();
   volDoubleCuda->SetRegion(volDoubleRegion);
   volDoubleCuda->SetSpacing(itk::MakeVector(1.0, 1.0));
   volDoubleCuda->SetImportPointer(vec_double_2d, 10 * 10, false);

--- a/test/rtkspectralonesteptest.cxx
+++ b/test/rtkspectralonesteptest.cxx
@@ -220,8 +220,7 @@ main(int argc, char * argv[])
 
   // Convert the itk::VectorImage<> returned by "forward" into
   // an itk::Image<itk::Vector<>>
-  typename CastMeasuredProjectionsFilterType::Pointer castMeasuredProjections =
-    CastMeasuredProjectionsFilterType::New();
+  auto castMeasuredProjections = CastMeasuredProjectionsFilterType::New();
   castMeasuredProjections->SetInput(forward->GetOutput());
 
   // Read the material attenuations image as a matrix


### PR DESCRIPTION
This is a follow up to #761 using the following command line find * -type f -exec sed -zi "s/[^\n]*::Pointer \([^\n]*=[^;]*New()\)/auto \1/g" {} \;