### PR TITLE
BUG:  Remove verbose option from rtkgaincorrection

### DIFF
--- a/applications/rtkgaincorrection/rtkgaincorrection.py
+++ b/applications/rtkgaincorrection/rtkgaincorrection.py
@@ -11,12 +11,8 @@ def build_parser():
     parser = rtk.RTKArgumentParser(description="Polynomial gain correction projections")
 
     parser.add_argument(
-        "--verbose", "-v", help="Verbose execution", action="store_true"
-    )
-    parser.add_argument(
         "--output", "-o", help="Output file name", type=str, required=True
     )
-
     parser.add_argument(
         "--calibDir",
         "-c",


### PR DESCRIPTION
The verbose option was moved to rtkArgumentParser in another commit, which caused CI error when gaincorrection application was added with the verbose option