### PR TITLE
BUG: Remove memory leak in Gengetopt structure

### DIFF
--- a/include/rtkMacro.h
+++ b/include/rtkMacro.h
@@ -69,11 +69,6 @@
   args_params.check_required = 0;                                                     \
   args_params.override = 1;                                                           \
   args_params.initialize = 1;                                                         \
-  if (0 != cmdline_parser_##ggo_filename##_ext(argc, argv, &args_info, &args_params)) \
-  {                                                                                   \
-    std::cerr << "Error in cmdline_parser_" #ggo_filename "_ext" << std::endl;        \
-    exit(1);                                                                          \
-  }                                                                                   \
   args_params.check_required = 1;                                                     \
   if (0 != cmdline_parser_##ggo_filename##_ext(argc, argv, &args_info, &args_params)) \
   {                                                                                   \


### PR DESCRIPTION
Every call to `cmdline_parser_##ggo_filename##_ext` requires a call to `cmdline_parser_##ggo_filename##_free` for cleanup. d0f15386cbc1c89376753469eea23debcdf78a3f removed one _free without removing the corresponding _ext which is no longer required.