### PR TITLE
COMP: Remove unused definition warning in conjugate gradient example

### DIFF
--- a/examples/ConjugateGradient/ConjugateGradient.cxx
+++ b/examples/ConjugateGradient/ConjugateGradient.cxx
@@ -84,7 +84,6 @@ main(int argc, char * argv[])
   conjugategradient->SetBackProjectionFilter(ConjugateGradientFilterType::BP_VOXELBASED);
 #endif
 
-  using VerboseIterationCommandType = rtk::VerboseIterationCommand<ConjugateGradientFilterType>;
   auto verboseIterationCommand = rtk::VerboseIterationCommand<ConjugateGradientFilterType>::New();
   conjugategradient->AddObserver(itk::AnyEvent(), verboseIterationCommand);
 


### PR DESCRIPTION
Adresses the warning;
```
/home/srit/src/rtk/dashboard_tests/RTK/examples/ConjugateGradient/ConjugateGradient.cxx: In function 'int main(int, char**)':
[CTest: warning matched] /home/sritrtk/dashboard_tests/RTK/examples/ConjugateGradient/ConjugateGradient.cxx:87:9: warning: typedef 'using VerboseIterationCommandType = class rtk::VerboseIterationCommand<rtk::ConjugateGradientConeBeamReconstructionFilter<itk::CudaImage<float, 3> > >' locally defined but not used [-Wunused-local-typedefs]
   87 |   using VerboseIterationCommandType = rtk::VerboseIterationCommand<ConjugateGradientFilterType>;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```