### PR TITLE
COMP: Generate the test header in the same forlder as RTKExport.h

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,12 @@
+# The test header file is generated in the same folder as RTKExport.h
+if(ITK_SOURCE_DIR)
+  set(_test_header_file "${ITKCommon_BINARY_DIR}/rtkTestConfiguration.h")
+else()
+  set(_test_header_file "${RTK_BINARY_DIR}/include/rtkTestConfiguration.h")
+endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/rtkTestConfiguration.h.in
-  ${RTK_BINARY_DIR}/include/rtkTestConfiguration.h
+  ${_test_header_file}
 )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The same as been done for rtkConfiguration.h in 4bb7d0d4cfeb06b88bc2ea328444fccdb3109965.