### PR TITLE
STYLE: remove “using” aliases to inline single-use types

### DIFF
--- a/applications/rtkadmmtotalvariation/rtkadmmtotalvariation.cxx
+++ b/applications/rtkadmmtotalvariation/rtkadmmtotalvariation.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Phase gating weights reader
-  using PhaseGatingFilterType = rtk::PhaseGatingImageFilter<OutputImageType>;
-  auto phaseGating = PhaseGatingFilterType::New();
+  auto phaseGating = rtk::PhaseGatingImageFilter<OutputImageType>::New();
   if (args_info.phases_given)
   {
     phaseGating->SetPhasesFileName(args_info.phases_arg);
@@ -80,8 +79,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }

--- a/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
+++ b/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
@@ -59,8 +59,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Displaced detector weighting
-  using DDFType = rtk::DisplacedDetectorImageFilter<OutputImageType>;
-  auto ddf = DDFType::New();
+  auto ddf = rtk::DisplacedDetectorImageFilter<OutputImageType>::New();
   ddf->SetInput(projectionsReader->GetOutput());
   ddf->SetGeometry(geometry);
 
@@ -69,8 +68,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }

--- a/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
+++ b/applications/rtkamsterdamshroud/rtkamsterdamshroud.cxx
@@ -30,10 +30,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkamsterdamshroud, args_info);
 
-  using OutputPixelType = double;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<double, Dimension>;
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<OutputImageType>;
@@ -79,8 +78,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(shroudFilter->UpdateOutputInformation())
 
   // Write
-  using WriterType = itk::ImageFileWriter<ShroudFilterType::OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<ShroudFilterType::OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(shroudFilter->GetOutput());
   writer->SetNumberOfStreamDivisions(shroudFilter->GetOutput()->GetLargestPossibleRegion().GetSize(1));

--- a/applications/rtkbackprojections/rtkbackprojections.cxx
+++ b/applications/rtkbackprojections/rtkbackprojections.cxx
@@ -83,9 +83,7 @@ main(int argc, char * argv[])
 
   // In case warp backprojection is used, we create a deformation
   using DVFPixelType = itk::Vector<float, 3>;
-  using DVFImageSequenceType = itk::Image<DVFPixelType, 4>;
-  using DVFImageType = itk::Image<DVFPixelType, 3>;
-  using DeformationType = rtk::CyclicDeformationImageFilter<DVFImageSequenceType, DVFImageType>;
+  using DeformationType = rtk::CyclicDeformationImageFilter<itk::Image<DVFPixelType, 4>, itk::Image<DVFPixelType, 3>>;
   auto def = DeformationType::New();
 
   switch (args_info.bp_arg)

--- a/applications/rtkconjugategradient/rtkconjugategradient.cxx
+++ b/applications/rtkconjugategradient/rtkconjugategradient.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -107,8 +106,7 @@ main(int argc, char * argv[])
   }
 
   // Set the forward and back projection filters to be used
-  using ConjugateGradientFilterType = rtk::ConjugateGradientConeBeamReconstructionFilter<OutputImageType>;
-  auto conjugategradient = ConjugateGradientFilterType::New();
+  auto conjugategradient = rtk::ConjugateGradientConeBeamReconstructionFilter<OutputImageType>::New();
   SetForwardProjectionFromGgo(args_info, conjugategradient.GetPointer());
   SetBackProjectionFromGgo(args_info, conjugategradient.GetPointer());
   conjugategradient->SetInputVolume(inputFilter->GetOutput());

--- a/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
+++ b/applications/rtkdrawgeometricphantom/rtkdrawgeometricphantom.cxx
@@ -28,9 +28,8 @@ main(int argc, char * argv[])
 {
   GGO(rtkdrawgeometricphantom, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Empty volume image
   using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
@@ -94,8 +93,7 @@ main(int argc, char * argv[])
   OutputImageType::Pointer output = dq->GetOutput();
   if (args_info.noise_given)
   {
-    using NIFType = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>;
-    auto noisy = NIFType::New();
+    auto noisy = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>::New();
     noisy->SetInput(output);
     noisy->SetMean(0.0);
     noisy->SetStandardDeviation(args_info.noise_arg);

--- a/applications/rtkdrawshepploganphantom/rtkdrawshepploganphantom.cxx
+++ b/applications/rtkdrawshepploganphantom/rtkdrawshepploganphantom.cxx
@@ -33,10 +33,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkdrawshepploganphantom, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Create a stack of empty projection images
   using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
@@ -63,8 +62,7 @@ main(int argc, char * argv[])
   OutputImageType::Pointer output = dsl->GetOutput();
   if (args_info.noise_given)
   {
-    using NIFType = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>;
-    auto noisy = NIFType::New();
+    auto noisy = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>::New();
     noisy->SetInput(output);
     noisy->SetMean(0.0);
     noisy->SetStandardDeviation(args_info.noise_arg);

--- a/applications/rtkextractphasesignal/rtkextractphasesignal.cxx
+++ b/applications/rtkextractphasesignal/rtkextractphasesignal.cxx
@@ -45,10 +45,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkextractphasesignal, args_info);
 
-  using PixelType = double;
   constexpr unsigned int Dimension = 1;
 
-  using ImageType = itk::Image<PixelType, Dimension>;
+  using ImageType = itk::Image<double, Dimension>;
 
   // Read
   ImageType::Pointer signal;

--- a/applications/rtkfdktwodweights/rtkfdktwodweights.cxx
+++ b/applications/rtkfdktwodweights/rtkfdktwodweights.cxx
@@ -29,10 +29,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkfdktwodweights, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<OutputImageType>;
@@ -46,16 +45,14 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Weights filter
-  using WeightType = rtk::FDKWeightProjectionFilter<OutputImageType>;
-  auto wf = WeightType::New();
+  auto wf = rtk::FDKWeightProjectionFilter<OutputImageType>::New();
   wf->SetInput(reader->GetOutput());
   wf->SetGeometry(geometry);
   wf->SetNumberOfWorkUnits(1);
   wf->InPlaceOff();
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(wf->GetOutput());
   writer->SetNumberOfStreamDivisions(args_info.divisions_arg);

--- a/applications/rtkfieldofview/rtkfieldofview.cxx
+++ b/applications/rtkfieldofview/rtkfieldofview.cxx
@@ -74,8 +74,7 @@ main(int argc, char * argv[])
   if (!args_info.bp_flag)
   {
     // FOV filter
-    using FOVFilterType = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>;
-    auto fieldofview = FOVFilterType::New();
+    auto fieldofview = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>::New();
     fieldofview->SetMask(args_info.mask_flag);
     fieldofview->SetInput(0, unmasked_reconstruction);
     fieldofview->SetProjectionsStack(reader->GetOutput());
@@ -110,27 +109,23 @@ main(int argc, char * argv[])
     zeroVol->SetConstant(0.);
     zeroVol->SetInformationFromImage(unmasked_reconstruction);
 
-    using BPType = rtk::BackProjectionImageFilter<MaskImgType, MaskImgType>;
-    auto bp = BPType::New();
+    auto bp = rtk::BackProjectionImageFilter<MaskImgType, MaskImgType>::New();
 #ifdef RTK_USE_CUDA
-    using BPCudaType = rtk::CudaBackProjectionImageFilter<MaskImgType>;
     if (!strcmp(args_info.hardware_arg, "cuda"))
-      bp = BPCudaType::New();
+      bp = rtk::CudaBackProjectionImageFilter<MaskImgType>::New();
 #endif
     bp->SetInput(zeroVol->GetOutput());
     bp->SetInput(1, ones->GetOutput());
     bp->SetGeometry(geometry);
 
-    using ThreshType = itk::ThresholdImageFilter<MaskImgType>;
-    auto thresh = ThreshType::New();
+    auto thresh = itk::ThresholdImageFilter<MaskImgType>::New();
     thresh->SetInput(bp->GetOutput());
     thresh->ThresholdBelow(geometry->GetGantryAngles().size() - 1);
     thresh->SetOutsideValue(0.);
 
     if (args_info.mask_flag)
     {
-      using DivideType = itk::DivideImageFilter<MaskImgType, MaskImgType, MaskImgType>;
-      auto div = DivideType::New();
+      auto div = itk::DivideImageFilter<MaskImgType, MaskImgType, MaskImgType>::New();
       div->SetInput(thresh->GetOutput());
       div->SetConstant2(geometry->GetGantryAngles().size());
 

--- a/applications/rtkforwardprojections/rtkforwardprojections.cxx
+++ b/applications/rtkforwardprojections/rtkforwardprojections.cxx
@@ -194,8 +194,7 @@ main(int argc, char * argv[])
   // Write
   if (args_info.verbose_flag)
     std::cout << "Writing... " << std::endl;
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(forwardProjection->GetOutput());
   if (args_info.lowmem_flag)

--- a/applications/rtkfourdconjugategradient/rtkfourdconjugategradient.cxx
+++ b/applications/rtkfourdconjugategradient/rtkfourdconjugategradient.cxx
@@ -63,8 +63,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<VolumeSeriesType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<VolumeSeriesType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -94,8 +93,7 @@ main(int argc, char * argv[])
   // Re-order geometry and projections
   // In the new order, projections with identical phases are packed together
   std::vector<double> signal = rtk::ReadSignalFile(args_info.signal_arg);
-  using ReorderProjectionsFilterType = rtk::ReorderProjectionsImageFilter<ProjectionStackType>;
-  auto reorder = ReorderProjectionsFilterType::New();
+  auto                reorder = rtk::ReorderProjectionsImageFilter<ProjectionStackType>::New();
   reorder->SetInput(reader->GetOutput());
   reorder->SetInputGeometry(geometry);
   reorder->SetInputSignal(signal);

--- a/applications/rtkfourdfdk/rtkfourdfdk.cxx
+++ b/applications/rtkfourdfdk/rtkfourdfdk.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Part specific to 4D
-  using SelectorType = rtk::SelectOneProjectionPerCycleImageFilter<OutputImageType>;
-  auto selector = SelectorType::New();
+  auto selector = rtk::SelectOneProjectionPerCycleImageFilter<OutputImageType>::New();
   selector->SetInput(reader->GetOutput());
   selector->SetInputGeometry(geometry);
   selector->SetSignalFilename(args_info.signal_arg);
@@ -78,18 +77,16 @@ main(int argc, char * argv[])
 #endif
 
   // Displaced detector weighting
-  using DDFCPUType = rtk::DisplacedDetectorImageFilter<OutputImageType>;
-  using DDFOFFFOVType = rtk::DisplacedDetectorForOffsetFieldOfViewImageFilter<OutputImageType>;
 #ifdef RTK_USE_CUDA
   using DDFType = rtk::CudaDisplacedDetectorImageFilter;
 #else
   using DDFType = rtk::DisplacedDetectorForOffsetFieldOfViewImageFilter<OutputImageType>;
 #endif
-  DDFCPUType::Pointer ddf;
+  rtk::DisplacedDetectorImageFilter<OutputImageType>::Pointer ddf;
   if (!strcmp(args_info.hardware_arg, "cuda"))
     ddf = DDFType::New();
   else
-    ddf = DDFOFFFOVType::New();
+    ddf = rtk::DisplacedDetectorForOffsetFieldOfViewImageFilter<OutputImageType>::New();
   ddf->SetInput(selector->GetOutput());
   ddf->SetGeometry(selector->GetOutputGeometry());
 
@@ -151,8 +148,7 @@ main(int argc, char * argv[])
 #endif
 
   // Streaming depending on streaming capability of writer
-  using StreamerType = itk::StreamingImageFilter<CPUOutputImageType, CPUOutputImageType>;
-  auto streamerBP = StreamerType::New();
+  auto streamerBP = itk::StreamingImageFilter<CPUOutputImageType, CPUOutputImageType>::New();
   streamerBP->SetInput(pfeldkamp);
   streamerBP->SetNumberOfStreamDivisions(args_info.divisions_arg);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(streamerBP->UpdateOutputInformation())

--- a/applications/rtkfourdrooster/rtkfourdrooster.cxx
+++ b/applications/rtkfourdrooster/rtkfourdrooster.cxx
@@ -64,8 +64,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<VolumeSeriesType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<VolumeSeriesType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -95,8 +94,7 @@ main(int argc, char * argv[])
   // Re-order geometry and projections
   // In the new order, projections with identical phases are packed together
   std::vector<double> signal = rtk::ReadSignalFile(args_info.signal_arg);
-  using ReorderProjectionsFilterType = rtk::ReorderProjectionsImageFilter<ProjectionStackType>;
-  auto reorder = ReorderProjectionsFilterType::New();
+  auto                reorder = rtk::ReorderProjectionsImageFilter<ProjectionStackType>::New();
   reorder->SetInput(reader->GetOutput());
   reorder->SetInputGeometry(geometry);
   reorder->SetInputSignal(signal);

--- a/applications/rtkfourdsart/rtkfourdsart.cxx
+++ b/applications/rtkfourdsart/rtkfourdsart.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<VolumeSeriesType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<VolumeSeriesType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }

--- a/applications/rtkgaincorrection/rtkgaincorrection.cxx
+++ b/applications/rtkgaincorrection/rtkgaincorrection.cxx
@@ -66,8 +66,7 @@ main(int argc, char * argv[])
   darkFile.append(args_info.Dark_arg);
 
   InputImageType::Pointer darkImage;
-  using DarkReaderType = itk::ImageFileReader<InputImageType>;
-  auto readerDark = DarkReaderType::New();
+  auto                    readerDark = itk::ImageFileReader<InputImageType>::New();
   readerDark->SetFileName(darkFile);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(readerDark->Update())
   darkImage = readerDark->GetOutput();
@@ -79,8 +78,7 @@ main(int argc, char * argv[])
   gainFile.append(args_info.Gain_arg);
 
   OutputImageType::Pointer gainImage;
-  using GainReaderType = itk::ImageFileReader<OutputImageType>;
-  auto readerGain = GainReaderType::New();
+  auto                     readerGain = itk::ImageFileReader<OutputImageType>::New();
   readerGain->SetFileName(gainFile);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(readerGain->Update())
   gainImage = readerGain->GetOutput();
@@ -98,13 +96,10 @@ main(int argc, char * argv[])
   gainfilter->SetK(args_info.K_arg);
 
   // Create empty volume for storing processed images
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto constantSource = ConstantImageSourceType::New();
+  auto constantSource = rtk::ConstantImageSource<OutputImageType>::New();
 
-  using ExtractType = itk::ExtractImageFilter<InputImageType, InputImageType>;
 
-  using PasteType = itk::PasteImageFilter<OutputImageType, OutputImageType>;
-  auto pasteFilter = PasteType::New();
+  auto pasteFilter = itk::PasteImageFilter<OutputImageType, OutputImageType>::New();
   pasteFilter->SetDestinationImage(constantSource->GetOutput());
 
   int bufferSize = args_info.bufferSize_arg;
@@ -124,7 +119,7 @@ main(int argc, char * argv[])
     desiredRegion.SetSize(itk::MakeSize(sliceRegion.GetSize()[0], sliceRegion.GetSize()[1], currentBufferSize));
     desiredRegion.SetIndex(itk::MakeIndex(sliceRegion.GetIndex()[0], sliceRegion.GetIndex()[1], bufferIdx));
 
-    auto extract = ExtractType::New();
+    auto extract = itk::ExtractImageFilter<InputImageType, InputImageType>::New();
     extract->SetDirectionCollapseToIdentity();
     extract->SetExtractionRegion(desiredRegion);
     extract->SetInput(reader->GetOutput());

--- a/applications/rtki0estimation/rtki0estimation.cxx
+++ b/applications/rtki0estimation/rtki0estimation.cxx
@@ -33,12 +33,10 @@ main(int argc, char * argv[])
 {
   GGO(rtki0estimation, args_info);
 
-  using InputPixelType = unsigned short;
   constexpr unsigned int Dimension = 3;
-  using InputImageType = itk::Image<InputPixelType, Dimension>;
+  using InputImageType = itk::Image<unsigned short, Dimension>;
 
-  using ReaderType = rtk::ProjectionsReader<InputImageType>;
-  auto reader = ReaderType::New();
+  auto reader = rtk::ProjectionsReader<InputImageType>::New();
   reader->SetFileNames(rtk::GetProjectionsFileNamesFromGgo(args_info));
   TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputInformation())
 
@@ -55,7 +53,6 @@ main(int argc, char * argv[])
   extractSize[2] = 1;
   InputImageType::IndexType start = subsetRegion.GetIndex();
 
-  using I0FilterType = rtk::I0EstimationProjectionFilter<InputImageType, InputImageType, 2>;
 
   std::vector<unsigned short> I0buffer;
 
@@ -73,7 +70,7 @@ main(int argc, char * argv[])
     }
   }
 
-  auto i0est = I0FilterType::New();
+  auto i0est = rtk::I0EstimationProjectionFilter<InputImageType, InputImageType, 2>::New();
 
   if (args_info.lambda_given)
   {

--- a/applications/rtkimagxgeometry/rtkimagxgeometry.cxx
+++ b/applications/rtkimagxgeometry/rtkimagxgeometry.cxx
@@ -27,12 +27,10 @@ main(int argc, char * argv[])
   GGO(rtkimagxgeometry, args_info);
 
   // Image Type
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // Create geometry reader
-  auto imagxReader = rtk::ImagXGeometryReader<OutputImageType>::New();
+  auto imagxReader = rtk::ImagXGeometryReader<itk::Image<float, Dimension>>::New();
   imagxReader->SetProjectionsFileNames(rtk::GetProjectionsFileNamesFromGgo(args_info));
   if (args_info.calibration_given)
   {

--- a/applications/rtklagcorrection/rtklagcorrection.cxx
+++ b/applications/rtklagcorrection/rtklagcorrection.cxx
@@ -80,8 +80,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(lagfilter->Update())
 
   // Streaming filter
-  using StreamerType = itk::StreamingImageFilter<OutputImageType, OutputImageType>;
-  auto streamer = StreamerType::New();
+  auto streamer = itk::StreamingImageFilter<OutputImageType, OutputImageType>::New();
   streamer->SetInput(lagfilter->GetOutput());
   streamer->SetNumberOfStreamDivisions(100);
 

--- a/applications/rtklastdimensionl0gradientdenoising/rtklastdimensionl0gradientdenoising.cxx
+++ b/applications/rtklastdimensionl0gradientdenoising/rtklastdimensionl0gradientdenoising.cxx
@@ -46,8 +46,7 @@ main(int argc, char * argv[])
   // #endif
 
   // Read input
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  auto reader = ReaderType::New();
+  auto reader = itk::ImageFileReader<OutputImageType>::New();
   reader->SetFileName(args_info.input_arg);
   reader->ReleaseDataFlagOn();
 

--- a/applications/rtklut/rtklut.cxx
+++ b/applications/rtklut/rtklut.cxx
@@ -39,15 +39,12 @@ main(int argc, char * argv[])
   rtk::SetProjectionsReaderFromGgo<ReaderType, args_info_rtklut>(reader, args_info);
 
   // Read lookup table
-  using LUTType = itk::Image<OutputPixelType, 1>;
-  using LUTReaderType = itk::ImageFileReader<LUTType>;
-  auto lutReader = LUTReaderType::New();
+  auto lutReader = itk::ImageFileReader<itk::Image<OutputPixelType, 1>>::New();
   lutReader->SetFileName(args_info.lut_arg);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(lutReader->Update())
 
   // Apply lookup table
-  using LUTFilterType = rtk::LookupTableImageFilter<OutputImageType, OutputImageType>;
-  auto lutFilter = LUTFilterType::New();
+  auto lutFilter = rtk::LookupTableImageFilter<OutputImageType, OutputImageType>::New();
   lutFilter->SetInput(reader->GetOutput());
   lutFilter->SetLookupTable(lutReader->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(lutFilter->Update())

--- a/applications/rtkmaskcollimation/rtkmaskcollimation.cxx
+++ b/applications/rtkmaskcollimation/rtkmaskcollimation.cxx
@@ -30,10 +30,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkmaskcollimation, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)
@@ -47,14 +46,12 @@ main(int argc, char * argv[])
   rtk::SetProjectionsReaderFromGgo<ReaderType, args_info_rtkmaskcollimation>(reader, args_info);
 
   // Create projection image filter
-  using OFMType = rtk::MaskCollimationImageFilter<OutputImageType, OutputImageType>;
-  auto ofm = OFMType::New();
+  auto ofm = rtk::MaskCollimationImageFilter<OutputImageType, OutputImageType>::New();
   ofm->SetInput(reader->GetOutput());
   ofm->SetGeometry(geometry);
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(ofm->GetOutput());
   if (args_info.verbose_flag)

--- a/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
@@ -65,8 +65,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<VolumeSeriesType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<VolumeSeriesType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -127,9 +126,8 @@ main(int argc, char * argv[])
 
   // The mcfourdcg filter reconstructs a static 4D volume (if the DVFs perfectly model the actual motion)
   // Warp this sequence with the inverse DVF so as to obtain a result similar to the classical 4D CG filter
-  using WarpSequenceFilterType =
-    rtk::WarpSequenceImageFilter<VolumeSeriesType, DVFSequenceImageType, ProjectionStackType, DVFImageType>;
-  auto warp = WarpSequenceFilterType::New();
+  auto warp =
+    rtk::WarpSequenceImageFilter<VolumeSeriesType, DVFSequenceImageType, ProjectionStackType, DVFImageType>::New();
   warp->SetInput(mcfourdcg->GetOutput());
   warp->SetDisplacementField(idvf);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(warp->Update())

--- a/applications/rtkosem/rtkosem.cxx
+++ b/applications/rtkosem/rtkosem.cxx
@@ -60,8 +60,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }

--- a/applications/rtkoverlayphaseandshroud/rtkoverlayphaseandshroud.cxx
+++ b/applications/rtkoverlayphaseandshroud/rtkoverlayphaseandshroud.cxx
@@ -34,11 +34,10 @@ main(int argc, char * argv[])
 {
   GGO(rtkoverlayphaseandshroud, args_info);
 
-  using InputPixelType = double;
   using RGBPixelType = itk::RGBPixel<unsigned char>;
   constexpr unsigned int Dimension = 2;
 
-  using InputImageType = itk::Image<InputPixelType, Dimension>;
+  using InputImageType = itk::Image<double, Dimension>;
   using OutputImageType = itk::Image<RGBPixelType, Dimension>;
 
   // Read
@@ -46,8 +45,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(readImage = itk::ReadImage<InputImageType>(args_info.input_arg))
 
   // Read signal file
-  using ReaderType = itk::CSVArray2DFileReader<double>;
-  auto signalReader = ReaderType::New();
+  auto signalReader = itk::CSVArray2DFileReader<double>::New();
   signalReader->SetFileName(args_info.signal_arg);
   signalReader->SetFieldDelimiterCharacter(';');
   signalReader->HasRowHeadersOff();

--- a/applications/rtkparkershortscanweighting/rtkparkershortscanweighting.cxx
+++ b/applications/rtkparkershortscanweighting/rtkparkershortscanweighting.cxx
@@ -78,8 +78,7 @@ main(int argc, char * argv[])
   pssf->InPlaceOff();
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(pssf->GetOutput());
   writer->SetNumberOfStreamDivisions(args_info.divisions_arg);

--- a/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.cxx
+++ b/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.cxx
@@ -30,10 +30,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkprojectgeometricphantom, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)

--- a/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
+++ b/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
@@ -159,12 +159,11 @@ main(int argc, char * argv[])
   if (args_info.verbose_flag)
     std::cout << "Backprojecting volume and recording matrix values..." << std::endl;
 
-  using JosephType = rtk::JosephBackProjectionImageFilter<
+  auto backProjection = rtk::JosephBackProjectionImageFilter<
     OutputImageType,
     OutputImageType,
     rtk::Functor::InterpolationWeightMultiplicationBackProjection<OutputPixelType, OutputPixelType>,
-    rtk::Functor::StoreSparseMatrixSplatWeightMultiplication<OutputPixelType, double, OutputPixelType>>;
-  auto backProjection = JosephType::New();
+    rtk::Functor::StoreSparseMatrixSplatWeightMultiplication<OutputPixelType, double, OutputPixelType>>::New();
   backProjection->SetInput(constantImageSource->GetOutput());
   backProjection->SetInput(1, reader->GetOutput());
   backProjection->SetGeometry(geometry);

--- a/applications/rtkprojections/rtkprojections.cxx
+++ b/applications/rtkprojections/rtkprojections.cxx
@@ -27,9 +27,8 @@ main(int argc, char * argv[])
 {
   GGO(rtkprojections, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<OutputImageType>;
@@ -37,8 +36,7 @@ main(int argc, char * argv[])
   rtk::SetProjectionsReaderFromGgo<ReaderType, args_info_rtkprojections>(reader, args_info);
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(reader->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(writer->UpdateOutputInformation())

--- a/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.cxx
+++ b/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.cxx
@@ -31,10 +31,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkprojectshepploganphantom, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)
@@ -79,8 +78,7 @@ main(int argc, char * argv[])
   OutputImageType::Pointer output = slp->GetOutput();
   if (args_info.noise_given)
   {
-    using NIFType = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>;
-    auto noisy = NIFType::New();
+    auto noisy = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>::New();
     noisy->SetInput(slp->GetOutput());
     noisy->SetMean(0.0);
     noisy->SetStandardDeviation(args_info.noise_arg);

--- a/applications/rtkramp/rtkramp.cxx
+++ b/applications/rtkramp/rtkramp.cxx
@@ -86,8 +86,7 @@ main(int argc, char * argv[])
   }
 
   // Streaming filter
-  using StreamerType = itk::StreamingImageFilter<OutputImageType, OutputImageType>;
-  auto streamer = StreamerType::New();
+  auto streamer = itk::StreamingImageFilter<OutputImageType, OutputImageType>::New();
 #ifdef RTK_USE_CUDA
   if (!strcmp(args_info.hardware_arg, "cuda"))
     streamer->SetInput(cudaRampFilter->GetOutput());
@@ -99,8 +98,7 @@ main(int argc, char * argv[])
 
   if (args_info.verbose_flag)
   {
-    using PercentageProgressCommandType = rtk::PercentageProgressCommand<CPURampFilterType>;
-    auto progressCommand = PercentageProgressCommandType::New();
+    auto progressCommand = rtk::PercentageProgressCommand<CPURampFilterType>::New();
 #ifdef RTK_USE_CUDA
     if (!strcmp(args_info.hardware_arg, "cuda"))
       cudaRampFilter->AddObserver(itk::ProgressEvent(), progressCommand);

--- a/applications/rtkrayboxintersection/rtkrayboxintersection.cxx
+++ b/applications/rtkrayboxintersection/rtkrayboxintersection.cxx
@@ -29,10 +29,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkrayboxintersection, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)
@@ -55,8 +54,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create projection image filter
-  using RBIType = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>;
-  auto rbi = RBIType::New();
+  auto rbi = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>::New();
   rbi->SetInput(constantImageSource->GetOutput());
   rbi->SetBoxFromImage(input);
   rbi->SetGeometry(geometry);

--- a/applications/rtkrayellipsoidintersection/rtkrayellipsoidintersection.cxx
+++ b/applications/rtkrayellipsoidintersection/rtkrayellipsoidintersection.cxx
@@ -30,10 +30,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkrayellipsoidintersection, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)
@@ -53,8 +52,7 @@ main(int argc, char * argv[])
     constantImageSource->GetSize()[0], constantImageSource->GetSize()[1], geometry->GetGantryAngles().size()));
 
   // Create projection image filter
-  using REIType = rtk::RayEllipsoidIntersectionImageFilter<OutputImageType, OutputImageType>;
-  auto rei = REIType::New();
+  auto rei = rtk::RayEllipsoidIntersectionImageFilter<OutputImageType, OutputImageType>::New();
 
   rei->SetDensity(args_info.mult_arg);
   if (args_info.axes_given > 0)

--- a/applications/rtkrayquadricintersection/rtkrayquadricintersection.cxx
+++ b/applications/rtkrayquadricintersection/rtkrayquadricintersection.cxx
@@ -30,10 +30,9 @@ main(int argc, char * argv[])
 {
   GGO(rtkrayquadricintersection, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Geometry
   if (args_info.verbose_flag)

--- a/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
+++ b/applications/rtkregularizedconjugategradient/rtkregularizedconjugategradient.cxx
@@ -57,8 +57,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -78,15 +77,13 @@ main(int argc, char * argv[])
   itk::ImageSource<OutputImageType>::Pointer weightsSource;
   if (args_info.weights_given)
   {
-    using WeightsReaderType = itk::ImageFileReader<OutputImageType>;
-    auto weightsReader = WeightsReaderType::New();
+    auto weightsReader = itk::ImageFileReader<OutputImageType>::New();
     weightsReader->SetFileName(args_info.weights_arg);
     weightsSource = weightsReader;
   }
   else
   {
-    using ConstantWeightsSourceType = rtk::ConstantImageSource<OutputImageType>;
-    auto constantWeightsSource = ConstantWeightsSourceType::New();
+    auto constantWeightsSource = rtk::ConstantImageSource<OutputImageType>::New();
 
     // Set the weights to be like the projections
     TRY_AND_EXIT_ON_ITK_EXCEPTION(reader->UpdateOutputInformation())

--- a/applications/rtksart/rtksart.cxx
+++ b/applications/rtksart/rtksart.cxx
@@ -56,8 +56,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
 
   // Phase gating weights reader
-  using PhaseGatingFilterType = rtk::PhaseGatingImageFilter<OutputImageType>;
-  auto phaseGating = PhaseGatingFilterType::New();
+  auto phaseGating = rtk::PhaseGatingImageFilter<OutputImageType>::New();
   if (args_info.signal_given)
   {
     phaseGating->SetPhasesFileName(args_info.signal_arg);
@@ -74,8 +73,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<OutputImageType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<OutputImageType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }

--- a/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
+++ b/applications/rtkscatterglarecorrection/rtkscatterglarecorrection.cxx
@@ -82,11 +82,9 @@ main(int argc, char * argv[])
   SFilter->SetTruncationCorrection(0.0);
   SFilter->SetCoefficients(coef);
 
-  using ConstantImageSourceType = rtk::ConstantImageSource<InputImageType>;
-  auto constantSource = ConstantImageSourceType::New();
+  auto constantSource = rtk::ConstantImageSource<InputImageType>::New();
 
-  using PasteImageFilterType = itk::PasteImageFilter<InputImageType, InputImageType>;
-  auto paste = PasteImageFilterType::New();
+  auto paste = itk::PasteImageFilter<InputImageType, InputImageType>::New();
   paste->SetSourceImage(SFilter->GetOutput());
   paste->SetDestinationImage(constantSource->GetOutput());
 
@@ -102,8 +100,7 @@ main(int argc, char * argv[])
     desiredRegionA.SetSize(itk::MakeSize(sliceRegionA.GetSize()[0], sliceRegionA.GetSize()[1], curBufferSize));
     desiredRegionA.SetIndex(itk::MakeIndex(sliceRegionA.GetIndex()[0], sliceRegionA.GetIndex()[1], projid));
 
-    using ExtractFilterType = itk::ExtractImageFilter<InputImageType, InputImageType>;
-    auto extract = ExtractFilterType::New();
+    auto extract = itk::ExtractImageFilter<InputImageType, InputImageType>::New();
     extract->SetDirectionCollapseToIdentity();
     extract->SetExtractionRegion(desiredRegionA);
     extract->SetInput(reader->GetOutput());
@@ -122,8 +119,7 @@ main(int argc, char * argv[])
     InputImageType::Pointer outImage;
     if (args_info.difference_flag)
     {
-      using SubtractImageFilterType = itk::SubtractImageFilter<InputImageType, InputImageType>;
-      auto subtractFilter = SubtractImageFilterType::New();
+      auto subtractFilter = itk::SubtractImageFilter<InputImageType, InputImageType>::New();
       subtractFilter->SetInput1(image);
       subtractFilter->SetInput2(procImage);
       TRY_AND_EXIT_ON_ITK_EXCEPTION(subtractFilter->Update())

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.cxx
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.cxx
@@ -27,8 +27,7 @@ main(int argc, char * argv[])
   GGO(rtksimulatedgeometry, args_info);
 
   // RTK geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
 
   // Projection matrices
   for (int noProj = 0; noProj < args_info.nproj_arg; noProj++)

--- a/applications/rtkspectraldenoiseprojections/rtkspectraldenoiseprojections.cxx
+++ b/applications/rtkspectraldenoiseprojections/rtkspectraldenoiseprojections.cxx
@@ -29,9 +29,8 @@ main(int argc, char * argv[])
 {
   GGO(rtkspectraldenoiseprojections, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using OutputImageType = itk::VectorImage<OutputPixelType, Dimension>;
+  using OutputImageType = itk::VectorImage<float, Dimension>;
 
   // Reader
   OutputImageType::Pointer input;

--- a/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
+++ b/applications/rtkspectralforwardmodel/rtkspectralforwardmodel.cxx
@@ -94,9 +94,9 @@ main(int argc, char * argv[])
                              << MaximumEnergy);
 
   // Create and set the filter
-  using ForwardModelFilterType =
-    rtk::SpectralForwardModelImageFilter<DecomposedProjectionType, MeasuredProjectionsType, IncidentSpectrumImageType>;
-  auto forward = ForwardModelFilterType::New();
+  auto forward = rtk::SpectralForwardModelImageFilter<DecomposedProjectionType,
+                                                      MeasuredProjectionsType,
+                                                      IncidentSpectrumImageType>::New();
   forward->SetInputDecomposedProjections(decomposedProjection);
   forward->SetInputMeasuredProjections(measuredProjections);
   forward->SetInputIncidentSpectrum(incidentSpectrum);

--- a/applications/rtkspectralrooster/rtkspectralrooster.cxx
+++ b/applications/rtkspectralrooster/rtkspectralrooster.cxx
@@ -71,8 +71,7 @@ main(int argc, char * argv[])
   // Create 4D input. Fill it either with an existing materials volume read from a file or a blank image
   VolumeSeriesType::Pointer input;
 
-  using VectorVolumeToVolumeSeriesFilterType = rtk::VectorImageToImageFilter<MaterialsVolumeType, VolumeSeriesType>;
-  auto vecVol2VolSeries = VectorVolumeToVolumeSeriesFilterType::New();
+  auto vecVol2VolSeries = rtk::VectorImageToImageFilter<MaterialsVolumeType, VolumeSeriesType>::New();
 
   if (args_info.input_given)
   {
@@ -182,9 +181,7 @@ main(int argc, char * argv[])
   }
 
   // Projections
-  using VectorProjectionsToProjectionsFilterType =
-    rtk::VectorImageToImageFilter<DecomposedProjectionType, ProjectionStackType>;
-  auto vproj2proj = VectorProjectionsToProjectionsFilterType::New();
+  auto vproj2proj = rtk::VectorImageToImageFilter<DecomposedProjectionType, ProjectionStackType>::New();
   vproj2proj->SetInput(decomposedProjection);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(vproj2proj->Update())
 
@@ -198,8 +195,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(signalToInterpolationWeights->Update())
 
   // Set the forward and back projection filters to be used
-  using ROOSTERFilterType = rtk::FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>;
-  auto rooster = ROOSTERFilterType::New();
+  auto rooster = rtk::FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::New();
   SetForwardProjectionFromGgo(args_info, rooster.GetPointer());
   SetBackProjectionFromGgo(args_info, rooster.GetPointer());
   rooster->SetInputVolumeSeries(input);
@@ -280,8 +276,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rooster->Update())
 
   // Convert to result to a vector image
-  using VolumeSeriesToVectorVolumeFilterType = rtk::ImageToVectorImageFilter<VolumeSeriesType, MaterialsVolumeType>;
-  auto volSeries2VecVol = VolumeSeriesToVectorVolumeFilterType::New();
+  auto volSeries2VecVol = rtk::ImageToVectorImageFilter<VolumeSeriesType, MaterialsVolumeType>::New();
   volSeries2VecVol->SetInput(rooster->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(volSeries2VecVol->Update())
 

--- a/applications/rtkspectralsimplexdecomposition/rtkspectralsimplexdecomposition.cxx
+++ b/applications/rtkspectralsimplexdecomposition/rtkspectralsimplexdecomposition.cxx
@@ -102,10 +102,9 @@ main(int argc, char * argv[])
                              << MaximumEnergy);
 
   // Create and set the filter
-  using SimplexFilterType = rtk::SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionType,
-                                                                                    SpectralProjectionsType,
-                                                                                    IncidentSpectrumImageType>;
-  auto simplex = SimplexFilterType::New();
+  auto simplex = rtk::SimplexSpectralProjectionsDecompositionImageFilter<DecomposedProjectionType,
+                                                                         SpectralProjectionsType,
+                                                                         IncidentSpectrumImageType>::New();
   simplex->SetInputDecomposedProjections(decomposedProjection);
   simplex->SetGuessInitialization(args_info.guess_flag);
   simplex->SetInputMeasuredProjections(spectralProjection);

--- a/applications/rtksubselect/rtksubselect.cxx
+++ b/applications/rtksubselect/rtksubselect.cxx
@@ -32,9 +32,8 @@ main(int argc, char * argv[])
 {
   GGO(rtksubselect, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<OutputImageType>;
@@ -65,12 +64,10 @@ main(int argc, char * argv[])
     }
 
   // Output RTK geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto outputGeometry = GeometryType::New();
+  auto outputGeometry = rtk::ThreeDCircularProjectionGeometry::New();
 
   // Output projections object
-  using SourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto source = SourceType::New();
+  auto source = rtk::ConstantImageSource<OutputImageType>::New();
   source->SetInformationFromImage(reader->GetOutput());
   OutputImageType::SizeType outputSize = reader->GetOutput()->GetLargestPossibleRegion().GetSize();
   outputSize[Dimension - 1] = indices.size();
@@ -79,8 +76,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(source->Update())
 
   // Fill in the outputGeometry and the output projections
-  using PasteType = itk::PasteImageFilter<OutputImageType>;
-  auto paste = PasteType::New();
+  auto paste = itk::PasteImageFilter<OutputImageType>::New();
   paste->SetSourceImage(reader->GetOutput());
   paste->SetDestinationImage(source->GetOutput());
 

--- a/applications/rtktotalnuclearvariationdenoising/rtktotalnuclearvariationdenoising.cxx
+++ b/applications/rtktotalnuclearvariationdenoising/rtktotalnuclearvariationdenoising.cxx
@@ -36,16 +36,15 @@ main(int argc, char * argv[])
   constexpr unsigned int DimensionsProcessed = 3; // Number of dimensions along which the gradient is computed
 
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
-  using GradientOutputImageType = itk::Image<itk::CovariantVector<OutputPixelType, DimensionsProcessed>, Dimension>;
-  using TVDenoisingFilterType =
-    rtk::TotalNuclearVariationDenoisingBPDQImageFilter<OutputImageType, GradientOutputImageType>;
 
   // Read input
   OutputImageType::Pointer input;
   TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Apply total nuclear variation denoising
-  auto tv = TVDenoisingFilterType::New();
+  auto tv = rtk::TotalNuclearVariationDenoisingBPDQImageFilter<
+    OutputImageType,
+    itk::Image<itk::CovariantVector<OutputPixelType, DimensionsProcessed>, Dimension>>::New();
   tv->SetInput(input);
   tv->SetGamma(args_info.gamma_arg);
   tv->SetNumberOfIterations(args_info.niter_arg);

--- a/applications/rtktotalvariationdenoising/rtktotalvariationdenoising.cxx
+++ b/applications/rtktotalvariationdenoising/rtktotalvariationdenoising.cxx
@@ -44,8 +44,9 @@ main(int argc, char * argv[])
   using TVDenoisingFilterType = rtk::CudaTotalVariationDenoisingBPDQImageFilter;
 #else
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
-  using GradientOutputImageType = itk::Image<itk::CovariantVector<OutputPixelType, Dimension>, Dimension>;
-  using TVDenoisingFilterType = rtk::TotalVariationDenoisingBPDQImageFilter<OutputImageType, GradientOutputImageType>;
+  using TVDenoisingFilterType = rtk::TotalVariationDenoisingBPDQImageFilter<
+    OutputImageType,
+    itk::Image<itk::CovariantVector<OutputPixelType, Dimension>, Dimension>>;
 #endif
 
   // Read input
@@ -53,8 +54,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Compute total variation before denoising
-  using TVFilterType = rtk::TotalVariationImageFilter<OutputImageType>;
-  auto tv = TVFilterType::New();
+  auto tv = rtk::TotalVariationImageFilter<OutputImageType>::New();
   tv->SetInput(input);
   if (args_info.verbose_flag)
   {

--- a/applications/rtktutorialapplication/rtktutorialapplication.cxx
+++ b/applications/rtktutorialapplication/rtktutorialapplication.cxx
@@ -69,18 +69,16 @@ main(int argc, char * argv[])
   // function. You can see how it is used in
   // rtkSARTConeBeamReconstructionFilter.hxx
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Read the input volume
   OutputImageType::Pointer input;
   TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create the Add filter
-  using AddFilterType = itk::AddImageFilter<OutputImageType>;
-  auto add = AddFilterType::New();
+  auto add = itk::AddImageFilter<OutputImageType>::New();
   add->SetInput1(input);
   add->SetConstant2(args_info.constant_arg);
 

--- a/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.cxx
+++ b/applications/rtkvectorconjugategradient/rtkvectorconjugategradient.cxx
@@ -111,9 +111,8 @@ main(int argc, char * argv[])
   }
 
   // Set the forward and back projection filters to be used
-  using ConjugateGradientFilterType =
-    rtk::ConjugateGradientConeBeamReconstructionFilter<OutputImageType, SingleComponentImageType, WeightsImageType>;
-  auto conjugategradient = ConjugateGradientFilterType::New();
+  auto conjugategradient = rtk::
+    ConjugateGradientConeBeamReconstructionFilter<OutputImageType, SingleComponentImageType, WeightsImageType>::New();
   SetForwardProjectionFromGgo(args_info, conjugategradient.GetPointer());
   SetBackProjectionFromGgo(args_info, conjugategradient.GetPointer());
   conjugategradient->SetInputVolume(input);

--- a/applications/rtkwangdisplaceddetectorweighting/rtkwangdisplaceddetectorweighting.cxx
+++ b/applications/rtkwangdisplaceddetectorweighting/rtkwangdisplaceddetectorweighting.cxx
@@ -79,8 +79,7 @@ main(int argc, char * argv[])
     ddf->SetOffsets(args_info.minOffset_arg, args_info.maxOffset_arg);
 
   // Write
-  using WriterType = itk::ImageFileWriter<OutputImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<OutputImageType>::New();
   writer->SetFileName(args_info.output_arg);
   writer->SetInput(ddf->GetOutput());
   writer->SetNumberOfStreamDivisions(args_info.divisions_arg);

--- a/applications/rtkwarpedbackprojectsequence/rtkwarpedbackprojectsequence.cxx
+++ b/applications/rtkwarpedbackprojectsequence/rtkwarpedbackprojectsequence.cxx
@@ -62,8 +62,7 @@ main(int argc, char * argv[])
   if (args_info.input_given)
   {
     // Read an existing image to initialize the volume
-    using InputReaderType = itk::ImageFileReader<VolumeSeriesType>;
-    auto inputReader = InputReaderType::New();
+    auto inputReader = itk::ImageFileReader<VolumeSeriesType>::New();
     inputReader->SetFileName(args_info.input_arg);
     inputFilter = inputReader;
   }
@@ -96,9 +95,8 @@ main(int argc, char * argv[])
   phaseReader->Update();
 
   // Create the main filter, connect the basic inputs, and set the basic parameters
-  using WarpForwardProjectSequenceFilterType =
-    rtk::WarpProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>;
-  auto warpbackprojectsequence = WarpForwardProjectSequenceFilterType::New();
+  auto warpbackprojectsequence =
+    rtk::WarpProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>::New();
   warpbackprojectsequence->SetInputVolumeSeries(inputFilter->GetOutput());
   warpbackprojectsequence->SetInputProjectionStack(reader->GetOutput());
   warpbackprojectsequence->SetGeometry(geometry);

--- a/applications/rtkwarpedforwardprojectsequence/rtkwarpedforwardprojectsequence.cxx
+++ b/applications/rtkwarpedforwardprojectsequence/rtkwarpedforwardprojectsequence.cxx
@@ -76,8 +76,7 @@ main(int argc, char * argv[])
   if (args_info.verbose_flag)
     std::cout << "Projecting volume sequence..." << std::endl;
 
-  using WarpForwardProjectType = rtk::WarpFourDToProjectionStackImageFilter<VolumeSeriesType, ProjectionStackType>;
-  auto forwardProjection = WarpForwardProjectType::New();
+  auto forwardProjection = rtk::WarpFourDToProjectionStackImageFilter<VolumeSeriesType, ProjectionStackType>::New();
 
   forwardProjection->SetInputProjectionStack(constantImageSource->GetOutput());
   forwardProjection->SetInputVolumeSeries(volumeSeries);

--- a/applications/rtkwaveletsdenoising/rtkwaveletsdenoising.cxx
+++ b/applications/rtkwaveletsdenoising/rtkwaveletsdenoising.cxx
@@ -30,18 +30,16 @@ main(int argc, char * argv[])
 {
   GGO(rtkwaveletsdenoising, args_info);
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Read the input image
   OutputImageType::Pointer input;
   TRY_AND_EXIT_ON_ITK_EXCEPTION(input = itk::ReadImage<OutputImageType>(args_info.input_arg))
 
   // Create the denoising filter
-  using WaveletsSoftThresholdFilterType = rtk::DeconstructSoftThresholdReconstructImageFilter<OutputImageType>;
-  auto wst = WaveletsSoftThresholdFilterType::New();
+  auto wst = rtk::DeconstructSoftThresholdReconstructImageFilter<OutputImageType>::New();
   wst->SetInput(input);
   wst->SetOrder(args_info.order_arg);
   wst->SetThreshold(args_info.threshold_arg);

--- a/examples/FirstReconstruction/FirstCudaReconstruction.cxx
+++ b/examples/FirstReconstruction/FirstCudaReconstruction.cxx
@@ -21,8 +21,7 @@ main(int argc, char ** argv)
   using ImageType = itk::CudaImage<float, 3>;
 
   // Defines the RTK geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto         geometry = GeometryType::New();
+  auto         geometry = rtk::ThreeDCircularProjectionGeometry::New();
   unsigned int numberOfProjections = 360;
   double       firstAngle = 0;
   double       angularArc = 360;
@@ -50,8 +49,7 @@ main(int argc, char ** argv)
   constantImageSource->SetConstant(0.);
 
   // Create projections of an ellipse
-  using REIType = rtk::RayEllipsoidIntersectionImageFilter<ImageType, ImageType>;
-  auto rei = REIType::New();
+  auto rei = rtk::RayEllipsoidIntersectionImageFilter<ImageType, ImageType>::New();
   rei->SetDensity(2.);
   rei->SetAngle(0.);
   rei->SetCenter(itk::MakePoint(0., 0., 10.));
@@ -68,8 +66,7 @@ main(int argc, char ** argv)
 
   // FDK reconstruction
   std::cout << "Reconstructing..." << std::endl;
-  using FDKGPUType = rtk::CudaFDKConeBeamReconstructionFilter;
-  auto feldkamp = FDKGPUType::New();
+  auto feldkamp = rtk::CudaFDKConeBeamReconstructionFilter::New();
   feldkamp->SetInput(0, constantImageSource2->GetOutput());
   feldkamp->SetInput(1, rei->GetOutput());
   feldkamp->SetGeometry(geometry);
@@ -77,16 +74,14 @@ main(int argc, char ** argv)
   feldkamp->GetRampFilter()->SetHannCutFrequency(0.0);
 
   // Field-of-view masking
-  using FOVFilterType = rtk::FieldOfViewImageFilter<ImageType, ImageType>;
-  auto fieldofview = FOVFilterType::New();
+  auto fieldofview = rtk::FieldOfViewImageFilter<ImageType, ImageType>::New();
   fieldofview->SetInput(0, feldkamp->GetOutput());
   fieldofview->SetProjectionsStack(rei->GetOutput());
   fieldofview->SetGeometry(geometry);
 
   // Writer
   std::cout << "Writing output image..." << std::endl;
-  using WriterType = itk::ImageFileWriter<ImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
   writer->SetFileName(argv[1]);
   writer->SetInput(fieldofview->GetOutput());
   writer->Update();

--- a/examples/FirstReconstruction/FirstReconstruction.cxx
+++ b/examples/FirstReconstruction/FirstReconstruction.cxx
@@ -21,8 +21,7 @@ main(int argc, char ** argv)
   using ImageType = itk::Image<float, 3>;
 
   // Defines the RTK geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto         geometry = GeometryType::New();
+  auto         geometry = rtk::ThreeDCircularProjectionGeometry::New();
   unsigned int numberOfProjections = 360;
   double       firstAngle = 0;
   double       angularArc = 360;
@@ -49,8 +48,7 @@ main(int argc, char ** argv)
   constantImageSource->SetSize(itk::MakeSize(128, 128, numberOfProjections));
 
   // Create projections of an ellipse
-  using REIType = rtk::RayEllipsoidIntersectionImageFilter<ImageType, ImageType>;
-  auto rei = REIType::New();
+  auto rei = rtk::RayEllipsoidIntersectionImageFilter<ImageType, ImageType>::New();
   rei->SetDensity(2.);
   rei->SetAngle(0.);
   rei->SetCenter(itk::MakePoint(0., 0., 10.));
@@ -67,8 +65,7 @@ main(int argc, char ** argv)
 
   // FDK reconstruction
   std::cout << "Reconstructing..." << std::endl;
-  using FDKCPUType = rtk::FDKConeBeamReconstructionFilter<ImageType>;
-  auto feldkamp = FDKCPUType::New();
+  auto feldkamp = rtk::FDKConeBeamReconstructionFilter<ImageType>::New();
   feldkamp->SetInput(0, constantImageSource2->GetOutput());
   feldkamp->SetInput(1, rei->GetOutput());
   feldkamp->SetGeometry(geometry);
@@ -76,16 +73,14 @@ main(int argc, char ** argv)
   feldkamp->GetRampFilter()->SetHannCutFrequency(0.0);
 
   // Field-of-view masking
-  using FOVFilterType = rtk::FieldOfViewImageFilter<ImageType, ImageType>;
-  auto fieldofview = FOVFilterType::New();
+  auto fieldofview = rtk::FieldOfViewImageFilter<ImageType, ImageType>::New();
   fieldofview->SetInput(0, feldkamp->GetOutput());
   fieldofview->SetProjectionsStack(rei->GetOutput());
   fieldofview->SetGeometry(geometry);
 
   // Writer
   std::cout << "Writing output image..." << std::endl;
-  using WriterType = itk::ImageFileWriter<ImageType>;
-  auto writer = WriterType::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
   writer->SetFileName(argv[1]);
   writer->SetInput(fieldofview->GetOutput());
   writer->Update();

--- a/examples/GeometricPhantom/GeometricPhantom.cxx
+++ b/examples/GeometricPhantom/GeometricPhantom.cxx
@@ -8,8 +8,7 @@ int
 main()
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   constexpr unsigned int numberOfProjections = 180;
   constexpr double       angularArc = 360.;

--- a/include/rtkAmsterdamShroudImageFilter.hxx
+++ b/include/rtkAmsterdamShroudImageFilter.hxx
@@ -153,8 +153,7 @@ AmsterdamShroudImageFilter<TInputImage>::CropOutsideProjectedBox()
   typename TInputImage::RegionType reg;
   reg = m_DerivativeFilter->GetOutput()->GetRequestedRegion();
 
-  using OutputIterator = typename itk::ImageRegionIterator<TInputImage>;
-  OutputIterator it(m_DerivativeFilter->GetOutput(), reg);
+  typename itk::ImageRegionIterator<TInputImage> it(m_DerivativeFilter->GetOutput(), reg);
 
   // Prepare the 8 corners of the box
   std::vector<GeometryType::HomogeneousVectorType> corners;
@@ -191,9 +190,10 @@ AmsterdamShroudImageFilter<TInputImage>::CropOutsideProjectedBox()
       vnl_vector<double> pCornerVnl = m_Geometry->GetMatrices()[iProj].GetVnlMatrix() * corners[ci].GetVnlVector();
       for (unsigned int i = 0; i < 2; i++)
         pCorner[i] = pCornerVnl[i] / pCornerVnl[2];
-      using ValueType = typename TInputImage::PointType::ValueType;
       const itk::ContinuousIndex<double, 3> pCornerI =
-        this->GetInput()->template TransformPhysicalPointToContinuousIndex<ValueType, double>(pCorner);
+        this->GetInput()
+          ->template TransformPhysicalPointToContinuousIndex<typename TInputImage::PointType::ValueType, double>(
+            pCorner);
       if (ci == 0)
       {
         pCornerInf = pCornerI;

--- a/include/rtkBackProjectionImageFilter.hxx
+++ b/include/rtkBackProjectionImageFilter.hxx
@@ -194,8 +194,7 @@ BackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
   auto interpolator = InterpolatorType::New();
 
   // Iterators on volume input and output
-  using InputRegionIterator = itk::ImageRegionConstIterator<TInputImage>;
-  InputRegionIterator itIn(this->GetInput(), outputRegionForThread);
+  itk::ImageRegionConstIterator<TInputImage> itIn(this->GetInput(), outputRegionForThread);
   using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
   OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
 

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -223,10 +223,9 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
   if (this->GetInputWeights().IsNull())
   {
     using PixelType = typename TWeightsImage::PixelType;
-    using ComponentType = typename itk::PixelTraits<PixelType>::ValueType;
     auto ones = ConstantWeightSourceType::New();
     ones->SetInformationFromImage(this->GetInputProjectionStack());
-    ones->SetConstant(PixelType(itk::NumericTraits<ComponentType>::One));
+    ones->SetConstant(PixelType(itk::NumericTraits<typename itk::PixelTraits<PixelType>::ValueType>::One));
     ones->Update();
     this->SetInputWeights(ones->GetOutput());
   }

--- a/include/rtkCudaBackProjectionImageFilter.hxx
+++ b/include/rtkCudaBackProjectionImageFilter.hxx
@@ -53,9 +53,10 @@ CudaBackProjectionImageFilter<ImageType>::GPUGenerateData()
   // Rotation center (assumed to be at 0 yet)
   typename ImageType::PointType rotCenterPoint;
   rotCenterPoint.Fill(0.0);
-  using ValueType = typename ImageType::PointType::ValueType;
   itk::ContinuousIndex<double, Dimension> rotCenterIndex =
-    this->GetInput(0)->template TransformPhysicalPointToContinuousIndex<ValueType, double>(rotCenterPoint);
+    this->GetInput(0)
+      ->template TransformPhysicalPointToContinuousIndex<typename ImageType::PointType::ValueType, double>(
+        rotCenterPoint);
 
   // Include non-zero index in matrix
   itk::Matrix<double, 4, 4> matrixIdxVol;

--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
@@ -151,8 +151,7 @@ CudaFFTProjectionsConvolutionImageFilter<TParentImageFilter>::GPUGenerateData()
   progress.CompletedPixel();
 
   // CUDA Cropping and Graft Output
-  using CropFilter = CudaCropImageFilter;
-  auto                                           cf = CropFilter::New();
+  auto                                           cf = CudaCropImageFilter::New();
   typename Superclass::OutputImageType::SizeType upCropSize, lowCropSize;
   for (unsigned int i = 0; i < CudaImageType::ImageDimension; i++)
   {

--- a/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
+++ b/include/rtkDaubechiesWaveletsConvolutionImageFilter.hxx
@@ -272,7 +272,6 @@ DaubechiesWaveletsConvolutionImageFilter<TImage>::GenerateData()
 
   std::vector<typename TImage::Pointer>                kernelImages;
   std::vector<typename ConvolutionFilterType::Pointer> convolutionFilters;
-  using KernelIteratorType = itk::ImageRegionIterator<TImage>;
 
   // Convolve the input "Dimension" times, each time with a 1-D kernel
   for (int d = 0; d < dim; d++)
@@ -292,7 +291,7 @@ DaubechiesWaveletsConvolutionImageFilter<TImage>::GenerateData()
     kernelImages.push_back(TImage::New());
     kernelImages[d]->SetRegions(kernelRegion);
     kernelImages[d]->Allocate();
-    KernelIteratorType kernelIt(kernelImages[d], kernelImages[d]->GetLargestPossibleRegion());
+    itk::ImageRegionIterator<TImage> kernelIt(kernelImages[d], kernelImages[d]->GetLargestPossibleRegion());
 
     int pos = 0;
     while (!kernelIt.IsAtEnd())

--- a/include/rtkDownsampleImageFilter.hxx
+++ b/include/rtkDownsampleImageFilter.hxx
@@ -96,7 +96,6 @@ DownsampleImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
   // Define/declare an iterator that will walk the output region for this
   // thread.
   using OutputIterator = itk::ImageRegionIterator<TOutputImage>;
-  using InputIterator = itk::ImageRegionConstIterator<TInputImage>;
 
   // Define a few indices that will be used to translate from an input pixel
   // to an output pixel
@@ -172,8 +171,8 @@ DownsampleImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateData(
     inputLine.SetSize(inputLineSize);
     inputLine.SetIndex(inputStartIndex + firstPixelOfInputLineOffset);
 
-    OutputIterator outIt(outputPtr, outputLine);
-    InputIterator  inIt(inputPtr, inputLine);
+    OutputIterator                             outIt(outputPtr, outputLine);
+    itk::ImageRegionConstIterator<TInputImage> inIt(inputPtr, inputLine);
 
     // Walk the line and copy the pixels
     while (!outIt.IsAtEnd())

--- a/include/rtkDrawGeometricPhantomImageFilter.hxx
+++ b/include/rtkDrawGeometricPhantomImageFilter.hxx
@@ -43,8 +43,7 @@ DrawGeometricPhantomImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Reading figure config file
   if (!m_ConfigFile.empty())
   {
-    using ReaderType = rtk::ForbildPhantomFileReader;
-    auto reader = ReaderType::New();
+    auto reader = rtk::ForbildPhantomFileReader::New();
     reader->SetFilename(m_ConfigFile);
     reader->GenerateOutputInformation();
     this->m_GeometricPhantom = reader->GetGeometricPhantom();

--- a/include/rtkExtractPhaseImageFilter.hxx
+++ b/include/rtkExtractPhaseImageFilter.hxx
@@ -68,29 +68,24 @@ ExtractPhaseImageFilter<TImage>::GenerateData()
   conv2->SetKernelImage(kernel2);
 
   // Define real image type for FFT
-  using InputPixelType = typename TImage::PixelType;
-  using RealOutputPixelType = typename itk::NumericTraits<InputPixelType>::RealType;
+  using RealOutputPixelType = typename itk::NumericTraits<typename TImage::PixelType>::RealType;
   using RealOutputImageType = itk::Image<RealOutputPixelType, 1>;
 
-  using SubtractType = itk::SubtractImageFilter<TImage, TImage, RealOutputImageType>;
-  auto sub = SubtractType::New();
+  auto sub = itk::SubtractImageFilter<TImage, TImage, RealOutputImageType>::New();
   sub->SetInput1(conv->GetOutput());
   sub->SetInput2(conv2->GetOutput());
   sub->InPlaceOff();
   sub->Update();
 
   // Define FFT output type (complex)
-  using ComplexType = std::complex<RealOutputPixelType>;
-  using ComplexSignalType = itk::Image<ComplexType, 1>;
+  using ComplexSignalType = itk::Image<std::complex<RealOutputPixelType>, 1>;
 
   // Hilbert transform
-  using HilbertType = rtk::HilbertImageFilter<RealOutputImageType, ComplexSignalType>;
-  auto hilbert = HilbertType::New();
+  auto hilbert = rtk::HilbertImageFilter<RealOutputImageType, ComplexSignalType>::New();
   hilbert->SetInput(sub->GetOutput());
 
   // Take the linear phase of this signal
-  using PhaseType = itk::ComplexToPhaseImageFilter<ComplexSignalType, TImage>;
-  auto phase = PhaseType::New();
+  auto phase = itk::ComplexToPhaseImageFilter<ComplexSignalType, TImage>::New();
   phase->SetInput(hilbert->GetOutput());
   phase->Update();
 

--- a/include/rtkFDKBackProjectionImageFilter.hxx
+++ b/include/rtkFDKBackProjectionImageFilter.hxx
@@ -57,14 +57,11 @@ FDKBackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   const unsigned int iFirstProj = this->GetInput(1)->GetLargestPossibleRegion().GetIndex(Dimension - 1);
 
   // Create interpolator, could be any interpolation
-  using InterpolatorType = itk::LinearInterpolateImageFunction<ProjectionImageType, double>;
-  auto interpolator = InterpolatorType::New();
+  auto interpolator = itk::LinearInterpolateImageFunction<ProjectionImageType, double>::New();
 
   // Iterators on volume input and output
-  using InputRegionIterator = itk::ImageRegionConstIterator<TInputImage>;
-  InputRegionIterator itIn(this->GetInput(), outputRegionForThread);
-  using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionConstIterator<TInputImage>      itIn(this->GetInput(), outputRegionForThread);
+  itk::ImageRegionIteratorWithIndex<TOutputImage> itOut(this->GetOutput(), outputRegionForThread);
 
   // Initialize output region with input region in case the filter is not in
   // place
@@ -82,9 +79,10 @@ FDKBackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   // Rotation center (assumed to be at 0 yet)
   typename TInputImage::PointType rotCenterPoint;
   rotCenterPoint.Fill(0.0);
-  using ValueType = typename TInputImage::PointType::ValueType;
   const itk::ContinuousIndex<double, Dimension> rotCenterIndex =
-    this->GetInput(0)->template TransformPhysicalPointToContinuousIndex<ValueType, double>(rotCenterPoint);
+    this->GetInput(0)
+      ->template TransformPhysicalPointToContinuousIndex<typename TInputImage::PointType::ValueType, double>(
+        rotCenterPoint);
 
   // Continuous index at which we interpolate
   itk::ContinuousIndex<double, Dimension - 1> pointProj;

--- a/include/rtkFDKWarpBackProjectionImageFilter.hxx
+++ b/include/rtkFDKWarpBackProjectionImageFilter.hxx
@@ -52,8 +52,7 @@ FDKWarpBackProjectionImageFilter<TInputImage, TOutputImage, TDeformation>::Gener
       this->GetOutput()->GetRequestedRegion(),
       [this](const typename TOutputImage::RegionType & outputRegionForThread) {
         // Iterators on volume input and output
-        using InputRegionIterator = itk::ImageRegionConstIterator<TInputImage>;
-        InputRegionIterator itIn(this->GetInput(), outputRegionForThread);
+        itk::ImageRegionConstIterator<TInputImage> itIn(this->GetInput(), outputRegionForThread);
         using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
         OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
 
@@ -73,8 +72,7 @@ FDKWarpBackProjectionImageFilter<TInputImage, TOutputImage, TDeformation>::Gener
   rotCenterPoint.Fill(0.0);
 
   // Warped point and interpolator for vector field
-  using WarpInterpolatorType = itk::LinearInterpolateImageFunction<typename TDeformation::OutputImageType, double>;
-  auto                                              warpInterpolator = WarpInterpolatorType::New();
+  auto warpInterpolator = itk::LinearInterpolateImageFunction<typename TDeformation::OutputImageType, double>::New();
   itk::Matrix<double, Dimension + 1, Dimension + 1> matrixVol =
     GetPhysicalPointToIndexMatrix<TOutputImage>(this->GetOutput());
 
@@ -88,8 +86,7 @@ FDKWarpBackProjectionImageFilter<TInputImage, TOutputImage, TDeformation>::Gener
 
     // Extract the current slice and create interpolator, could be any interpolation
     ProjectionImagePointer projection = this->template GetProjection<ProjectionImageType>(iProj);
-    using InterpolatorType = itk::LinearInterpolateImageFunction<ProjectionImageType, double>;
-    auto interpolator = InterpolatorType::New();
+    auto                   interpolator = itk::LinearInterpolateImageFunction<ProjectionImageType, double>::New();
     interpolator->SetInputImage(projection);
 
     // Index to index matrix normalized to have a correct backprojection weight

--- a/include/rtkFDKWeightProjectionFilter.hxx
+++ b/include/rtkFDKWeightProjectionFilter.hxx
@@ -78,10 +78,8 @@ FDKWeightProjectionFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
     pointIncrement[i] -= pointBase[i];
 
   // Iterators
-  using InputConstIterator = itk::ImageRegionConstIterator<InputImageType>;
-  InputConstIterator itI(this->GetInput(), outputRegionForThread);
-  using OutputIterator = itk::ImageRegionIterator<OutputImageType>;
-  OutputIterator itO(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionConstIterator<InputImageType> itI(this->GetInput(), outputRegionForThread);
+  itk::ImageRegionIterator<OutputImageType>     itO(this->GetOutput(), outputRegionForThread);
   itI.GoToBegin();
   itO.GoToBegin();
 

--- a/include/rtkFFTHilbertImageFilter.hxx
+++ b/include/rtkFFTHilbertImageFilter.hxx
@@ -86,8 +86,7 @@ FFTHilbertImageFilter<TInputImage, TOutputImage, TFFTPrecision>::UpdateFFTProjec
   }
 
   // FFT kernel
-  using FFTType = itk::RealToHalfHermitianForwardFFTImageFilter<FFTInputImageType, FFTOutputImageType>;
-  auto fftK = FFTType::New();
+  auto fftK = itk::RealToHalfHermitianForwardFFTImageFilter<FFTInputImageType, FFTOutputImageType>::New();
   fftK->SetInput(kernel);
   fftK->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   fftK->Update();

--- a/include/rtkFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkFFTProjectionsConvolutionImageFilter.hxx
@@ -176,8 +176,7 @@ FFTProjectionsConvolutionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::
     }
 
     // Inverse FFT image
-    using IFFTType = itk::HalfHermitianToRealInverseFFTImageFilter<typename FFTType::OutputImageType>;
-    auto ifft = IFFTType::New();
+    auto ifft = itk::HalfHermitianToRealInverseFFTImageFilter<typename FFTType::OutputImageType>::New();
     ifft->SetInput(fftI->GetOutput());
     ifft->SetNumberOfWorkUnits(m_BackupNumberOfThreads);
     ifft->SetReleaseDataFlag(true);

--- a/include/rtkFFTVarianceRampImageFilter.hxx
+++ b/include/rtkFFTVarianceRampImageFilter.hxx
@@ -41,8 +41,7 @@ FFTVarianceRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>::UpdateFFTP
   Superclass::UpdateFFTProjectionsConvolutionKernel(s);
 
   // iFFT kernel
-  using IFFTType = itk::HalfHermitianToRealInverseFFTImageFilter<FFTOutputImageType, FFTInputImageType>;
-  auto ifftK = IFFTType::New();
+  auto ifftK = itk::HalfHermitianToRealInverseFFTImageFilter<FFTOutputImageType, FFTInputImageType>::New();
   ifftK->SetInput(this->m_KernelFFT);
   ifftK->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   ifftK->Update();
@@ -50,12 +49,12 @@ FFTVarianceRampImageFilter<TInputImage, TOutputImage, TFFTPrecision>::UpdateFFTP
   typename FFTType::InputImageType::Pointer KernelIFFT = ifftK->GetOutput();
 
   // calculate ratio g_C/g^2
-  using InverseIteratorType = itk::ImageRegionIteratorWithIndex<typename FFTType::InputImageType>;
-  InverseIteratorType                         itiK(KernelIFFT, KernelIFFT->GetLargestPossibleRegion());
-  typename FFTType::InputImageType::PixelType sumgc = 0.;
-  typename FFTType::InputImageType::PixelType sumg2 = 0.;
-  typename FFTType::InputImageType::IndexType idxshifted;
-  const unsigned int                          widthFFT = KernelIFFT->GetLargestPossibleRegion().GetSize()[0];
+  itk::ImageRegionIteratorWithIndex<typename FFTType::InputImageType> itiK(KernelIFFT,
+                                                                           KernelIFFT->GetLargestPossibleRegion());
+  typename FFTType::InputImageType::PixelType                         sumgc = 0.;
+  typename FFTType::InputImageType::PixelType                         sumg2 = 0.;
+  typename FFTType::InputImageType::IndexType                         idxshifted;
+  const unsigned int widthFFT = KernelIFFT->GetLargestPossibleRegion().GetSize()[0];
   for (; !itiK.IsAtEnd(); ++itiK)
   {
     idxshifted = itiK.GetIndex();

--- a/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
+++ b/include/rtkFourDROOSTERConeBeamReconstructionFilter.hxx
@@ -277,10 +277,8 @@ FourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>:
     m_AverageOutOfROIFilter->SetROI(m_ResampleFilter->GetOutput());
 
     // Set the resample filter
-    using TransformType = itk::IdentityTransform<double, Dimension>;
-    using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<VolumeType, double>;
-    m_ResampleFilter->SetInterpolator(InterpolatorType::New());
-    m_ResampleFilter->SetTransform(TransformType::New());
+    m_ResampleFilter->SetInterpolator(itk::NearestNeighborInterpolateImageFunction<VolumeType, double>::New());
+    m_ResampleFilter->SetTransform(itk::IdentityTransform<double, Dimension>::New());
     typename VolumeType::SizeType      VolumeSize;
     typename VolumeType::SpacingType   VolumeSpacing;
     typename VolumeType::PointType     VolumeOrigin;

--- a/include/rtkHilbertImageFilter.hxx
+++ b/include/rtkHilbertImageFilter.hxx
@@ -33,8 +33,7 @@ void
 HilbertImageFilter<TInputImage, TOutputImage>::GenerateData()
 {
   // Take the FFT of the input
-  using FFTFilterType = typename itk::ForwardFFTImageFilter<TInputImage, TOutputImage>;
-  auto fftFilt = FFTFilterType::New();
+  auto fftFilt = itk::ForwardFFTImageFilter<TInputImage, TOutputImage>::New();
   fftFilt->SetInput(this->GetInput());
   fftFilt->Update();
 
@@ -42,8 +41,7 @@ HilbertImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Weights according to
   // [Marple, IEEE Trans Sig Proc, 1999]
-  using IteratorType = typename itk::ImageRegionIteratorWithIndex<TOutputImage>;
-  IteratorType it(fft, fft->GetLargestPossibleRegion());
+  auto it = itk::ImageRegionIteratorWithIndex<TOutputImage>(fft, fft->GetLargestPossibleRegion());
   it.Set(it.Get());
   ++it;
   int n = fft->GetLargestPossibleRegion().GetSize()[0];

--- a/include/rtkInterpolatorWithKnownWeightsImageFilter.hxx
+++ b/include/rtkInterpolatorWithKnownWeightsImageFilter.hxx
@@ -157,18 +157,15 @@ InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>::DynamicTh
   typename VolumeSeriesType::SizeType   volumeSeriesSize;
   typename VolumeSeriesType::IndexType  volumeSeriesIndex;
 
-  using VolumeRegionIterator = itk::ImageRegionIterator<VolumeType>;
-  using VolumeRegionConstIterator = itk::ImageRegionConstIterator<VolumeType>;
-  using VolumeSeriesRegionIterator = itk::ImageRegionIterator<VolumeSeriesType>;
 
   float weight = NAN;
 
   // Initialize output region with input region in case the filter is not in
   // place
-  VolumeRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionIterator<VolumeType> itOut(this->GetOutput(), outputRegionForThread);
   if (this->GetInput() != this->GetOutput())
   {
-    VolumeRegionConstIterator itIn(volume, outputRegionForThread);
+    itk::ImageRegionConstIterator<VolumeType> itIn(volume, outputRegionForThread);
     while (!itOut.IsAtEnd())
     {
       itOut.Set(itIn.Get());
@@ -202,7 +199,7 @@ InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>::DynamicTh
       volumeSeriesRegion.SetIndex(volumeSeriesIndex);
 
       // Iterators
-      VolumeSeriesRegionIterator itVolumeSeries(volumeSeries, volumeSeriesRegion);
+      itk::ImageRegionIterator<VolumeSeriesType> itVolumeSeries(volumeSeries, volumeSeriesRegion);
       itOut.GoToBegin();
 
       while (!itOut.IsAtEnd())

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -93,8 +93,7 @@ JosephBackProjectionImageFilter<TInputImage,
     using InputRegionIterator = itk::ImageRegionConstIterator<TInputImage>;
     InputRegionIterator itVolIn(this->GetInput(0), this->GetInput()->GetBufferedRegion());
 
-    using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
-    OutputRegionIterator itVolOut(this->GetOutput(), this->GetInput()->GetBufferedRegion());
+    itk::ImageRegionIteratorWithIndex<TOutputImage> itVolOut(this->GetOutput(), this->GetInput()->GetBufferedRegion());
 
     while (!itVolIn.IsAtEnd())
     {

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -207,8 +207,7 @@ JosephForwardProjectionImageFilter<TInputImage,
   using InputRegionIterator = ProjectionsRegionConstIteratorRayBased<TInputImage>;
   InputRegionIterator * itIn = nullptr;
   itIn = InputRegionIterator::New(this->GetInput(), outputRegionForThread, geometry, volPPToIndex);
-  using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionIteratorWithIndex<TOutputImage> itOut(this->GetOutput(), outputRegionForThread);
   using ClipImageIterator = itk::ImageRegionConstIterator<TClipImageType>;
   ClipImageIterator * itInferiorImage = nullptr;
   ClipImageIterator * itSuperiorImage = nullptr;

--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
@@ -78,8 +78,8 @@ template <class TInputImage, class TOutputImage>
 void
 LUTbasedVariableI0RawToAttenuationImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  using I0EstimationType = rtk::I0EstimationProjectionFilter<TInputImage>;
-  auto * i0est = dynamic_cast<I0EstimationType *>(this->GetInput()->GetSource().GetPointer());
+  auto * i0est =
+    dynamic_cast<rtk::I0EstimationProjectionFilter<TInputImage> *>(this->GetInput()->GetSource().GetPointer());
   if (i0est)
   {
     m_SubtractLUTFilter->SetConstant1((OutputImagePixelType)log(std::max((double)i0est->GetI0() - m_IDark, 1.)));

--- a/include/rtkMaskCollimationImageFilter.hxx
+++ b/include/rtkMaskCollimationImageFilter.hxx
@@ -61,14 +61,12 @@ MaskCollimationImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDa
   using InputRegionIterator = ProjectionsRegionConstIteratorRayBased<TInputImage>;
   InputRegionIterator * itIn = nullptr;
   itIn = InputRegionIterator::New(this->GetInput(), outputRegionForThread, m_Geometry);
-  using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionIteratorWithIndex<TOutputImage> itOut(this->GetOutput(), outputRegionForThread);
 
   // Go over each projection
   unsigned int npixperslice = 0;
   npixperslice = outputRegionForThread.GetSize(0) * outputRegionForThread.GetSize(1);
-  using SizeValueType = typename OutputImageRegionType::SizeValueType;
-  for (SizeValueType iProj = outputRegionForThread.GetIndex(2);
+  for (typename OutputImageRegionType::SizeValueType iProj = outputRegionForThread.GetIndex(2);
        iProj < outputRegionForThread.GetIndex(2) + outputRegionForThread.GetSize(2);
        iProj++)
   {

--- a/include/rtkProjectGeometricPhantomImageFilter.hxx
+++ b/include/rtkProjectGeometricPhantomImageFilter.hxx
@@ -53,8 +53,7 @@ ProjectGeometricPhantomImageFilter<TInputImage, TOutputImage>::GenerateData()
   // Reading figure config file
   if (!m_ConfigFile.empty())
   {
-    using ReaderType = rtk::ForbildPhantomFileReader;
-    auto reader = ReaderType::New();
+    auto reader = rtk::ForbildPhantomFileReader::New();
     reader->SetFilename(m_ConfigFile);
     reader->GenerateOutputInformation();
     this->m_GeometricPhantom = reader->GetGeometricPhantom();

--- a/include/rtkProjectionsReader.hxx
+++ b/include/rtkProjectionsReader.hxx
@@ -218,8 +218,7 @@ ProjectionsReader<TOutputImage>::GenerateOutputInformation()
       {
         /////////// XRad
         // Convert raw to Projections
-        using XRadRawFilterType = rtk::XRadRawToAttenuationImageFilter<InputImageType, OutputImageType>;
-        auto rawFilterXRad = XRadRawFilterType::New();
+        auto rawFilterXRad = rtk::XRadRawToAttenuationImageFilter<InputImageType, OutputImageType>::New();
         m_RawToAttenuationFilter = rawFilterXRad;
 
         // Or just cast to OutputImageType
@@ -659,8 +658,8 @@ ProjectionsReader<TOutputImage>::PropagateParametersToMiniPipeline()
     }
 
     // ESRF raw to attenuation converter also needs the filenames
-    using EdfRawFilterType = rtk::EdfRawToAttenuationImageFilter<TInputImage, OutputImageType>;
-    auto * edf = dynamic_cast<EdfRawFilterType *>(m_RawToAttenuationFilter.GetPointer());
+    auto * edf = dynamic_cast<rtk::EdfRawToAttenuationImageFilter<TInputImage, OutputImageType> *>(
+      m_RawToAttenuationFilter.GetPointer());
     if (edf)
       edf->SetFileNames(this->GetFileNames());
 

--- a/include/rtkRayConvexIntersectionImageFilter.hxx
+++ b/include/rtkRayConvexIntersectionImageFilter.hxx
@@ -61,8 +61,7 @@ RayConvexIntersectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGene
   using InputRegionIterator = ProjectionsRegionConstIteratorRayBased<TInputImage>;
   InputRegionIterator * itIn = nullptr;
   itIn = InputRegionIterator::New(this->GetInput(), outputRegionForThread, m_Geometry);
-  using OutputRegionIterator = itk::ImageRegionIteratorWithIndex<TOutputImage>;
-  OutputRegionIterator itOut(this->GetOutput(), outputRegionForThread);
+  itk::ImageRegionIteratorWithIndex<TOutputImage> itOut(this->GetOutput(), outputRegionForThread);
 
   // Go over each projection
   const double r = m_ConvexShape->GetDensity() / m_Attenuation;

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -291,8 +291,7 @@ typename std::enable_if<std::is_same<TSingleComponentImage, ImageType>::value, I
 ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWeightsImage>::
   ConnectGradientRegularization()
 {
-  using LaplacianFilterType = rtk::LaplacianImageFilter<TOutputImage, GradientImageType>;
-  m_LaplacianFilter = LaplacianFilterType::New();
+  m_LaplacianFilter = rtk::LaplacianImageFilter<TOutputImage, GradientImageType>::New();
   m_LaplacianFilter->SetInput(m_FloatingInputPointer);
   m_MultiplyLaplacianFilter = MultiplyFilterType::New();
   m_MultiplyLaplacianFilter->SetInput1(m_LaplacianFilter->GetOutput());

--- a/include/rtkReg1DExtractShroudSignalImageFilter.hxx
+++ b/include/rtkReg1DExtractShroudSignalImageFilter.hxx
@@ -88,16 +88,12 @@ TOutputPixel
 Reg1DExtractShroudSignalImageFilter<TInputPixel, TOutputPixel>::register1D(const RegisterImageType * f,
                                                                            const RegisterImageType * m)
 {
-  using TransformType = itk::TranslationTransform<TOutputPixel, 1>;
-  using OptimizerType = itk::RegularStepGradientDescentOptimizer;
-  using MetricType = itk::MeanSquaresImageToImageMetric<RegisterImageType, RegisterImageType>;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<RegisterImageType, TOutputPixel>;
   using RegistrationType = itk::ImageRegistrationMethod<RegisterImageType, RegisterImageType>;
 
-  auto metric = MetricType::New();
-  auto transform = TransformType::New();
-  auto optimizer = OptimizerType::New();
-  auto interpolator = InterpolatorType::New();
+  auto metric = itk::MeanSquaresImageToImageMetric<RegisterImageType, RegisterImageType>::New();
+  auto transform = itk::TranslationTransform<TOutputPixel, 1>::New();
+  auto optimizer = itk::RegularStepGradientDescentOptimizer::New();
+  auto interpolator = itk::LinearInterpolateImageFunction<RegisterImageType, TOutputPixel>::New();
   auto registration = RegistrationType::New();
 
   registration->SetMetric(metric);
@@ -109,8 +105,7 @@ Reg1DExtractShroudSignalImageFilter<TInputPixel, TOutputPixel>::register1D(const
   registration->SetMovingImage(m);
   registration->SetFixedImageRegion(f->GetLargestPossibleRegion());
 
-  using ParametersType = typename RegistrationType::ParametersType;
-  ParametersType initialParameters(transform->GetNumberOfParameters());
+  typename RegistrationType::ParametersType initialParameters(transform->GetNumberOfParameters());
   // Initial offset along X
   initialParameters[0] = itk::NumericTraits<TOutputPixel>::Zero;
 
@@ -132,14 +127,12 @@ Reg1DExtractShroudSignalImageFilter<TInputPixel, TOutputPixel>::GenerateData()
 {
   this->AllocateOutputs();
 
-  using ExtractFilterType = itk::ExtractImageFilter<TInputImage, RegisterImageType>;
-  using DuplicatorType = itk::ImageDuplicator<RegisterImageType>;
 
   typename TInputImage::ConstPointer input = this->GetInput();
   typename TInputImage::RegionType   inputRegion = input->GetLargestPossibleRegion();
   typename TInputImage::SizeType     inputSize = inputRegion.GetSize();
 
-  auto extractor = ExtractFilterType::New();
+  auto extractor = itk::ExtractImageFilter<TInputImage, RegisterImageType>::New();
   extractor->SetInput(input);
 
   typename TInputImage::RegionType extractRegion;
@@ -153,7 +146,7 @@ Reg1DExtractShroudSignalImageFilter<TInputPixel, TOutputPixel>::GenerateData()
   extractor->SetExtractionRegion(extractRegion);
   extractor->SetDirectionCollapseToIdentity();
   extractor->Update();
-  auto duplicator = DuplicatorType::New();
+  auto duplicator = itk::ImageDuplicator<RegisterImageType>::New();
   duplicator->SetInputImage(extractor->GetOutput());
   duplicator->Update();
   const RegisterImageType * prev = duplicator->GetOutput();

--- a/include/rtkScatterGlareCorrectionImageFilter.hxx
+++ b/include/rtkScatterGlareCorrectionImageFilter.hxx
@@ -88,15 +88,13 @@ ScatterGlareCorrectionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::Upd
   }
 
   // FFT kernel
-  using ForwardFFTType = itk::RealToHalfHermitianForwardFFTImageFilter<FFTInputImageType, FFTOutputImageType>;
-  auto fftK = ForwardFFTType::New();
+  auto fftK = itk::RealToHalfHermitianForwardFFTImageFilter<FFTInputImageType, FFTOutputImageType>::New();
   fftK->SetInput(kernel);
   fftK->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
   fftK->Update();
 
   // Inverse
-  using DivideType = itk::DivideImageFilter<FFTOutputImageType, FFTOutputImageType, FFTOutputImageType>;
-  auto div = DivideType::New();
+  auto div = itk::DivideImageFilter<FFTOutputImageType, FFTOutputImageType, FFTOutputImageType>::New();
   div->SetConstant1(1.);
   div->SetInput(1, fftK->GetOutput());
   div->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
@@ -31,8 +31,7 @@ void
 SelectOneProjectionPerCycleImageFilter<ProjectionStackType>::GenerateOutputInformation()
 {
   // Read signal file
-  using ReaderType = itk::CSVArray2DFileReader<double>;
-  auto reader = ReaderType::New();
+  auto reader = itk::CSVArray2DFileReader<double>::New();
   reader->SetFileName(m_SignalFilename);
   reader->SetFieldDelimiterCharacter(';');
   reader->HasRowHeadersOff();

--- a/include/rtkUpsampleImageFilter.hxx
+++ b/include/rtkUpsampleImageFilter.hxx
@@ -93,7 +93,6 @@ UpsampleImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
   // Define/declare an iterator that will walk the output region for this
   // thread.
   using OutputIterator = itk::ImageRegionIterator<TOutputImage>;
-  using InputIterator = itk::ImageRegionConstIterator<TInputImage>;
   OutputIterator outIt(outputPtr, outputRegionForThread);
 
   // Fill the output region with zeros
@@ -172,8 +171,8 @@ UpsampleImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
       inputLine.SetSize(inputLineSize);
       inputLine.SetIndex(inputStartIndex + inputOffset);
 
-      OutputIterator outIt_local(outputPtr, outputLine);
-      InputIterator  inIt(inputPtr, inputLine);
+      OutputIterator                             outIt_local(outputPtr, outputLine);
+      itk::ImageRegionConstIterator<TInputImage> inIt(inputPtr, inputLine);
 
       // Walk the line and copy the pixels
       while (!inIt.IsAtEnd())

--- a/include/rtkVarianObiRawImageFilter.hxx
+++ b/include/rtkVarianObiRawImageFilter.hxx
@@ -31,8 +31,8 @@ template <typename TInputImage, typename TOutputImage>
 void
 VarianObiRawImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  using I0EstimationType = rtk::I0EstimationProjectionFilter<TInputImage>;
-  auto * i0est = dynamic_cast<I0EstimationType *>(this->GetInput()->GetSource().GetPointer());
+  auto * i0est =
+    dynamic_cast<rtk::I0EstimationProjectionFilter<TInputImage> *>(this->GetInput()->GetSource().GetPointer());
   if (i0est)
   {
     m_I0 = (double)i0est->GetI0();

--- a/include/rtkXRadRawToAttenuationImageFilter.hxx
+++ b/include/rtkXRadRawToAttenuationImageFilter.hxx
@@ -37,8 +37,7 @@ template <class TInputImage, class TOutputImage>
 void
 XRadRawToAttenuationImageFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData()
 {
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  auto reader = ReaderType::New();
+  auto reader = itk::ImageFileReader<OutputImageType>::New();
 
   reader->SetFileName(m_DarkImageFileName);
   reader->Update();

--- a/src/rtkCudaFDKBackProjectionImageFilter.cxx
+++ b/src/rtkCudaFDKBackProjectionImageFilter.cxx
@@ -46,9 +46,8 @@ CudaFDKBackProjectionImageFilter ::GPUGenerateData()
   // Rotation center (assumed to be at 0 yet)
   ImageType::PointType rotCenterPoint;
   rotCenterPoint.Fill(0.0);
-  using ValueType = ImageType::PointType::ValueType;
   itk::ContinuousIndex<double, Dimension> rotCenterIndex =
-    this->GetInput(0)->TransformPhysicalPointToContinuousIndex<ValueType, double>(rotCenterPoint);
+    this->GetInput(0)->TransformPhysicalPointToContinuousIndex<ImageType::PointType::ValueType, double>(rotCenterPoint);
 
   // Include non-zero index in matrix
   itk::Matrix<double, 4, 4> matrixIdxVol;

--- a/src/rtkCudaWarpBackProjectionImageFilter.cxx
+++ b/src/rtkCudaWarpBackProjectionImageFilter.cxx
@@ -105,9 +105,8 @@ CudaWarpBackProjectionImageFilter ::GenerateInputRequestedRegion()
     }
     else
     {
-      using DisplacementRegionType = DVFType::RegionType;
 
-      DisplacementRegionType fieldRequestedRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
+      DVFType::RegionType fieldRequestedRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
         outputPtr->GetRequestedRegion(), outputPtr.GetPointer(), fieldPtr.GetPointer());
       fieldPtr->SetRequestedRegion(fieldRequestedRegion);
     }
@@ -133,9 +132,9 @@ CudaWarpBackProjectionImageFilter ::GPUGenerateData()
   // Rotation center (assumed to be at 0 yet)
   ImageType::PointType rotCenterPoint;
   rotCenterPoint.Fill(0.0);
-  using ValueType = ImageType::PointType::ValueType;
   itk::ContinuousIndex<double, Dimension> rotCenterIndex =
-    this->GetInputVolume()->TransformPhysicalPointToContinuousIndex<ValueType, double>(rotCenterPoint);
+    this->GetInputVolume()->TransformPhysicalPointToContinuousIndex<ImageType::PointType::ValueType, double>(
+      rotCenterPoint);
 
   // Include non-zero index in matrix
   itk::Matrix<double, 4, 4> matrixIdxVol;

--- a/src/rtkCudaWarpForwardProjectionImageFilter.cxx
+++ b/src/rtkCudaWarpForwardProjectionImageFilter.cxx
@@ -114,9 +114,8 @@ CudaWarpForwardProjectionImageFilter ::GenerateInputRequestedRegion()
     }
     else
     {
-      using DisplacementRegionType = DVFType::RegionType;
 
-      DisplacementRegionType fieldRequestedRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
+      DVFType::RegionType fieldRequestedRegion = itk::ImageAlgorithm::EnlargeRegionOverBox(
         inputPtr->GetRequestedRegion(), inputPtr.GetPointer(), fieldPtr.GetPointer());
       fieldPtr->SetRequestedRegion(fieldRequestedRegion);
     }

--- a/src/rtkDigisensGeometryReader.cxx
+++ b/src/rtkDigisensGeometryReader.cxx
@@ -101,8 +101,7 @@ rtk::DigisensGeometryReader ::GenerateData()
     itk::Versor<double> xfm3DVersor;
     xfm3DVersor.Set(rotationAxis, angle * degreesToRadians);
 
-    using ThreeDTransformType = itk::CenteredEuler3DTransform<double>;
-    auto xfm3D = ThreeDTransformType::New();
+    auto xfm3D = itk::CenteredEuler3DTransform<double>::New();
     xfm3D->SetMatrix(xfm3DVersor.GetMatrix());
 
     m_Geometry->AddProjectionInRadians(sid,

--- a/src/rtkThreeDCircularProjectionGeometry.cxx
+++ b/src/rtkThreeDCircularProjectionGeometry.cxx
@@ -534,8 +534,7 @@ rtk::ThreeDCircularProjectionGeometry::GetAngularGaps(const std::vector<double> 
 rtk::ThreeDCircularProjectionGeometry::ThreeDHomogeneousMatrixType
 rtk::ThreeDCircularProjectionGeometry::ComputeRotationHomogeneousMatrix(double angleX, double angleY, double angleZ)
 {
-  using ThreeDTransformType = itk::CenteredEuler3DTransform<double>;
-  auto xfm = ThreeDTransformType::New();
+  auto xfm = itk::CenteredEuler3DTransform<double>::New();
   xfm->SetIdentity();
   xfm->SetRotation(angleX, angleY, angleZ);
 

--- a/src/rtkVarianObiGeometryReader.cxx
+++ b/src/rtkVarianObiGeometryReader.cxx
@@ -49,9 +49,9 @@ rtk::VarianObiGeometryReader ::GenerateData()
   const double sdd = dynamic_cast<MetaDataDoubleType *>(dic["CalibratedSID"].GetPointer())->GetMetaDataObjectValue();
   const double sid = dynamic_cast<MetaDataDoubleType *>(dic["CalibratedSAD"].GetPointer())->GetMetaDataObjectValue();
 
-  using MetaDataStringType = itk::MetaDataObject<std::string>;
   double      offsetx = NAN;
-  std::string fanType = dynamic_cast<const MetaDataStringType *>(dic["FanType"].GetPointer())->GetMetaDataObjectValue();
+  std::string fanType =
+    dynamic_cast<const itk::MetaDataObject<std::string> *>(dic["FanType"].GetPointer())->GetMetaDataObjectValue();
   if (itksys::SystemTools::Strucmp(fanType.c_str(), "HalfFan") == 0)
   {
     // Half Fan (offset detector), get lateral offset from XML file
@@ -75,11 +75,8 @@ rtk::VarianObiGeometryReader ::GenerateData()
   // Projection matrices
   for (const std::string & projectionsFileName : m_ProjectionsFileNames)
   {
-    using InputPixelType = unsigned int;
-    using InputImageType = itk::Image<InputPixelType, 2>;
 
-    using ReaderType = itk::ImageFileReader<InputImageType>;
-    auto reader = ReaderType::New();
+    auto reader = itk::ImageFileReader<itk::Image<unsigned int, 2>>::New();
     reader->SetFileName(projectionsFileName);
     reader->UpdateOutputInformation();
 

--- a/src/rtkVarianProBeamGeometryReader.cxx
+++ b/src/rtkVarianProBeamGeometryReader.cxx
@@ -51,11 +51,8 @@ rtk::VarianProBeamGeometryReader ::GenerateData()
   // Projection matrices
   for (const std::string & projectionsFileName : m_ProjectionsFileNames)
   {
-    using InputPixelType = unsigned int;
-    using InputImageType = itk::Image<InputPixelType, 2>;
 
-    using ReaderType = itk::ImageFileReader<InputImageType>;
-    auto reader = ReaderType::New();
+    auto reader = itk::ImageFileReader<itk::Image<unsigned int, 2>>::New();
     reader->SetFileName(projectionsFileName);
     reader->UpdateOutputInformation();
 

--- a/test/rtkI0estimationtest.cxx
+++ b/test/rtkI0estimationtest.cxx
@@ -17,16 +17,14 @@ main(int, char **)
   constexpr unsigned int Dimension = 3;
   using ImageType = itk::Image<unsigned short, Dimension>;
 
-  using I0FilterType = rtk::I0EstimationProjectionFilter<ImageType, ImageType, 3>;
-  auto i0est = I0FilterType::New();
+  auto i0est = rtk::I0EstimationProjectionFilter<ImageType, ImageType, 3>::New();
 
   // Constant image sources
   auto                  size = itk::MakeSize(150, 150, 1);
   ImageType::RegionType region;
   region.SetSize(size);
 
-  using RandomImageSourceType = itk::RandomImageSource<ImageType>;
-  auto randomSource = RandomImageSourceType::New();
+  auto randomSource = itk::RandomImageSource<ImageType>::New();
   randomSource->SetSize(size);
 
   i0est->SetExpectedI0(23);

--- a/test/rtkTestReg23ProjectionGeometry.cxx
+++ b/test/rtkTestReg23ProjectionGeometry.cxx
@@ -111,7 +111,6 @@ main(int argc, char * argv[])
   VERBOSE(<< "\n\nStart testing ora::Reg23ProjectionGeometry\n\n")
 
   using RandomType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
-  using EulerType = itk::Euler3DTransform<double>;
   using Point2DType = itk::Point<double, 2>;
 
   GeometryType::PointType              sourcePosition;
@@ -179,7 +178,7 @@ main(int argc, char * argv[])
     GeometryType::HomogeneousVectorType hv;
     GeometryType::VectorType            tmp;
 
-    auto                eu = EulerType::New();
+    auto                eu = itk::Euler3DTransform<double>::New();
     std::vector<double> gantryAngles;
     std::vector<double> outOfPlaneAngles;
     std::vector<double> inPlaneAngles;

--- a/test/rtkadjointoperatorstest.cxx
+++ b/test/rtkadjointoperatorstest.cxx
@@ -127,8 +127,7 @@ main(int, char **)
 
     std::cout << "\n\n****** Joseph Forward projector ******" << std::endl;
 
-    using JosephForwardProjectorType = rtk::JosephForwardProjectionImageFilter<OutputImageType, OutputImageType>;
-    auto fw = JosephForwardProjectorType::New();
+    auto fw = rtk::JosephForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
     fw->SetInput(0, constantProjectionsSource->GetOutput());
     fw->SetInput(1, randomVolumeSource->GetOutput());
     fw->SetGeometry(geometry);
@@ -136,8 +135,7 @@ main(int, char **)
 
     std::cout << "\n\n****** Joseph Back projector ******" << std::endl;
 
-    using JosephBackProjectorType = rtk::JosephBackProjectionImageFilter<OutputImageType, OutputImageType>;
-    auto bp = JosephBackProjectorType::New();
+    auto bp = rtk::JosephBackProjectionImageFilter<OutputImageType, OutputImageType>::New();
     bp->SetInput(0, constantVolumeSource->GetOutput());
     bp->SetInput(1, randomProjectionsSource->GetOutput());
     bp->SetGeometry(geometry.GetPointer());
@@ -226,17 +224,15 @@ main(int, char **)
 
     std::cout << "\n\n****** Joseph Vector Forward projector ******" << std::endl;
 
-    using VectorJosephForwardProjectorType = rtk::JosephForwardProjectionImageFilter<VectorImageType, VectorImageType>;
 
-    auto vfw = VectorJosephForwardProjectorType::New();
+    auto vfw = rtk::JosephForwardProjectionImageFilter<VectorImageType, VectorImageType>::New();
     vfw->SetInput(0, vectorConstantProjections);
     vfw->SetInput(1, vectorRandomVolume);
     vfw->SetGeometry(geometry);
     TRY_AND_EXIT_ON_ITK_EXCEPTION(vfw->Update());
 
     std::cout << "\n\n****** Joseph Vector Back projector ******" << std::endl;
-    using VectorJosephBackProjectorType = rtk::JosephBackProjectionImageFilter<VectorImageType, VectorImageType>;
-    auto vbp = VectorJosephBackProjectorType::New();
+    auto vbp = rtk::JosephBackProjectionImageFilter<VectorImageType, VectorImageType>::New();
     vbp->SetInput(0, vectorConstantVolume);
     vbp->SetInput(1, vectorRandomProjections);
     vbp->SetGeometry(geometry.GetPointer());
@@ -249,9 +245,7 @@ main(int, char **)
 
     std::cout << "\n\n****** Attenuated Joseph Forward projector ******" << std::endl;
 
-    using JosephForwardAttenuatedProjectorType =
-      rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>;
-    auto attfw = JosephForwardAttenuatedProjectorType::New();
+    auto attfw = rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>::New();
     attfw->SetInput(0, constantProjectionsSource->GetOutput());
     attfw->SetInput(1, randomVolumeSource->GetOutput());
     attfw->SetInput(2, constantAttenuationSource->GetOutput());
@@ -260,9 +254,7 @@ main(int, char **)
 
     std::cout << "\n\n****** Attenuated Joseph Back projector ******" << std::endl;
 
-    using JosephBackAttenuatedProjectorType =
-      rtk::JosephBackAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>;
-    auto attbp = JosephBackAttenuatedProjectorType::New();
+    auto attbp = rtk::JosephBackAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>::New();
     attbp->SetInput(0, constantVolumeSource->GetOutput());
     attbp->SetInput(1, randomProjectionsSource->GetOutput());
     attbp->SetInput(2, constantAttenuationSource->GetOutput());
@@ -277,8 +269,7 @@ main(int, char **)
 #ifdef USE_CUDA
     std::cout << "\n\n****** Cuda Ray Cast Forward projector ******" << std::endl;
 
-    using CudaForwardProjectorType = rtk::CudaForwardProjectionImageFilter<OutputImageType, OutputImageType>;
-    auto cfw = CudaForwardProjectorType::New();
+    auto cfw = rtk::CudaForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
     cfw->SetInput(0, constantProjectionsSource->GetOutput());
     cfw->SetInput(1, randomVolumeSource->GetOutput());
     cfw->SetGeometry(geometry);
@@ -286,8 +277,7 @@ main(int, char **)
 
     std::cout << "\n\n****** Cuda Ray Cast Back projector ******" << std::endl;
 
-    using CudaRayCastBackProjectorType = rtk::CudaRayCastBackProjectionImageFilter;
-    auto cbp = CudaRayCastBackProjectorType::New();
+    auto cbp = rtk::CudaRayCastBackProjectionImageFilter::New();
     cbp->SetInput(0, constantVolumeSource->GetOutput());
     cbp->SetInput(1, randomProjectionsSource->GetOutput());
     cbp->SetGeometry(geometry.GetPointer());

--- a/test/rtkadmmtotalvariationtest.cxx
+++ b/test/rtkadmmtotalvariationtest.cxx
@@ -82,8 +82,7 @@ main(int argc, char * argv[])
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -107,8 +106,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 
@@ -160,8 +158,7 @@ main(int argc, char * argv[])
   admmtotalvariation->SetBackProjectionFilter(ADMMTotalVariationType::BP_VOXELBASED);
 
   // Generate arbitrary gating weights (select every third projection)
-  using PhaseGatingFilterType = rtk::PhaseGatingImageFilter<OutputImageType>;
-  auto phaseGating = PhaseGatingFilterType::New();
+  auto phaseGating = rtk::PhaseGatingImageFilter<OutputImageType>::New();
 #if FAST_TESTS_NO_CHECKS
   phaseGating->SetPhasesFileName(argv[2]);
 #else

--- a/test/rtkadmmwaveletstest.cxx
+++ b/test/rtkadmmwaveletstest.cxx
@@ -131,8 +131,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -153,8 +152,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 

--- a/test/rtkamsterdamshroudtest.cxx
+++ b/test/rtkamsterdamshroudtest.cxx
@@ -31,8 +31,7 @@ main(int argc, char * argv[])
 {
   constexpr unsigned int Dimension = 3;
   using reg1DPixelType = double;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
   using reg1DImageType = itk::Image<reg1DPixelType, Dimension - 2>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
@@ -78,13 +77,12 @@ main(int argc, char * argv[])
   constantImageSource->SetSize(size);
   constantImageSource->SetConstant(0.);
 
-  using PasteImageFilterType = itk::PasteImageFilter<OutputImageType, OutputImageType, OutputImageType>;
   OutputImageType::IndexType destinationIndex;
   destinationIndex[0] = 0;
   destinationIndex[1] = 0;
   destinationIndex[2] = 0;
 
-  auto pasteFilter = PasteImageFilterType::New();
+  auto pasteFilter = itk::PasteImageFilter<OutputImageType, OutputImageType, OutputImageType>::New();
 
   // Single projection
   using REIType = rtk::RayEllipsoidIntersectionImageFilter<OutputImageType, OutputImageType>;
@@ -177,8 +175,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(shroudFilter->Update());
 
   // Read reference object
-  using ReaderAmsterdamType = itk::ImageFileReader<ShroudFilterType::OutputImageType>;
-  auto reader2 = ReaderAmsterdamType::New();
+  auto reader2 = itk::ImageFileReader<ShroudFilterType::OutputImageType>::New();
   reader2->SetFileName(argv[1]);
   reader2->Update();
 
@@ -203,9 +200,8 @@ main(int argc, char * argv[])
   std::cout << "\n\n****** Case 2: Breathing signal calculated by reg1D algorithm ******\n" << std::endl;
 
   // Estimation of breathing signal
-  using reg1DFilterType = rtk::Reg1DExtractShroudSignalImageFilter<reg1DPixelType, reg1DPixelType>;
   reg1DImageType::Pointer reg1DSignal;
-  auto                    reg1DFilter = reg1DFilterType::New();
+  auto                    reg1DFilter = rtk::Reg1DExtractShroudSignalImageFilter<reg1DPixelType, reg1DPixelType>::New();
   reg1DFilter->SetInput(reader2->GetOutput());
   reg1DFilter->Update();
   reg1DSignal = reg1DFilter->GetOutput();
@@ -243,9 +239,8 @@ main(int argc, char * argv[])
   std::cout << "\n\n****** Case 3: Breathing signal calculated by DP algorithm ******\n" << std::endl;
 
   // Estimation of breathing signal
-  using DPFilterType = rtk::DPExtractShroudSignalImageFilter<reg1DPixelType, reg1DPixelType>;
   reg1DImageType::Pointer DPSignal;
-  auto                    DPFilter = DPFilterType::New();
+  auto                    DPFilter = rtk::DPExtractShroudSignalImageFilter<reg1DPixelType, reg1DPixelType>::New();
   DPFilter->SetInput(reader2->GetOutput());
   DPFilter->SetAmplitude(20.);
   DPFilter->Update();

--- a/test/rtkbinningtest.cxx
+++ b/test/rtkbinningtest.cxx
@@ -19,8 +19,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 2;
-  using OutputPixelType = unsigned short;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<unsigned short, Dimension>;
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
@@ -43,8 +42,7 @@ main(int, char **)
   imgRef->UpdateLargestPossibleRegion();
 
   // Binning filter
-  using BINType = itk::BinShrinkImageFilter<OutputImageType, OutputImageType>;
-  auto bin = BINType::New();
+  auto bin = itk::BinShrinkImageFilter<OutputImageType, OutputImageType>::New();
 
   std::cout << "\n\n****** Case 1: binning 2x2 ******" << std::endl;
 

--- a/test/rtkconjugategradientreconstructiontest.cxx
+++ b/test/rtkconjugategradientreconstructiontest.cxx
@@ -71,8 +71,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -92,8 +91,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 

--- a/test/rtkconjugategradienttest.cxx
+++ b/test/rtkconjugategradienttest.cxx
@@ -19,10 +19,8 @@ CheckImageQuality(typename TImage1::Pointer itkNotUsed(recon), typename TImage2:
 void
 CheckImageQuality(typename TImage1::Pointer recon, typename TImage2::Pointer ref)
 {
-  using ImageIteratorType1 = itk::ImageRegionConstIterator<TImage1>;
-  using ImageIteratorType2 = itk::ImageRegionConstIterator<TImage2>;
-  ImageIteratorType1 itTest(recon, recon->GetBufferedRegion());
-  ImageIteratorType2 itRef(ref, ref->GetBufferedRegion());
+  itk::ImageRegionConstIterator<TImage1> itTest(recon, recon->GetBufferedRegion());
+  itk::ImageRegionConstIterator<TImage2> itRef(ref, ref->GetBufferedRegion());
 
   // Compute the mean of the reference image (which cannot be recovered by inverting the gradient)
   double mean = 0;
@@ -107,15 +105,12 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Random and constant image sources
-  using RandomImageSourceType = itk::RandomImageSource<OutputImageType>;
-  auto randomVolumeSource = RandomImageSourceType::New();
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto constantVolumeSource = ConstantImageSourceType::New();
+  auto randomVolumeSource = itk::RandomImageSource<OutputImageType>::New();
+  auto constantVolumeSource = rtk::ConstantImageSource<OutputImageType>::New();
 
   // Volume metadata
   auto origin = itk::MakePoint(-127., -127., -127.);
@@ -152,8 +147,7 @@ main(int, char **)
     dimProcessed = true;
   }
   gradientFilter->SetDimensionsProcessed(dimsProcessed);
-  using DivergenceFilterType = rtk::BackwardDifferenceDivergenceImageFilter<GradientFilterType::OutputImageType>;
-  auto divergenceFilter = DivergenceFilterType::New();
+  auto divergenceFilter = rtk::BackwardDifferenceDivergenceImageFilter<GradientFilterType::OutputImageType>::New();
   divergenceFilter->SetInput(gradientFilter->GetOutput());
 
   // Update the gradient and divergence filters
@@ -161,11 +155,9 @@ main(int, char **)
 
   // Create and set the conjugate gradient optimizer
   // It uses the operator DivergenceOfGradientConjugateGradientOperator
-  using CGFilterType = rtk::ConjugateGradientImageFilter<OutputImageType>;
-  auto cg = CGFilterType::New();
+  auto cg = rtk::ConjugateGradientImageFilter<OutputImageType>::New();
 
-  using CGoperatorType = rtk::DivergenceOfGradientConjugateGradientOperator<OutputImageType>;
-  auto cg_op = CGoperatorType::New();
+  auto cg_op = rtk::DivergenceOfGradientConjugateGradientOperator<OutputImageType>::New();
   cg->SetA(cg_op.GetPointer());
   cg->SetX(constantVolumeSource->GetOutput());
   cg->SetB(divergenceFilter->GetOutput());

--- a/test/rtkcroptest.cxx
+++ b/test/rtkcroptest.cxx
@@ -10,16 +10,14 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using PixelType = float;
-  using ImageType = itk::CudaImage<PixelType, Dimension>;
+  using ImageType = itk::CudaImage<float, Dimension>;
 
   auto image = ImageType::New();
   image->SetRegions(itk::MakeSize(50, 50, 50));
   image->Allocate();
   image->FillBuffer(12.3);
 
-  using CropImageFilter = rtk::CudaCropImageFilter;
-  auto crop = CropImageFilter::New();
+  auto crop = rtk::CudaCropImageFilter::New();
   crop->SetInput(image);
   crop->SetLowerBoundaryCropSize(itk::MakeSize(1, 1, 1));
   crop->SetUpperBoundaryCropSize(itk::MakeSize(10, 10, 10));

--- a/test/rtkcudaraycastadjointoperatorstest.cxx
+++ b/test/rtkcudaraycastadjointoperatorstest.cxx
@@ -94,15 +94,13 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(constantProjectionsSource->Update());
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
   std::cout << "\n\n****** CUDA ray cast Forward projector, flat panel detector ******" << std::endl;
 
-  using ForwardProjectorType = rtk::CudaForwardProjectionImageFilter<OutputImageType, OutputImageType>;
-  auto fw = ForwardProjectorType::New();
+  auto fw = rtk::CudaForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
   fw->SetInput(0, constantProjectionsSource->GetOutput());
   fw->SetInput(1, randomVolumeSource->GetOutput());
   fw->SetGeometry(geometry);
@@ -110,8 +108,7 @@ main(int, char **)
 
   std::cout << "\n\n****** CUDA ray cast Back projector, flat panel detector ******" << std::endl;
 
-  using BackProjectorType = rtk::CudaRayCastBackProjectionImageFilter;
-  auto bp = BackProjectorType::New();
+  auto bp = rtk::CudaRayCastBackProjectionImageFilter::New();
   bp->SetInput(0, constantVolumeSource->GetOutput());
   bp->SetInput(1, randomProjectionsSource->GetOutput());
   bp->SetGeometry(geometry.GetPointer());

--- a/test/rtkcyclicdeformationtest.cxx
+++ b/test/rtkcyclicdeformationtest.cxx
@@ -56,10 +56,10 @@ main(int, char **)
   deformationField->SetSpacing(spacing);
   deformationField->Allocate();
 
-  using IteratorType = itk::ImageRegionIteratorWithIndex<DVFSequenceImageType>;
   // Vector Field initilization
-  DVFImageType::PixelType vec;
-  IteratorType            dvfIt(deformationField, deformationField->GetLargestPossibleRegion());
+  DVFImageType::PixelType                                 vec;
+  itk::ImageRegionIteratorWithIndex<DVFSequenceImageType> dvfIt(deformationField,
+                                                                deformationField->GetLargestPossibleRegion());
 
   DVFSequenceImageType::OffsetType DVFCenter;
   DVFSequenceImageType::IndexType  toCenter;
@@ -95,11 +95,10 @@ main(int, char **)
   signalFile.close();
 
   // Set the forward and back projection filters to be used
-  using CyclicDeformationType = rtk::CyclicDeformationImageFilter<DVFSequenceImageType, DVFImageType>;
 
   std::cout << "\n\n****** Case 1: CPU cyclic deformation field ******" << std::endl;
 
-  auto cyclic = CyclicDeformationType::New();
+  auto cyclic = rtk::CyclicDeformationImageFilter<DVFSequenceImageType, DVFImageType>::New();
   cyclic->SetInput(deformationField);
   cyclic->SetSignalFilename(signalFileName);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(cyclic->Update());

--- a/test/rtkcylindricaldetectorreconstructiontest.cxx
+++ b/test/rtkcylindricaldetectorreconstructiontest.cxx
@@ -94,8 +94,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 

--- a/test/rtkdigisenstest.cxx
+++ b/test/rtkdigisenstest.cxx
@@ -46,9 +46,8 @@ main(int argc, char * argv[])
   CheckGeometries(geoTargReader->GetGeometry(), geoRefReader->GetOutputObject());
 
   // ******* COMPARING projections *******
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Tif projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;

--- a/test/rtkdisplaceddetectorcompcudatest.cxx
+++ b/test/rtkdisplaceddetectorcompcudatest.cxx
@@ -22,27 +22,23 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::CudaImage<OutputPixelType, Dimension>;
+  using OutputImageType = itk::CudaImage<float, Dimension>;
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto projSource = ConstantImageSourceType::New();
+  auto projSource = rtk::ConstantImageSource<OutputImageType>::New();
   projSource->SetOrigin(itk::MakePoint(-127., -3., 0.));
   projSource->SetSpacing(itk::MakeVector(2., 2., 2.));
   projSource->SetSize(itk::MakeSize(128, 4, 4));
 
   // Geometry
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   geometry->AddProjection(600., 700., 0., 84., 35, 23, 15, 21, 26);
   geometry->AddProjection(500., 800., 45., 21., 12, 16, 546, 14, 41);
   geometry->AddProjection(700., 900., 90., 68., 68, 54, 38, 35, 56);
   geometry->AddProjection(900., 1000., 135., 48., 35, 84, 10, 84, 59);
 
   // Projections
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);

--- a/test/rtkdisplaceddetectorcompoffsettest.cxx
+++ b/test/rtkdisplaceddetectorcompoffsettest.cxx
@@ -22,27 +22,23 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto projSource = ConstantImageSourceType::New();
+  auto projSource = rtk::ConstantImageSource<OutputImageType>::New();
   projSource->SetOrigin(itk::MakePoint(-508., -3., 0.));
   projSource->SetSpacing(itk::MakeVector(8., 2., 2.));
   projSource->SetSize(itk::MakeSize(128, 4, 4));
 
   // Geometry
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   geometry->AddProjection(600., 560., 0., 3., 0., 0., 0., 2., 0.);
   geometry->AddProjection(500., 545., 90., 2., 0., 0., 0., 4., 0.);
   geometry->AddProjection(700., 790., 180., 8., 0., 0., 0., 5., 0.);
   geometry->AddProjection(900., 935., 270., 4., 0., 0., 0., 8., 0.);
 
   // Projections
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);

--- a/test/rtkdisplaceddetectortest.cxx
+++ b/test/rtkdisplaceddetectortest.cxx
@@ -73,8 +73,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
 
   // Displaced detector weighting
@@ -87,14 +86,12 @@ main(int, char **)
   ddf->SetInput(slp->GetOutput());
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update());
 
   // FDK reconstruction filtering
-  using FDKCPUType = rtk::FDKConeBeamReconstructionFilter<OutputImageType>;
-  auto feldkamp = FDKCPUType::New();
+  auto feldkamp = rtk::FDKConeBeamReconstructionFilter<OutputImageType>::New();
   feldkamp->SetInput(0, tomographySource->GetOutput());
   feldkamp->SetInput(1, ddf->GetOutput());
 

--- a/test/rtkdivergencetest.cxx
+++ b/test/rtkdivergencetest.cxx
@@ -88,13 +88,11 @@ main(int, char **)
   grad2->SetDimensionsProcessed(computeGradientAlongDim);
 
   // Now compute MINUS the divergence of grad2
-  using DivergenceFilterType = rtk::BackwardDifferenceDivergenceImageFilter<GradientImageType, ImageType>;
-  auto div = DivergenceFilterType::New();
+  auto div = rtk::BackwardDifferenceDivergenceImageFilter<GradientImageType, ImageType>::New();
   div->SetInput(grad2->GetOutput());
   div->SetDimensionsProcessed(computeGradientAlongDim);
 
-  using MultiplyFilterType = itk::MultiplyImageFilter<ImageType>;
-  auto multiply = MultiplyFilterType::New();
+  auto multiply = itk::MultiplyImageFilter<ImageType>::New();
   multiply->SetInput1(div->GetOutput());
   multiply->SetConstant2(-1);
 

--- a/test/rtkdrawgeometricphantomtest.cxx
+++ b/test/rtkdrawgeometricphantomtest.cxx
@@ -36,12 +36,10 @@ main(int argc, char * argv[])
   }
 
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto tomographySource = ConstantImageSourceType::New();
+  auto tomographySource = rtk::ConstantImageSource<OutputImageType>::New();
   auto origin = itk::MakePoint(-127., -127., -127.);
 #if FAST_TESTS_NO_CHECKS
   auto spacing = itk::MakeVector(254., 254., 254.);
@@ -60,16 +58,14 @@ main(int argc, char * argv[])
   //////////////////////////////////
 
   // Shepp Logan reference filter
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(128.);
   dsl->InPlaceOff();
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update());
 
   // Shepp Logan reference filter from Configuration File
-  using DGPType = rtk::DrawGeometricPhantomImageFilter<OutputImageType, OutputImageType>;
-  auto dgp = DGPType::New();
+  auto dgp = rtk::DrawGeometricPhantomImageFilter<OutputImageType, OutputImageType>::New();
   dgp->SetInput(tomographySource->GetOutput());
   dgp->InPlaceOff();
   dgp->SetConfigFile(argv[1]);
@@ -100,8 +96,7 @@ main(int argc, char * argv[])
   //    center.push_back(2.);
 
   // Draw CYLINDER
-  using DCType = rtk::DrawCylinderImageFilter<OutputImageType, OutputImageType>;
-  auto dcl = DCType::New();
+  auto dcl = rtk::DrawCylinderImageFilter<OutputImageType, OutputImageType>::New();
 
   dcl->SetInput(tomographySource->GetOutput());
   dcl->SetAxis(itk::MakeVector(100., 0., 100.));
@@ -111,8 +106,7 @@ main(int argc, char * argv[])
   dcl->InPlaceOff();
 
   // Draw CONE
-  using DCOType = rtk::DrawConeImageFilter<OutputImageType, OutputImageType>;
-  auto dco = DCOType::New();
+  auto dco = rtk::DrawConeImageFilter<OutputImageType, OutputImageType>::New();
   dco->SetInput(tomographySource->GetOutput());
   dco->SetAxis(itk::MakeVector(25., -50., 25.));
   dco->SetCenter(itk::MakeVector(2., 2., 2.));
@@ -120,8 +114,7 @@ main(int argc, char * argv[])
   dco->SetDensity(-0.54);
 
   // Add Image Filter used to concatenate the different figures obtained on each iteration
-  using AddImageFilterType = itk::AddImageFilter<OutputImageType, OutputImageType, OutputImageType>;
-  auto addFilter = AddImageFilterType::New();
+  auto addFilter = itk::AddImageFilter<OutputImageType, OutputImageType, OutputImageType>::New();
 
   addFilter->SetInput1(dcl->GetOutput());
   addFilter->SetInput2(dco->GetOutput());

--- a/test/rtkedftest.cxx
+++ b/test/rtkedftest.cxx
@@ -24,9 +24,8 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // 1. ESRF / Edf projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;

--- a/test/rtkelektatest.cxx
+++ b/test/rtkelektatest.cxx
@@ -69,9 +69,8 @@ main(int argc, char * argv[])
   std::cout << "Testing his file processing..." << std::endl;
 
   // ******* COMPARING projections *******
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Elekta projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;
@@ -92,25 +91,20 @@ main(int argc, char * argv[])
   CheckImageQuality<ImageType>(reader->GetOutput(), readerRef->GetOutput(), 1.6e-7, 100, 2.0);
 
   // ******* Test split of lookup table ******
-  using InputPixelType = unsigned short;
-  using InputImageType = itk::Image<InputPixelType, 3>;
-  using RawReaderType = itk::ImageFileReader<InputImageType>;
-  auto r = RawReaderType::New();
+  using InputImageType = itk::Image<unsigned short, 3>;
+  auto r = itk::ImageFileReader<InputImageType>::New();
   r->SetFileName(argv[3]);
   r->Update();
 
-  using FullLUTType = rtk::ElektaSynergyLookupTableImageFilter<ImageType>;
-  auto full = FullLUTType::New();
+  auto full = rtk::ElektaSynergyLookupTableImageFilter<ImageType>::New();
   full->SetInput(r->GetOutput());
   full->Update();
 
-  using RawLUTType = rtk::ElektaSynergyRawLookupTableImageFilter<InputImageType, InputImageType>;
-  auto raw = RawLUTType::New();
+  auto raw = rtk::ElektaSynergyRawLookupTableImageFilter<InputImageType, InputImageType>::New();
   raw->SetInput(r->GetOutput());
   raw->Update();
 
-  using LogLUTType = rtk::LUTbasedVariableI0RawToAttenuationImageFilter<InputImageType, ImageType>;
-  auto log = LogLUTType::New();
+  auto log = rtk::LUTbasedVariableI0RawToAttenuationImageFilter<InputImageType, ImageType>::New();
   log->SetInput(raw->GetOutput());
   log->SetI0(log->GetI0() + 1.);
   log->Update();

--- a/test/rtkfbpparalleltest.cxx
+++ b/test/rtkfbpparalleltest.cxx
@@ -68,22 +68,19 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 0., noProj * 360. / NumberOfProjectionImages, 0, 0, 0, 0, 20, 15);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(slp->Update());
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
@@ -102,8 +99,7 @@ main(int, char **)
 
 
   // FOV
-  using FOVFilterType = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>;
-  auto fov = FOVFilterType::New();
+  auto fov = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>::New();
   fov->SetInput(0, feldkamp->GetOutput());
   fov->SetProjectionsStack(slp->GetOutput());
   fov->SetGeometry(geometry);

--- a/test/rtkfdkprojweightcompcudatest.cxx
+++ b/test/rtkfdkprojweightcompcudatest.cxx
@@ -23,28 +23,24 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::CudaImage<OutputPixelType, Dimension>;
+  using OutputImageType = itk::CudaImage<float, Dimension>;
 
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto projSource = ConstantImageSourceType::New();
+  auto projSource = rtk::ConstantImageSource<OutputImageType>::New();
   projSource->SetOrigin(itk::MakePoint(-127., -3., 0.));
   projSource->SetSpacing(itk::MakeVector(2., 2., 2.));
   projSource->SetSize(itk::MakeSize(128, 4, 4));
 
   // Geometry
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   geometry->AddProjection(600., 700., 0., 84., 35, 23, 15, 21, 26);
   geometry->AddProjection(500., 800., 45., 21., 12, 16, 546, 14, 41);
   geometry->AddProjection(700., 900., 90., 68., 68, 54, 38, 35, 56);
   geometry->AddProjection(900., 1000., 135., 48., 35, 84, 10, 84, 59);
 
   // Projections
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);

--- a/test/rtkfdktest.cxx
+++ b/test/rtkfdktest.cxx
@@ -77,22 +77,19 @@ main(int, char **)
   std::cout << "\n\n****** Case 1: No streaming ******" << std::endl;
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages, 0, 0, 0, 0, 20, 15);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(slp->Update());
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
@@ -111,8 +108,7 @@ main(int, char **)
 
 
   // FOV
-  using FOVFilterType = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>;
-  auto fov = FOVFilterType::New();
+  auto fov = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>::New();
   fov->SetInput(0, feldkamp->GetOutput());
   fov->SetProjectionsStack(slp->GetOutput());
   fov->SetGeometry(geometry);
@@ -166,8 +162,7 @@ main(int, char **)
   // Make sure that the data will be recomputed by releasing them
   fov->GetOutput()->ReleaseData();
 
-  using StreamingType = itk::StreamingImageFilter<OutputImageType, OutputImageType>;
-  auto streamer = StreamingType::New();
+  auto streamer = itk::StreamingImageFilter<OutputImageType, OutputImageType>::New();
   streamer->SetInput(0, fov->GetOutput());
   streamer->SetNumberOfStreamDivisions(8);
   auto splitter = itk::ImageRegionSplitterDirection::New();

--- a/test/rtkforbildtest.cxx
+++ b/test/rtkforbildtest.cxx
@@ -19,8 +19,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
@@ -64,8 +63,7 @@ main(int, char **)
   rotMat[2][1] = -1.;
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 0., noProj * 360. / NumberOfProjectionImages);
 
@@ -73,8 +71,7 @@ main(int, char **)
 
   // Shepp Logan projections filter
   std::cout << "\n\n****** Projecting ******" << std::endl;
-  using ProjectGPType = rtk::ProjectGeometricPhantomImageFilter<OutputImageType, OutputImageType>;
-  auto pgp = ProjectGPType::New();
+  auto pgp = rtk::ProjectGeometricPhantomImageFilter<OutputImageType, OutputImageType>::New();
   pgp->SetInput(projectionsSource->GetOutput());
   pgp->SetGeometry(geometry);
   pgp->SetPhantomScale(1.2);
@@ -84,8 +81,7 @@ main(int, char **)
 
   // Create a reference object (in this case a 3D phantom reference).
   std::cout << "\n\n****** Drawing ******" << std::endl;
-  using DrawGPType = rtk::DrawGeometricPhantomImageFilter<OutputImageType, OutputImageType>;
-  auto dgp = DrawGPType::New();
+  auto dgp = rtk::DrawGeometricPhantomImageFilter<OutputImageType, OutputImageType>::New();
   dgp->SetInput(tomographySource->GetOutput());
   dgp->SetPhantomScale(1.2);
   dgp->SetConfigFile(configFileName);
@@ -94,8 +90,7 @@ main(int, char **)
 
   // FDK reconstruction filtering
   std::cout << "\n\n****** Reconstructing ******" << std::endl;
-  using FDKType = rtk::FDKConeBeamReconstructionFilter<OutputImageType>;
-  auto feldkamp = FDKType::New();
+  auto feldkamp = rtk::FDKConeBeamReconstructionFilter<OutputImageType>::New();
   feldkamp->SetInput(0, tomographySource->GetOutput());
   feldkamp->SetInput(1, pgp->GetOutput());
   feldkamp->SetGeometry(geometry);

--- a/test/rtkforwardattenuatedprojectiontest.cxx
+++ b/test/rtkforwardattenuatedprojectiontest.cxx
@@ -77,8 +77,7 @@ main(int, char **)
   attenuationInput->SetSize(size);
   attenuationInput->SetConstant(0);
 
-  using DEIFType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto deif = DEIFType::New();
+  auto deif = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   auto axis_vol = itk::MakeVector(50., 50., 50.);
   auto center_vol = itk::MakeVector(0., 0., -30.);
   deif->SetInput(volInput->GetOutput());
@@ -140,15 +139,12 @@ main(int, char **)
   clip_plane_direction_init[0] = 0.;
   clip_plane_direction_init[1] = 0.;
   clip_plane_direction_init[2] = 1.;
-  using TransformType = itk::CenteredEuler3DTransform<double>;
-  auto transform = TransformType::New();
-  using SubtractImageFilterType = itk::SubtractImageFilter<OutputImageType, OutputImageType>;
-  auto                                subtractImageFilter = SubtractImageFilterType::New();
+  auto transform = itk::CenteredEuler3DTransform<double>::New();
+  auto subtractImageFilter = itk::SubtractImageFilter<OutputImageType, OutputImageType>::New();
   typename OutputImageType::IndexType indexSlice;
   typename OutputImageType::Pointer   pimg;
   indexSlice.Fill(0);
-  using PasteImageFilterType = itk::PasteImageFilter<OutputImageType, OutputImageType>;
-  auto pasteImageFilter = PasteImageFilterType::New();
+  auto pasteImageFilter = itk::PasteImageFilter<OutputImageType, OutputImageType>::New();
   pasteImageFilter->SetDestinationImage(projTotal->GetOutput());
 
   int count = 0;
@@ -193,8 +189,7 @@ main(int, char **)
   }
 
   // Streaming filter to test for unusual regions
-  using StreamingFilterType = itk::StreamingImageFilter<OutputImageType, OutputImageType>;
-  auto stream = StreamingFilterType::New();
+  auto stream = itk::StreamingImageFilter<OutputImageType, OutputImageType>::New();
   stream->SetInput(jfp->GetOutput());
 
   stream->SetNumberOfStreamDivisions(9);
@@ -222,8 +217,7 @@ main(int, char **)
   rei->SetGeometry(geometry);
   rei->Update();
 
-  using CustomBinaryFilterType = itk::BinaryGeneratorImageFilter<OutputImageType, OutputImageType, OutputImageType>;
-  auto customBinaryFilter = CustomBinaryFilterType::New();
+  auto customBinaryFilter = itk::BinaryGeneratorImageFilter<OutputImageType, OutputImageType, OutputImageType>::New();
   // Set Lambda function
   auto customLambda = [&](const typename OutputImageType::PixelType & input1,
                           const typename OutputImageType::PixelType & input2) -> typename OutputImageType::PixelType {

--- a/test/rtkforwardprojectiontest.cxx
+++ b/test/rtkforwardprojectiontest.cxx
@@ -84,19 +84,17 @@ main(int, char **)
   jfp->SetInput(1, volInput->GetOutput());
 
   // Ray Box Intersection filter (reference)
-  using RBIType = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>;
 #ifdef USE_CUDA
   jfp->SetStepSize(10);
 #endif
-  auto rbi = RBIType::New();
+  auto rbi = rtk::RayBoxIntersectionImageFilter<OutputImageType, OutputImageType>::New();
   rbi->InPlaceOff();
   rbi->SetInput(projInput->GetOutput());
   rbi->SetBoxMin(itk::MakeVector(-126.0, -126.0, -126.0));
   rbi->SetBoxMax(itk::MakeVector(126.0, 126.0, 47.6));
 
   // Streaming filter to test for unusual regions
-  using StreamingFilterType = itk::StreamingImageFilter<OutputImageType, OutputImageType>;
-  auto stream = StreamingFilterType::New();
+  auto stream = itk::StreamingImageFilter<OutputImageType, OutputImageType>::New();
   stream->SetInput(jfp->GetOutput());
 
   stream->SetNumberOfStreamDivisions(9);
@@ -155,8 +153,7 @@ main(int, char **)
   std::cout << "\n\n****** Case 3: Shepp-Logan, outer ray source ******" << std::endl;
 
   // Create Shepp Logan reference projections
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->InPlaceOff();
   slp->SetInput(projInput->GetOutput());
   slp->SetGeometry(geometry);
@@ -171,8 +168,7 @@ main(int, char **)
   volInput->SetSize(size);
   volInput->SetConstant(0.);
 
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->InPlaceOff();
   dsl->SetInput(volInput->GetOutput());
   dsl->Update();

--- a/test/rtkfourdadjointoperatorstest.cxx
+++ b/test/rtkfourdadjointoperatorstest.cxx
@@ -53,18 +53,14 @@ main(int argc, char * argv[])
 
 
   // Random image sources
-  using RandomProjectionStackSourceType = itk::RandomImageSource<ProjectionStackType>;
-  auto randomProjectionStackSource = RandomProjectionStackSourceType::New();
+  auto randomProjectionStackSource = itk::RandomImageSource<ProjectionStackType>::New();
 
-  using RandomVolumeSeriesSourceType = itk::RandomImageSource<VolumeSeriesType>;
-  auto randomVolumeSeriesSource = RandomVolumeSeriesSourceType::New();
+  auto randomVolumeSeriesSource = itk::RandomImageSource<VolumeSeriesType>::New();
 
   // Constant sources
-  using ConstantProjectionStackSourceType = rtk::ConstantImageSource<ProjectionStackType>;
-  auto constantProjectionStackSource = ConstantProjectionStackSourceType::New();
+  auto constantProjectionStackSource = rtk::ConstantImageSource<ProjectionStackType>::New();
 
-  using ConstantVolumeSeriesSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
-  auto constantVolumeSeriesSource = ConstantVolumeSeriesSourceType::New();
+  auto constantVolumeSeriesSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
 
   // Volume metadata
   auto fourDOrigin = itk::MakePoint(-127., -127., -127., 0.);
@@ -113,8 +109,7 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(constantProjectionStackSource->Update());
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -126,12 +121,9 @@ main(int argc, char * argv[])
 
   std::cout << "\n\n****** 4D to projection stack ******" << std::endl;
 
-  using JosephForwardProjectorType = rtk::JosephForwardProjectionImageFilter<ProjectionStackType, ProjectionStackType>;
-  auto jfw = JosephForwardProjectorType::New();
+  auto jfw = rtk::JosephForwardProjectionImageFilter<ProjectionStackType, ProjectionStackType>::New();
 
-  using FourDToProjectionStackFilterType =
-    rtk::FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>;
-  auto fw = FourDToProjectionStackFilterType::New();
+  auto fw = rtk::FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::New();
   fw->SetInputProjectionStack(constantProjectionStackSource->GetOutput());
   fw->SetInputVolumeSeries(randomVolumeSeriesSource->GetOutput());
   fw->SetForwardProjectionFilter(jfw.GetPointer());
@@ -142,12 +134,9 @@ main(int argc, char * argv[])
 
   std::cout << "\n\n****** Projection stack to 4D ******" << std::endl;
 
-  using JosephBackProjectorType = rtk::JosephBackProjectionImageFilter<ProjectionStackType, ProjectionStackType>;
-  auto jbp = JosephBackProjectorType::New();
+  auto jbp = rtk::JosephBackProjectionImageFilter<ProjectionStackType, ProjectionStackType>::New();
 
-  using ProjectionStackToFourDFilterType =
-    rtk::ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>;
-  auto bp = ProjectionStackToFourDFilterType::New();
+  auto bp = rtk::ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType>::New();
   bp->SetInputVolumeSeries(constantVolumeSeriesSource->GetOutput());
   bp->SetInputProjectionStack(randomProjectionStackSource->GetOutput());
   bp->SetBackProjectionFilter(jbp.GetPointer());

--- a/test/rtkfourdconjugategradienttest.cxx
+++ b/test/rtkfourdconjugategradienttest.cxx
@@ -48,7 +48,6 @@ main(int, char **)
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
-  using FourDSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
 
   auto tomographySource = ConstantImageSourceType::New();
   auto origin = itk::MakePoint(-63., -31., -63.);
@@ -64,7 +63,7 @@ main(int, char **)
   tomographySource->SetSize(size);
   tomographySource->SetConstant(0.);
 
-  auto fourdSource = FourDSourceType::New();
+  auto fourdSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
   auto fourDOrigin = itk::MakePoint(-63., -31., -63., 0.);
 #if FAST_TESTS_NO_CHECKS
   auto fourDSize = itk::MakeSize(8, 8, 8, 2);
@@ -105,9 +104,8 @@ main(int, char **)
 
   // Projections
   using REIType = rtk::RayEllipsoidIntersectionImageFilter<VolumeType, ProjectionStackType>;
-  using PasteImageFilterType = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>;
   auto destinationIndex = itk::MakeIndex(0, 0, 0);
-  auto pasteFilter = PasteImageFilterType::New();
+  auto pasteFilter = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>::New();
   pasteFilter->SetDestinationImage(projectionsSource->GetOutput());
 
 #ifdef USE_CUDA
@@ -172,8 +170,7 @@ main(int, char **)
 
   // Ground truth
   auto * Volumes = new VolumeType::Pointer[fourDSize[3]];
-  using JoinFilterType = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>;
-  auto join = JoinFilterType::New();
+  auto   join = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>::New();
 
   for (itk::SizeValueType n = 0; n < fourDSize[3]; n++)
   {

--- a/test/rtkfourdroostertest.cxx
+++ b/test/rtkfourdroostertest.cxx
@@ -52,7 +52,6 @@ main(int, char **)
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
-  using FourDSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
   auto tomographySource = ConstantImageSourceType::New();
   auto origin = itk::MakePoint(-63., -31., -63.);
 #if FAST_TESTS_NO_CHECKS
@@ -67,7 +66,7 @@ main(int, char **)
   tomographySource->SetSize(size);
   tomographySource->SetConstant(0.);
 
-  auto fourdSource = FourDSourceType::New();
+  auto fourdSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
   auto fourDOrigin = itk::MakePoint(-63., -31., -63., 0.);
 #if FAST_TESTS_NO_CHECKS
   auto fourDSize = itk::MakeSize(8, 8, 8, 2);
@@ -108,9 +107,8 @@ main(int, char **)
 
   // Projections
   using REIType = rtk::RayEllipsoidIntersectionImageFilter<VolumeType, ProjectionStackType>;
-  using PasteImageFilterType = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>;
   auto destinationIndex = itk::MakeIndex(0, 0, 0);
-  auto pasteFilter = PasteImageFilterType::New();
+  auto pasteFilter = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>::New();
   pasteFilter->SetDestinationImage(projectionsSource->GetOutput());
 
 #ifdef USE_CUDA
@@ -227,8 +225,7 @@ main(int, char **)
 
   // Ground truth
   auto * Volumes = new VolumeType::Pointer[fourDSize[3]];
-  using JoinFilterType = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>;
-  auto join = JoinFilterType::New();
+  auto   join = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>::New();
 
   for (itk::SizeValueType n = 0; n < fourDSize[3]; n++)
   {

--- a/test/rtkfourdsarttest.cxx
+++ b/test/rtkfourdsarttest.cxx
@@ -148,12 +148,11 @@ main(int, char **)
 
   // Projections
   using REIType = rtk::RayEllipsoidIntersectionImageFilter<VolumeType, ProjectionStackType>;
-  using PasteImageFilterType = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>;
   ProjectionStackType::IndexType destinationIndex;
   destinationIndex[0] = 0;
   destinationIndex[1] = 0;
   destinationIndex[2] = 0;
-  auto pasteFilter = PasteImageFilterType::New();
+  auto pasteFilter = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType, ProjectionStackType>::New();
   pasteFilter->SetDestinationImage(projectionsSource->GetOutput());
 
 #ifdef USE_CUDA
@@ -218,8 +217,7 @@ main(int, char **)
 
   // Ground truth
   auto * Volumes = new VolumeType::Pointer[fourDSize[3]];
-  using JoinFilterType = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>;
-  auto join = JoinFilterType::New();
+  auto   join = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>::New();
 
   for (itk::SizeValueType n = 0; n < fourDSize[3]; n++)
   {

--- a/test/rtkfovtest.cxx
+++ b/test/rtkfovtest.cxx
@@ -24,8 +24,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
 #else
@@ -76,29 +75,25 @@ main(int, char **)
   std::cout << "\n\n****** Case 1: centered detector ******" << std::endl;
 
   // Geometry
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600, 1200., noProj * 360. / NumberOfProjectionImages);
 
   // FOV
-  using FOVFilterType = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>;
-  auto fov = FOVFilterType::New();
+  auto fov = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>::New();
   fov->SetInput(0, fovInput->GetOutput());
   fov->SetProjectionsStack(projectionsSource->GetOutput());
   fov->SetGeometry(geometry);
   fov->Update();
 
   // Backprojection reconstruction filter
-  using BPType = rtk::BackProjectionImageFilter<OutputImageType, OutputImageType>;
-  auto bp = BPType::New();
+  auto bp = rtk::BackProjectionImageFilter<OutputImageType, OutputImageType>::New();
   bp->SetInput(0, bpInput->GetOutput());
   bp->SetInput(1, projectionsSource->GetOutput());
   bp->SetGeometry(geometry.GetPointer());
 
   // Thresholded to the number of projections
-  using ThresholdType = itk::BinaryThresholdImageFilter<OutputImageType, OutputImageType>;
-  auto threshold = ThresholdType::New();
+  auto threshold = itk::BinaryThresholdImageFilter<OutputImageType, OutputImageType>::New();
   threshold->SetInput(bp->GetOutput());
   threshold->SetOutsideValue(0.);
   threshold->SetLowerThreshold(NumberOfProjectionImages - 0.01);

--- a/test/rtkgradienttest.cxx
+++ b/test/rtkgradienttest.cxx
@@ -26,8 +26,7 @@ CheckGradient(typename TImage::Pointer im, typename TGradient::Pointer grad, con
       dimsToProcess.push_back(dim);
   }
 
-  using GradientIteratorType = itk::ImageRegionConstIterator<TGradient>;
-  GradientIteratorType itGrad(grad, grad->GetBufferedRegion());
+  itk::ImageRegionConstIterator<TGradient> itGrad(grad, grad->GetBufferedRegion());
 
   const int ImageDimension = TImage::ImageDimension;
 
@@ -102,8 +101,7 @@ main(int, char **)
 #endif
 
   // Random image sources
-  using RandomImageSourceType = itk::RandomImageSource<OutputImageType>;
-  auto randomVolumeSource = RandomImageSourceType::New();
+  auto randomVolumeSource = itk::RandomImageSource<OutputImageType>::New();
 
   // Volume metadata
   auto origin = itk::MakePoint<OutputPixelType>(-127., -127., -127.);

--- a/test/rtkhilbertfiltertest.cxx
+++ b/test/rtkhilbertfiltertest.cxx
@@ -73,8 +73,7 @@ main(int, char **)
   auto hilbert = HilbertType::New();
   hilbert->SetInput(signal);
 
-  using ZeroPadFactorsType = HilbertType::ZeroPadFactorsType;
-  ZeroPadFactorsType zeroPadFactors;
+  HilbertType::ZeroPadFactorsType zeroPadFactors;
   zeroPadFactors.Fill(1);
   hilbert->SetZeroPadFactors(zeroPadFactors);
 

--- a/test/rtkimagxtest.cxx
+++ b/test/rtkimagxtest.cxx
@@ -28,9 +28,8 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Generate projections names
   std::vector<std::string> FileNames;

--- a/test/rtkimporttest.cxx
+++ b/test/rtkimporttest.cxx
@@ -32,8 +32,7 @@ CheckError(typename TImage::Pointer     recon,
            double                       PSNRTolerance,
            double                       RefValueForPSNR)
 {
-  using ImageIteratorType = itk::ImageRegionConstIterator<TImage>;
-  ImageIteratorType itTest(recon, recon->GetBufferedRegion());
+  itk::ImageRegionConstIterator<TImage> itTest(recon, recon->GetBufferedRegion());
 
   using ErrorType = double;
   ErrorType TestError = 0.;

--- a/test/rtkinterpolatesplatadjointtest.cxx
+++ b/test/rtkinterpolatesplatadjointtest.cxx
@@ -48,18 +48,14 @@ main(int argc, char * argv[])
 
 
   // Random image sources
-  using RandomVolumeSourceType = itk::RandomImageSource<VolumeType>;
-  auto randomVolumeSource = RandomVolumeSourceType::New();
+  auto randomVolumeSource = itk::RandomImageSource<VolumeType>::New();
 
-  using RandomVolumeSeriesSourceType = itk::RandomImageSource<VolumeSeriesType>;
-  auto randomVolumeSeriesSource = RandomVolumeSeriesSourceType::New();
+  auto randomVolumeSeriesSource = itk::RandomImageSource<VolumeSeriesType>::New();
 
   // Constant sources
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<VolumeType>;
-  auto constantVolumeSource = ConstantVolumeSourceType::New();
+  auto constantVolumeSource = rtk::ConstantImageSource<VolumeType>::New();
 
-  using ConstantVolumeSeriesSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
-  auto constantVolumeSeriesSource = ConstantVolumeSeriesSourceType::New();
+  auto constantVolumeSeriesSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
 
   // Volume metadata
   auto fourDOrigin = itk::MakePoint(-127., -127., -127., 0.);
@@ -115,8 +111,7 @@ main(int argc, char * argv[])
 
   std::cout << "\n\n****** 4D to 3D (interpolation) ******" << std::endl;
 
-  using InterpolateFilterType = rtk::InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>;
-  auto interp = InterpolateFilterType::New();
+  auto interp = rtk::InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>::New();
   interp->SetInputVolume(constantVolumeSource->GetOutput());
   interp->SetInputVolumeSeries(randomVolumeSeriesSource->GetOutput());
   interp->SetWeights(phaseReader->GetOutput());
@@ -124,8 +119,7 @@ main(int argc, char * argv[])
 
   std::cout << "\n\n****** 3D to 4D (splat) ******" << std::endl;
 
-  using SplatFilterType = rtk::SplatWithKnownWeightsImageFilter<VolumeSeriesType, VolumeType>;
-  auto splat = SplatFilterType::New();
+  auto splat = rtk::SplatWithKnownWeightsImageFilter<VolumeSeriesType, VolumeType>::New();
   splat->SetInputVolumeSeries(constantVolumeSeriesSource->GetOutput());
   splat->SetInputVolume(randomVolumeSource->GetOutput());
   splat->SetWeights(phaseReader->GetOutput());

--- a/test/rtkiterativefdktest.cxx
+++ b/test/rtkiterativefdktest.cxx
@@ -76,22 +76,19 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages, 0, 0, 0, 0, 20, 15);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(slp->Update());
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
@@ -115,8 +112,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(ifdk->Update());
 
   // FOV
-  using FOVFilterType = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>;
-  auto fov = FOVFilterType::New();
+  auto fov = rtk::FieldOfViewImageFilter<OutputImageType, OutputImageType>::New();
   fov->SetInput(0, ifdk->GetOutput());
   fov->SetProjectionsStack(slp->GetOutput());
   fov->SetGeometry(geometry);

--- a/test/rtkl0gradientnormtest.cxx
+++ b/test/rtkl0gradientnormtest.cxx
@@ -182,8 +182,7 @@ main(int, char **)
   delete[] signal;
 
   // Perform regularization
-  using DenoisingFilterType = rtk::LastDimensionL0GradientDenoisingImageFilter<VolumeSeriesType>;
-  auto denoising = DenoisingFilterType::New();
+  auto denoising = rtk::LastDimensionL0GradientDenoisingImageFilter<VolumeSeriesType>::New();
   denoising->SetInput(input);
   denoising->SetLambda(0.3);
   denoising->SetNumberOfIterations(5);

--- a/test/rtklaplaciantest.cxx
+++ b/test/rtklaplaciantest.cxx
@@ -42,8 +42,7 @@ main(int argc, char * argv[])
 #endif
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto tomographySource = ConstantImageSourceType::New();
+  auto tomographySource = rtk::ConstantImageSource<OutputImageType>::New();
   auto origin = itk::MakePoint(-127., -127., -127.);
 #if FAST_TESTS_NO_CHECKS
   auto size = itk::MakeSize(2, 2, 2);
@@ -58,8 +57,7 @@ main(int argc, char * argv[])
   tomographySource->SetConstant(0.);
 
   // Generate a shepp logan phantom
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(128.);
   dsl->InPlaceOff();
@@ -67,8 +65,7 @@ main(int argc, char * argv[])
 
 
   // Read a reference image
-  using ReaderType = itk::ImageFileReader<OutputImageType>;
-  auto readerRef = ReaderType::New();
+  auto readerRef = itk::ImageFileReader<OutputImageType>::New();
   readerRef->SetFileName(argv[1]);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(readerRef->Update());
 
@@ -76,8 +73,7 @@ main(int argc, char * argv[])
   std::cout << "\n\n****** Case 1: CPU laplacian ******" << std::endl;
 
   // Create and set the laplacian filter
-  using LaplacianFilterType = rtk::LaplacianImageFilter<OutputImageType, GradientImageType>;
-  auto laplacian = LaplacianFilterType::New();
+  auto laplacian = rtk::LaplacianImageFilter<OutputImageType, GradientImageType>::New();
   laplacian->SetInput(dsl->GetOutput());
 
   // Compute the laplacian of the shepp logan

--- a/test/rtklutbasedvarI0rawtoatttest.cxx
+++ b/test/rtklutbasedvarI0rawtoatttest.cxx
@@ -12,7 +12,6 @@
  */
 
 using ShortImageType = itk::Image<unsigned short, 2>;
-using FloatImageType = itk::Image<float, 2>;
 
 void
 fillImageWithRawData(ShortImageType::Pointer image, unsigned short I0)
@@ -32,8 +31,7 @@ fillImageWithRawData(ShortImageType::Pointer image, unsigned short I0)
 int
 main(int, char **)
 {
-  using ConvertFilterType = rtk::LUTbasedVariableI0RawToAttenuationImageFilter<ShortImageType, FloatImageType>;
-  auto convert = ConvertFilterType::New();
+  auto convert = rtk::LUTbasedVariableI0RawToAttenuationImageFilter<ShortImageType, itk::Image<float, 2>>::New();
 
   // Constant image sources
   ShortImageType::RegionType region;

--- a/test/rtkluttest.cxx
+++ b/test/rtkluttest.cxx
@@ -28,8 +28,7 @@ main(int argc, char * argv[])
 
   // Elekta projections reader
   using ShortImageType = itk::Image<unsigned short, 3>;
-  using ReaderType = rtk::ProjectionsReader<ShortImageType>;
-  auto                     r = ReaderType::New();
+  auto                     r = rtk::ProjectionsReader<ShortImageType>::New();
   std::vector<std::string> fileNames;
   fileNames.emplace_back(argv[1]);
   r->SetFileNames(fileNames);
@@ -42,19 +41,15 @@ main(int argc, char * argv[])
   sflut->SetInput(r->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(sflut->Update());
 
-  using FloatCastType = itk::CastImageFilter<ShortImageType, FloatImageType>;
-  auto fCast = FloatCastType::New();
+  auto fCast = itk::CastImageFilter<ShortImageType, FloatImageType>::New();
   fCast->SetInput(r->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(fCast->Update());
 
-  using FloatLUTType = itk::Image<float, 1>;
-  using FloatLUTCastType = itk::CastImageFilter<ShortFloatLUTType::LookupTableType, FloatLUTType>;
-  auto flCast = FloatLUTCastType::New();
+  auto flCast = itk::CastImageFilter<ShortFloatLUTType::LookupTableType, itk::Image<float, 1>>::New();
   flCast->SetInput(sflut->GetLookupTable());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(flCast->Update());
 
-  using FloatLUTTypea = rtk::LookupTableImageFilter<FloatImageType, FloatImageType>;
-  auto flut = FloatLUTTypea::New();
+  auto flut = rtk::LookupTableImageFilter<FloatImageType, FloatImageType>::New();
   flut->SetInput(fCast->GetOutput());
   flut->SetLookupTable(flCast->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(flut->Update());
@@ -68,19 +63,15 @@ main(int argc, char * argv[])
   sdlut->SetInput(r->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(sdlut->Update());
 
-  using DoubleCastType = itk::CastImageFilter<ShortImageType, DoubleImageType>;
-  auto dCast = DoubleCastType::New();
+  auto dCast = itk::CastImageFilter<ShortImageType, DoubleImageType>::New();
   dCast->SetInput(r->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dCast->Update());
 
-  using DoubleLUTType = itk::Image<float, 1>;
-  using DoubleLUTCastType = itk::CastImageFilter<ShortDoubleLUTType::LookupTableType, DoubleLUTType>;
-  auto dlCast = DoubleLUTCastType::New();
+  auto dlCast = itk::CastImageFilter<ShortDoubleLUTType::LookupTableType, itk::Image<float, 1>>::New();
   dlCast->SetInput(sdlut->GetLookupTable());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dlCast->Update());
 
-  using DoubleLUTTypea = rtk::LookupTableImageFilter<DoubleImageType, DoubleImageType>;
-  auto dlut = DoubleLUTTypea::New();
+  auto dlut = rtk::LookupTableImageFilter<DoubleImageType, DoubleImageType>::New();
   dlut->SetInput(dCast->GetOutput());
   dlut->SetLookupTable(dlCast->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dlut->Update());

--- a/test/rtkmaximumintensityprojectiontest.cxx
+++ b/test/rtkmaximumintensityprojectiontest.cxx
@@ -55,20 +55,17 @@ main(int, char **)
   projInput->Update();
 
   // MIP Forward Projection filter
-  using MIPType = rtk::MaximumIntensityProjectionImageFilter<OutputImageType, OutputImageType>;
-  auto mipfp = MIPType::New();
+  auto mipfp = rtk::MaximumIntensityProjectionImageFilter<OutputImageType, OutputImageType>::New();
   mipfp->SetInput(projInput->GetOutput());
   mipfp->SetInput(1, volInput->GetOutput());
 
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   geometry->AddProjection(700, 800, 0);
 
   mipfp->SetGeometry(geometry);
   mipfp->Update();
 
-  using ConstIteratorType = itk::ImageRegionConstIterator<OutputImageType>;
-  ConstIteratorType inputIt(mipfp->GetOutput(), mipfp->GetOutput()->GetRequestedRegion());
+  itk::ImageRegionConstIterator<OutputImageType> inputIt(mipfp->GetOutput(), mipfp->GetOutput()->GetRequestedRegion());
 
   inputIt.GoToBegin();
 

--- a/test/rtknewtonupdatetest.cxx
+++ b/test/rtknewtonupdatetest.cxx
@@ -33,24 +33,20 @@ main(int argc, char * argv[])
   using THessian = itk::Image<itk::Vector<dataType, nMaterials * nMaterials>, 3>;
 
   // Define, instantiate, set and update readers
-  using GradientReaderType = itk::ImageFileReader<TGradient>;
-  auto gradientReader = GradientReaderType::New();
+  auto gradientReader = itk::ImageFileReader<TGradient>::New();
   gradientReader->SetFileName(argv[1]);
   gradientReader->Update();
 
-  using HessianReaderType = itk::ImageFileReader<THessian>;
-  auto hessianReader = HessianReaderType::New();
+  auto hessianReader = itk::ImageFileReader<THessian>::New();
   hessianReader->SetFileName(argv[2]);
   hessianReader->Update();
 
-  using OutputReaderType = itk::ImageFileReader<TGradient>;
-  auto outputReader = OutputReaderType::New();
+  auto outputReader = itk::ImageFileReader<TGradient>::New();
   outputReader->SetFileName(argv[3]);
   outputReader->Update();
 
   // Create the filter
-  using NewtonUpdateFilterType = rtk::GetNewtonUpdateImageFilter<TGradient, THessian>;
-  auto newtonUpdate = NewtonUpdateFilterType::New();
+  auto newtonUpdate = rtk::GetNewtonUpdateImageFilter<TGradient, THessian>::New();
 
   // Set its inputs
   newtonUpdate->SetInputGradient(gradientReader->GetOutput());

--- a/test/rtkoratest.cxx
+++ b/test/rtkoratest.cxx
@@ -90,9 +90,8 @@ main(int argc, char * argv[])
   // ******* COMPARING projections *******
   std::cout << "Testing attenuation conversion..." << std::endl;
 
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;
@@ -109,8 +108,7 @@ main(int argc, char * argv[])
   reader->SetDirection(direction);
 
   // Create projection image filter
-  using OFMType = rtk::MaskCollimationImageFilter<ImageType, ImageType>;
-  auto ofm = OFMType::New();
+  auto ofm = rtk::MaskCollimationImageFilter<ImageType, ImageType>::New();
   ofm->SetInput(reader->GetOutput());
   ofm->SetGeometry(geoTargReader->GetModifiableGeometry());
 

--- a/test/rtkosemtest.cxx
+++ b/test/rtkosemtest.cxx
@@ -85,8 +85,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -109,15 +108,13 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetAxis(semiprincipalaxis);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update());
 
   // Create attenuation map according to the reference object
-  using MaskFilterType = itk::MaskImageFilter<OutputImageType, OutputImageType>;
-  auto maskFilter = MaskFilterType::New();
+  auto maskFilter = itk::MaskImageFilter<OutputImageType, OutputImageType>::New();
   maskFilter->SetInput(attenuationInput->GetOutput());
   maskFilter->SetMaskImage(dsl->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(maskFilter->Update());
@@ -177,8 +174,7 @@ main(int, char **)
   std::cout << "\n\nTest PASSED! " << std::endl;
 #endif
 
-  using ImageIterator = itk::ImageRegionIterator<OutputImageType>;
-  ImageIterator itRei(rei->GetOutput(), rei->GetOutput()->GetBufferedRegion());
+  itk::ImageRegionIterator<OutputImageType> itRei(rei->GetOutput(), rei->GetOutput()->GetBufferedRegion());
 
   itRei.GoToBegin();
 

--- a/test/rtkprojectgeometricphantomtest.cxx
+++ b/test/rtkprojectgeometricphantomtest.cxx
@@ -32,8 +32,7 @@ main(int argc, char * argv[])
   }
 
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
 #else
@@ -42,8 +41,7 @@ main(int argc, char * argv[])
   using GeometryType = rtk::ThreeDCircularProjectionGeometry;
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto projectionsSource = ConstantImageSourceType::New();
+  auto projectionsSource = rtk::ConstantImageSource<OutputImageType>::New();
   auto origin = itk::MakePoint(-254., -254., -254.);
 #if FAST_TESTS_NO_CHECKS
   auto size = itk::MakeSize(2, 2, NumberOfProjectionImages);
@@ -64,15 +62,13 @@ main(int argc, char * argv[])
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(slp->Update());
 
   // Shepp Logan projections filter from Configuration File
-  using PGPType = rtk::ProjectGeometricPhantomImageFilter<OutputImageType, OutputImageType>;
-  auto pgp = PGPType::New();
+  auto pgp = rtk::ProjectGeometricPhantomImageFilter<OutputImageType, OutputImageType>::New();
   pgp->SetInput(projectionsSource->GetOutput());
   pgp->SetGeometry(geometry);
   pgp->SetConfigFile(argv[1]);

--- a/test/rtkrampfiltertest.cxx
+++ b/test/rtkrampfiltertest.cxx
@@ -75,29 +75,25 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
 
   std::cout << "\n\n****** Test 1: add noise and test Hann window ******" << std::endl;
 
   // Add noise
-  using NIFType = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>;
-  auto noisy = NIFType::New();
+  auto noisy = rtk::AdditiveGaussianNoiseImageFilter<OutputImageType>::New();
   noisy->SetInput(slp->GetOutput());
   noisy->SetMean(0.0);
   noisy->SetStandardDeviation(1.);
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update());
 

--- a/test/rtkregularizedconjugategradienttest.cxx
+++ b/test/rtkregularizedconjugategradienttest.cxx
@@ -72,8 +72,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -93,8 +92,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 
@@ -172,8 +170,7 @@ main(int, char **)
   dsl->SetAxis(itk::MakeVector(9., 9., 9.));
 
   // Add gaussian noise on the projections
-  using GaussianNoiseFilterType = itk::AdditiveGaussianNoiseImageFilter<OutputImageType>;
-  auto gaussian = GaussianNoiseFilterType::New();
+  auto gaussian = itk::AdditiveGaussianNoiseImageFilter<OutputImageType>::New();
   gaussian->SetStandardDeviation(1);
   gaussian->SetMean(0.);
   gaussian->SetInput(rei->GetOutput());

--- a/test/rtksarttest.cxx
+++ b/test/rtksarttest.cxx
@@ -72,8 +72,7 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * 360. / NumberOfProjectionImages);
 
@@ -94,8 +93,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(rei->Update());
 
   // Create REFERENCE object (3D ellipsoid).
-  using DEType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto dsl = DEType::New();
+  auto dsl = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 

--- a/test/rtkselectoneprojpercycletest.cxx
+++ b/test/rtkselectoneprojpercycletest.cxx
@@ -21,8 +21,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
   constexpr unsigned int NumberOfProjectionImages = 24;
 
   // Constant image sources
@@ -56,11 +55,10 @@ main(int, char **)
 
   // Projections
   using REIType = rtk::RayEllipsoidIntersectionImageFilter<OutputImageType, OutputImageType>;
-  using PasteImageFilterType = itk::PasteImageFilter<OutputImageType, OutputImageType, OutputImageType>;
   OutputImageType::IndexType destinationIndex, destinationIndexRef;
   destinationIndex.Fill(0);
   destinationIndexRef.Fill(0);
-  auto pasteFilter = PasteImageFilterType::New();
+  auto pasteFilter = itk::PasteImageFilter<OutputImageType, OutputImageType, OutputImageType>::New();
 
   std::string              signalFileName = "signal_SelectOneProjPerCycle.txt";
   std::ofstream            signalFile(signalFileName.c_str());
@@ -132,8 +130,7 @@ main(int, char **)
   signalFile.close();
 
   // Select
-  using SelectionType = rtk::SelectOneProjectionPerCycleImageFilter<OutputImageType>;
-  auto select = SelectionType::New();
+  auto select = rtk::SelectOneProjectionPerCycleImageFilter<OutputImageType>::New();
   select->SetInput(wholeImage);
   select->SetInputGeometry(geometry);
   select->SetPhase(0.4);

--- a/test/rtkshortscancompcudatest.cxx
+++ b/test/rtkshortscancompcudatest.cxx
@@ -22,13 +22,11 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::CudaImage<OutputPixelType, Dimension>;
+  using OutputImageType = itk::CudaImage<float, Dimension>;
 
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto projSource = ConstantImageSourceType::New();
+  auto projSource = rtk::ConstantImageSource<OutputImageType>::New();
   auto origin = itk::MakePoint(-127., -3., 0.);
   auto size = itk::MakeSize(128, 4, 4);
   auto spacing = itk::MakeVector(2., 2., 2.);
@@ -38,16 +36,14 @@ main(int, char **)
   projSource->SetSize(size);
 
   // Geometry
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   geometry->AddProjection(600., 700., 0., 84., 35, 23, 15, 21, 26);
   geometry->AddProjection(500., 800., 45., 21., 12, 16, 546, 14, 41);
   geometry->AddProjection(700., 900., 90., 68., 68, 54, 38, 35, 56);
   geometry->AddProjection(900., 1000., 135., 48., 35, 84, 10, 84, 59);
 
   // Projections
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);

--- a/test/rtkshortscantest.cxx
+++ b/test/rtkshortscantest.cxx
@@ -73,14 +73,12 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 1200., noProj * ArcSize / NumberOfProjectionImages);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(116);
@@ -99,15 +97,13 @@ main(int, char **)
   pssf->Update();
 
   // Create a reference object (in this case a 3D phantom reference).
-  using DSLType = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>;
-  auto dsl = DSLType::New();
+  auto dsl = rtk::DrawSheppLoganFilter<OutputImageType, OutputImageType>::New();
   dsl->SetInput(tomographySource->GetOutput());
   dsl->SetPhantomScale(116);
   TRY_AND_EXIT_ON_ITK_EXCEPTION(dsl->Update())
 
   // FDK reconstruction filtering
-  using FDKCPUType = rtk::FDKConeBeamReconstructionFilter<OutputImageType>;
-  auto feldkamp = FDKCPUType::New();
+  auto feldkamp = rtk::FDKConeBeamReconstructionFilter<OutputImageType>::New();
   feldkamp->SetInput(0, tomographySource->GetOutput());
   feldkamp->SetInput(1, pssf->GetOutput());
   feldkamp->SetGeometry(geometry);

--- a/test/rtktotalvariationtest.cxx
+++ b/test/rtktotalvariationtest.cxx
@@ -9,8 +9,7 @@ template <class TImage>
 void
 CheckTotalVariation(typename TImage::Pointer before, typename TImage::Pointer after)
 {
-  using TotalVariationFilterType = rtk::TotalVariationImageFilter<TImage>;
-  auto tv = TotalVariationFilterType::New();
+  auto tv = rtk::TotalVariationImageFilter<TImage>::New();
 
   double totalVariationBefore = NAN;
   double totalVariationAfter = NAN;
@@ -64,8 +63,7 @@ main(int, char **)
 #endif
 
   // Random image sources
-  using RandomImageSourceType = itk::RandomImageSource<OutputImageType>;
-  auto randomVolumeSource = RandomImageSourceType::New();
+  auto randomVolumeSource = itk::RandomImageSource<OutputImageType>::New();
 
   // Volume metadata
   auto origin = itk::MakePoint(0., 0., 0.);
@@ -87,8 +85,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(randomVolumeSource->Update());
 
   // Create and set the TV denoising filter
-  using TVDenoisingFilterType = rtk::TotalVariationDenoisingBPDQImageFilter<OutputImageType, GradientOutputImageType>;
-  auto TVdenoising = TVDenoisingFilterType::New();
+  auto TVdenoising = rtk::TotalVariationDenoisingBPDQImageFilter<OutputImageType, GradientOutputImageType>::New();
   TVdenoising->SetInput(randomVolumeSource->GetOutput());
   TVdenoising->SetNumberOfIterations(100);
   TVdenoising->SetGamma(0.3);

--- a/test/rtkvariancereconstructiontest.cxx
+++ b/test/rtkvariancereconstructiontest.cxx
@@ -28,8 +28,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
   constexpr double hann = 1.0;
 #if FAST_TESTS_NO_CHECKS
   constexpr unsigned int NumberOfProjectionImages = 3;
@@ -70,14 +69,12 @@ main(int, char **)
   projectionsSource->SetConstant(0.);
 
   // Geometry object
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int noProj = 0; noProj < NumberOfProjectionImages; noProj++)
     geometry->AddProjection(600., 0., noProj * 360. / NumberOfProjectionImages);
 
   // Shepp Logan projections filter
-  using SLPType = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>;
-  auto slp = SLPType::New();
+  auto slp = rtk::SheppLoganPhantomFilter<OutputImageType, OutputImageType>::New();
   slp->SetInput(projectionsSource->GetOutput());
   slp->SetGeometry(geometry);
   slp->SetPhantomScale(8.);
@@ -86,8 +83,7 @@ main(int, char **)
   std::cout << "\n\n****** Test : Create a set of noisy projections ******" << std::endl;
 
   // Add noise
-  using NIFType = itk::ShotNoiseImageFilter<OutputImageType>;
-  auto noisy = NIFType::New();
+  auto noisy = itk::ShotNoiseImageFilter<OutputImageType>::New();
   noisy->SetInput(slp->GetOutput());
 
   using AddType = itk::AddImageFilter<OutputImageType, OutputImageType>;
@@ -97,8 +93,7 @@ main(int, char **)
   OutputImageType::Pointer currentSum = tomographySource->GetOutput();
   currentSum->DisconnectPipeline();
 
-  using SquareType = itk::SquareImageFilter<OutputImageType, OutputImageType>;
-  auto square = SquareType::New();
+  auto square = itk::SquareImageFilter<OutputImageType, OutputImageType>::New();
   auto addSquare = AddType::New();
   addSquare->SetInput(1, square->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(tomographySource->Update());
@@ -106,8 +101,7 @@ main(int, char **)
   currentSumOfSquares->DisconnectPipeline();
 
   // FDK reconstruction
-  using FDKType = rtk::FDKConeBeamReconstructionFilter<OutputImageType>;
-  auto feldkamp = FDKType::New();
+  auto feldkamp = rtk::FDKConeBeamReconstructionFilter<OutputImageType>::New();
   TRY_AND_EXIT_ON_ITK_EXCEPTION(tomographySource->Update());
   feldkamp->SetInput(0, tomographySource->GetOutput());
   feldkamp->SetInput(1, noisy->GetOutput());
@@ -135,8 +129,7 @@ main(int, char **)
     currentSumOfSquares->DisconnectPipeline();
   }
 
-  using MultiplyType = itk::MultiplyImageFilter<OutputImageType, OutputImageType>;
-  auto multiply = MultiplyType::New();
+  auto multiply = itk::MultiplyImageFilter<OutputImageType, OutputImageType>::New();
   multiply->SetInput(0, currentSumOfSquares);
   multiply->SetConstant((float)(1. / NumberOfSamples));
   TRY_AND_EXIT_ON_ITK_EXCEPTION(multiply->Update());
@@ -151,8 +144,7 @@ main(int, char **)
   addSquare->SetInput(1, multiply->GetOutput());
   TRY_AND_EXIT_ON_ITK_EXCEPTION(addSquare->Update());
 
-  using VarianceType = rtk::FDKVarianceReconstructionFilter<OutputImageType, OutputImageType>;
-  auto variance = VarianceType::New();
+  auto variance = rtk::FDKVarianceReconstructionFilter<OutputImageType, OutputImageType>::New();
   variance->SetGeometry(geometry);
   variance->SetInput(0, tomographySource->GetOutput());
   variance->SetInput(1, slp->GetOutput());

--- a/test/rtkvariantest.cxx
+++ b/test/rtkvariantest.cxx
@@ -55,9 +55,8 @@ main(int argc, char * argv[])
   CheckGeometries(geoTargReader->GetGeometry(), geoRefReader->GetOutputObject());
 
   // ******* COMPARING projections *******
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Varian projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;

--- a/test/rtkvectorimageconverterstest.cxx
+++ b/test/rtkvectorimageconverterstest.cxx
@@ -58,8 +58,7 @@ main(int, char **)
   }
 
   // Create the filter to convert it to a vector image
-  using HigherDimensionToVectorType = rtk::ImageToVectorImageFilter<HigherDimensionImageType, VectorImageType>;
-  auto higherDimensionToVector = HigherDimensionToVectorType::New();
+  auto higherDimensionToVector = rtk::ImageToVectorImageFilter<HigherDimensionImageType, VectorImageType>::New();
   higherDimensionToVector->SetInput(higherDimensionInput);
 
   // Perform conversion
@@ -102,8 +101,7 @@ main(int, char **)
     higherDimensionToVector->GetOutput(), refVectorImage, 1e-7, 100, 2.0);
 
   // Create the filter to convert the result back to an image
-  using VectorToHigherDimensionType = rtk::VectorImageToImageFilter<VectorImageType, HigherDimensionImageType>;
-  auto vectorToHigherDimension = VectorToHigherDimensionType::New();
+  auto vectorToHigherDimension = rtk::VectorImageToImageFilter<VectorImageType, HigherDimensionImageType>::New();
   vectorToHigherDimension->SetInput(higherDimensionToVector->GetOutput());
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(vectorToHigherDimension->Update());
@@ -141,8 +139,7 @@ main(int, char **)
   }
 
   // Create the filter to convert it to a vector image
-  using ToVectorType = rtk::ImageToVectorImageFilter<ImageType, VectorImageType>;
-  auto imageToVector = ToVectorType::New();
+  auto imageToVector = rtk::ImageToVectorImageFilter<ImageType, VectorImageType>::New();
   imageToVector->SetInput(input);
   imageToVector->SetNumberOfChannels(8);
 
@@ -153,8 +150,7 @@ main(int, char **)
   CheckVariableLengthVectorImageQuality<VectorImageType>(imageToVector->GetOutput(), refVectorImage, 1e-7, 100, 2.0);
 
   // Create the filter to convert the result back to an image
-  using VectorToType = rtk::VectorImageToImageFilter<VectorImageType, ImageType>;
-  auto vectorToImage = VectorToType::New();
+  auto vectorToImage = rtk::VectorImageToImageFilter<VectorImageType, ImageType>::New();
   vectorToImage->SetInput(imageToVector->GetOutput());
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(vectorToImage->Update());

--- a/test/rtkwarpfourdtoprojectionstacktest.cxx
+++ b/test/rtkwarpfourdtoprojectionstacktest.cxx
@@ -52,7 +52,6 @@ main(int, char **)
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
-  using FourDSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
 
   auto tomographySource = ConstantImageSourceType::New();
   auto origin = itk::MakePoint(-63.0, -31.0, -63.0);
@@ -68,7 +67,7 @@ main(int, char **)
   tomographySource->SetSize(size);
   tomographySource->SetConstant(0.);
 
-  auto fourdSource = FourDSourceType::New();
+  auto fourdSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
   auto fourDOrigin = itk::MakePoint(-63.0, -31.5, -63.0, 0.0);
 #if FAST_TESTS_NO_CHECKS
   auto fourDSize = itk::MakeSize(8, 8, 8, 2);
@@ -254,8 +253,7 @@ main(int, char **)
 
   // Input 4D volume sequence
   auto * Volumes = new VolumeType::Pointer[fourDSize[3]];
-  using JoinFilterType = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>;
-  auto join = JoinFilterType::New();
+  auto   join = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>::New();
 
   for (itk::SizeValueType n = 0; n < fourDSize[3]; n++)
   {
@@ -304,8 +302,7 @@ main(int, char **)
   phaseReader->Update();
 
   // Create and set the warped forward projection filter
-  using WarpFourDToProjectionStackType = rtk::WarpFourDToProjectionStackImageFilter<VolumeSeriesType, VolumeType>;
-  auto warpforwardproject = WarpFourDToProjectionStackType::New();
+  auto warpforwardproject = rtk::WarpFourDToProjectionStackImageFilter<VolumeSeriesType, VolumeType>::New();
   warpforwardproject->SetInputVolumeSeries(join->GetOutput());
   warpforwardproject->SetInputProjectionStack(pasteFilter->GetOutput());
   warpforwardproject->SetGeometry(geometry);

--- a/test/rtkwarpprojectionstacktofourdtest.cxx
+++ b/test/rtkwarpprojectionstacktofourdtest.cxx
@@ -53,7 +53,6 @@ main(int, char **)
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
-  using FourDSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
 
   auto tomographySource = ConstantImageSourceType::New();
   auto origin = itk::MakePoint(-63., -31., -63.);
@@ -69,7 +68,7 @@ main(int, char **)
   tomographySource->SetSize(size);
   tomographySource->SetConstant(0.);
 
-  auto fourdSource = FourDSourceType::New();
+  auto fourdSource = rtk::ConstantImageSource<VolumeSeriesType>::New();
   auto fourDOrigin = itk::MakePoint(-63., -31.5, -63., 0.);
 #if FAST_TESTS_NO_CHECKS
   auto fourDSize = itk::MakeSize(8, 8, 8, 2);
@@ -255,8 +254,7 @@ main(int, char **)
     }
 
     // Input 4D volume sequence
-    using JoinFilterType = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>;
-    auto join = JoinFilterType::New();
+    auto join = itk::JoinSeriesImageFilter<VolumeType, VolumeSeriesType>::New();
 
     // Read the phases file
     auto phaseReader = rtk::PhasesToInterpolationWeights::New();
@@ -265,8 +263,7 @@ main(int, char **)
     phaseReader->Update();
 
     // The CPU voxel-based static 3D back projection used as a reference for comparison
-    using StaticBackProjectionFilterType = rtk::BackProjectionImageFilter<VolumeType, VolumeType>;
-    auto backprojection = StaticBackProjectionFilterType::New();
+    auto backprojection = rtk::BackProjectionImageFilter<VolumeType, VolumeType>::New();
     backprojection->SetInput(0, tomographySource->GetOutput());
     backprojection->SetInput(1, pasteFilterStaticProjections->GetOutput());
     backprojection->SetGeometry(geometry.GetPointer());
@@ -274,8 +271,7 @@ main(int, char **)
 
     // Divide the result by the number of volumes in the 4D sequence,
     // for the attenuation results to approximately match
-    using DivideFilterType = itk::DivideImageFilter<VolumeType, VolumeType, VolumeType>;
-    auto divide = DivideFilterType::New();
+    auto divide = itk::DivideImageFilter<VolumeType, VolumeType, VolumeType>::New();
     divide->SetInput1(backprojection->GetOutput());
     divide->SetConstant2(fourDSize[3]);
     divide->Update();
@@ -287,8 +283,7 @@ main(int, char **)
     join->Update();
 
     // Create and set the warped forward projection filter
-    using WarpProjectionStackToFourDType = rtk::WarpProjectionStackToFourDImageFilter<VolumeSeriesType, VolumeType>;
-    auto warpbackproject = WarpProjectionStackToFourDType::New();
+    auto warpbackproject = rtk::WarpProjectionStackToFourDImageFilter<VolumeSeriesType, VolumeType>::New();
     warpbackproject->SetInputVolumeSeries(fourdSource->GetOutput());
     warpbackproject->SetInputProjectionStack(pasteFilter->GetOutput());
     warpbackproject->SetGeometry(geometry);

--- a/test/rtkwarptest.cxx
+++ b/test/rtkwarptest.cxx
@@ -28,12 +28,10 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 3;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Constant image sources
-  using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;
-  auto tomographySource = ConstantImageSourceType::New();
+  auto tomographySource = rtk::ConstantImageSource<OutputImageType>::New();
   auto origin = itk::MakePoint(-63., -31., -63.);
 #if FAST_TESTS_NO_CHECKS
   auto size = itk::MakeSize(32, 32, 32);
@@ -50,7 +48,6 @@ main(int, char **)
   // Create vector field
   using DVFPixelType = itk::Vector<float, 3>;
   using DVFImageType = itk::Image<DVFPixelType, 3>;
-  using IteratorType = itk::ImageRegionIteratorWithIndex<DVFImageType>;
 
   auto deformationField = DVFImageType::New();
 
@@ -68,7 +65,7 @@ main(int, char **)
   // Vector Field initilization
   DVFPixelType vec;
   vec.Fill(0.);
-  IteratorType defIt(deformationField, deformationField->GetLargestPossibleRegion());
+  itk::ImageRegionIteratorWithIndex<DVFImageType> defIt(deformationField, deformationField->GetLargestPossibleRegion());
   for (defIt.GoToBegin(); !defIt.IsAtEnd(); ++defIt)
   {
     vec.Fill(0.);
@@ -106,16 +103,14 @@ main(int, char **)
   e2->InPlaceOff();
   TRY_AND_EXIT_ON_ITK_EXCEPTION(e2->Update())
 
-  using WarpFilterType = itk::WarpImageFilter<OutputImageType, OutputImageType, DVFImageType>;
-  auto warp = WarpFilterType::New();
+  auto warp = itk::WarpImageFilter<OutputImageType, OutputImageType, DVFImageType>::New();
   warp->SetInput(e2->GetOutput());
   warp->SetDisplacementField(deformationField);
   warp->SetOutputParametersFromImage(e2->GetOutput());
 
   TRY_AND_EXIT_ON_ITK_EXCEPTION(warp->Update());
 
-  using ForwardWarpFilterType = rtk::ForwardWarpImageFilter<OutputImageType, OutputImageType, DVFImageType>;
-  auto forwardWarp = ForwardWarpFilterType::New();
+  auto forwardWarp = rtk::ForwardWarpImageFilter<OutputImageType, OutputImageType, DVFImageType>::New();
   forwardWarp->SetInput(warp->GetOutput());
   forwardWarp->SetDisplacementField(deformationField);
   forwardWarp->SetOutputParametersFromImage(warp->GetOutput());

--- a/test/rtkwaterprecorrectiontest.cxx
+++ b/test/rtkwaterprecorrectiontest.cxx
@@ -15,8 +15,7 @@ int
 main(int, char **)
 {
   constexpr unsigned int Dimension = 2;
-  using OutputPixelType = float;
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
 
   // Constant image sources
   using ConstantImageSourceType = rtk::ConstantImageSource<OutputImageType>;

--- a/test/rtkwaveletstest.cxx
+++ b/test/rtkwaveletstest.cxx
@@ -75,13 +75,11 @@ CheckImageQuality(typename TImage::Pointer recon, typename TImage::Pointer ref)
 int
 main(int, char **)
 {
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using OutputImageType = itk::Image<float, Dimension>;
   // Random image sources
-  using RandomImageSourceType = itk::RandomImageSource<OutputImageType>;
-  auto randomVolumeSource = RandomImageSourceType::New();
+  auto randomVolumeSource = itk::RandomImageSource<OutputImageType>::New();
 
   // Volume metadata
   auto origin = itk::MakePoint(0., 0., 0.);
@@ -104,8 +102,7 @@ main(int, char **)
   TRY_AND_EXIT_ON_ITK_EXCEPTION(randomVolumeSource->Update());
 
   // Wavelets deconstruction and reconstruction
-  using DeconstructReconstructFilterType = rtk::DeconstructSoftThresholdReconstructImageFilter<OutputImageType>;
-  auto wavelets = DeconstructReconstructFilterType::New();
+  auto wavelets = rtk::DeconstructSoftThresholdReconstructImageFilter<OutputImageType>::New();
   wavelets->SetInput(randomVolumeSource->GetOutput());
   wavelets->SetNumberOfLevels(3);
   wavelets->SetOrder(3);

--- a/test/rtkweidingerforwardmodeltest.cxx
+++ b/test/rtkweidingerforwardmodeltest.cxx
@@ -47,39 +47,32 @@ main(int argc, char * argv[])
   vnl_matrix<dataType> materialAttenuations(nEnergies, nMaterials);
 
   // Define, instantiate, set and update readers
-  using DecomposedProjectionsReaderType = itk::ImageFileReader<TDecomposedProjections>;
-  auto decomposedProjectionsReader = DecomposedProjectionsReaderType::New();
+  auto decomposedProjectionsReader = itk::ImageFileReader<TDecomposedProjections>::New();
   decomposedProjectionsReader->SetFileName(argv[1]);
   decomposedProjectionsReader->Update();
 
-  using MeasuredProjectionsReaderType = itk::ImageFileReader<TMeasuredProjections>;
-  auto measuredProjectionsReader = MeasuredProjectionsReaderType::New();
+  auto measuredProjectionsReader = itk::ImageFileReader<TMeasuredProjections>::New();
   measuredProjectionsReader->SetFileName(argv[2]);
   measuredProjectionsReader->Update();
 
-  using IncidentSpectrumReaderType = itk::ImageFileReader<TIncidentSpectrum>;
-  auto incidentSpectrumReader = IncidentSpectrumReaderType::New();
+  auto incidentSpectrumReader = itk::ImageFileReader<TIncidentSpectrum>::New();
   incidentSpectrumReader->SetFileName(argv[3]);
   incidentSpectrumReader->Update();
 
-  using ProjectionsReaderType = itk::ImageFileReader<TProjections>;
-  auto projectionsReader = ProjectionsReaderType::New();
+  auto projectionsReader = itk::ImageFileReader<TProjections>::New();
   projectionsReader->SetFileName(argv[4]);
   projectionsReader->Update();
 
-  using Output1ReaderType = itk::ImageFileReader<TOutput1>;
-  auto output1Reader = Output1ReaderType::New();
+  auto output1Reader = itk::ImageFileReader<TOutput1>::New();
   output1Reader->SetFileName(argv[7]);
   output1Reader->Update();
 
-  using Output2ReaderType = itk::ImageFileReader<TOutput2>;
-  auto output2Reader = Output2ReaderType::New();
+  auto output2Reader = itk::ImageFileReader<TOutput2>::New();
   output2Reader->SetFileName(argv[8]);
   output2Reader->Update();
 
   // Read binned detector response
-  using CSVReaderType = itk::CSVArray2DFileReader<dataType>;
-  auto csvReader = CSVReaderType::New();
+  auto csvReader = itk::CSVArray2DFileReader<dataType>::New();
   csvReader->SetFieldDelimiterCharacter(',');
   csvReader->HasColumnHeadersOff();
   csvReader->HasRowHeadersOff();
@@ -100,9 +93,10 @@ main(int argc, char * argv[])
       materialAttenuations[r][c] = csvReader->GetOutput()->GetData(r, c);
 
   // Create the filter
-  using WeidingerForwardModelType = rtk::
-    WeidingerForwardModelImageFilter<TDecomposedProjections, TMeasuredProjections, TIncidentSpectrum, TProjections>;
-  auto weidingerForward = WeidingerForwardModelType::New();
+  auto weidingerForward = rtk::WeidingerForwardModelImageFilter<TDecomposedProjections,
+                                                                TMeasuredProjections,
+                                                                TIncidentSpectrum,
+                                                                TProjections>::New();
 
   // Set its inputs
   weidingerForward->SetInputDecomposedProjections(decomposedProjectionsReader->GetOutput());

--- a/test/rtkxradtest.cxx
+++ b/test/rtkxradtest.cxx
@@ -45,9 +45,8 @@ main(int argc, char * argv[])
   CheckGeometries(geoTargReader->GetGeometry(), geoRefReader->GetOutputObject());
 
   // ******* COMPARING projections *******
-  using OutputPixelType = float;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image<OutputPixelType, Dimension>;
+  using ImageType = itk::Image<float, Dimension>;
 
   // Elekta projections reader
   using ReaderType = rtk::ProjectionsReader<ImageType>;

--- a/test/rtkzengforwardprojectiontest.cxx
+++ b/test/rtkzengforwardprojectiontest.cxx
@@ -74,8 +74,7 @@ main(int, char **)
   projInput->Update();
 
 
-  using DEIFType = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>;
-  auto volInput = DEIFType::New();
+  auto volInput = rtk::DrawEllipsoidImageFilter<OutputImageType, OutputImageType>::New();
   auto axis_vol = itk::MakeVector(32., 32., 32.);
   auto center_vol = itk::MakeVector(0., 0., 0.);
   volInput->SetInput(tomographySource->GetOutput());
@@ -85,24 +84,21 @@ main(int, char **)
   volInput->Update();
 
   // Zeng Forward Projection filter
-  using JFPType = rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>;
 
-  auto jfp = JFPType::New();
+  auto jfp = rtk::ZengForwardProjectionImageFilter<OutputImageType, OutputImageType>::New();
   jfp->InPlaceOff();
   jfp->SetInput(projInput->GetOutput());
   jfp->SetInput(1, volInput->GetOutput());
   jfp->SetInput(2, attenuationInput->GetOutput());
 
   // Joseph Forward Attenuated Projection filter
-  using ATTJFPType = rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>;
-  auto attjfp = ATTJFPType::New();
+  auto attjfp = rtk::JosephForwardAttenuatedProjectionImageFilter<OutputImageType, OutputImageType>::New();
   attjfp->InPlaceOff();
   attjfp->SetInput(projInput->GetOutput());
   attjfp->SetInput(1, volInput->GetOutput());
   attjfp->SetInput(2, attenuationInput->GetOutput());
 
-  using GeometryType = rtk::ThreeDCircularProjectionGeometry;
-  auto geometry = GeometryType::New();
+  auto geometry = rtk::ThreeDCircularProjectionGeometry::New();
   for (unsigned int i = 0; i < NumberOfProjectionImages; i++)
   {
     geometry->AddProjection(500, 0, i * 360. / NumberOfProjectionImages, 16., 12.);


### PR DESCRIPTION
My script is maybe a little too aggressive, for example, it removes "using OutputPixelType = double" .
But no compilation error and all test passed.