### PR TITLE
STYLE: Reorganize imports in Python applications

### DIFF
--- a/applications/rtkconjugategradient/rtkconjugategradient.py
+++ b/applications/rtkconjugategradient/rtkconjugategradient.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import sys
 import itk
 from itk import RTK as rtk
 

--- a/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
+++ b/applications/rtkelektasynergygeometry/rtkelektasynergygeometry.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import sys
-import itk
 from itk import RTK as rtk
 
 

--- a/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.py
+++ b/applications/rtkprojectgeometricphantom/rtkprojectgeometricphantom.py
@@ -1,7 +1,7 @@
-import itk
 import argparse
-from itk import RTK as rtk
 import sys
+import itk
+from itk import RTK as rtk
 import numpy as np
 
 

--- a/applications/rtkprojections/rtkprojections.py
+++ b/applications/rtkprojections/rtkprojections.py
@@ -1,5 +1,5 @@
-import itk
 import argparse
+import itk
 from itk import RTK as rtk
 
 

--- a/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.py
+++ b/applications/rtkprojectshepploganphantom/rtkprojectshepploganphantom.py
@@ -1,5 +1,5 @@
-import itk
 import argparse
+import itk
 from itk import RTK as rtk
 
 

--- a/applications/rtkshowgeometry/rtkshowgeometry.py
+++ b/applications/rtkshowgeometry/rtkshowgeometry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
+import argparse
 import numpy as np
 import itk
 from itk import RTK as rtk
-import argparse
 
 
 def build_parser():

--- a/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
+++ b/applications/rtksimulatedgeometry/rtksimulatedgeometry.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import sys
 from itk import RTK as rtk
 
 

--- a/applications/rtkvarianobigeometry/rtkvarianobigeometry.py
+++ b/applications/rtkvarianobigeometry/rtkvarianobigeometry.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import sys
 import itk
 from itk import RTK as rtk
 


### PR DESCRIPTION
- Remove unused imports
- Reordered imports such that imports from the standard library appear first, as per the Python style guide (https://peps.python.org/pep-0008/#imports)

Fixes #784.