### PR TITLE
Documentation on 3D+time applications

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -16,8 +16,12 @@ The following are examples using RTK applications:
 ./rtkvarianobigeometry/README.md
 ./rtkadmmtotalvariation/README.md
 ./rtkadmmwavelets/README.md
+./rtkfourdfdk/README.md
 ./rtkfourdconjugategradient/README.md
+./rtkfourdsart/README.md
 ./rtkfourdrooster/README.md
+./rtkmotioncompensatedfourdconjugategradient/README.md
+./rtkmcrooster/README.md
 ./rtkshowgeometry/README.md
 ./rtkosem/README.md
 ./rtksart/README.md

--- a/applications/rtkfourdconjugategradient/README.md
+++ b/applications/rtkfourdconjugategradient/README.md
@@ -1,10 +1,10 @@
-# 4D conjugate gradient: unregularized 3D + time reconstruction
+# 4D conjugate gradient
 
 Please start by reading the [main documentation page on 3D + time reconstruction](../../documentation/docs/3d_time.md) if you have not read it already. It gives the necessary background to understand the 3D + time reconstruction tools, including this one. You can skip the sections on known non-rigid motion and deformation vector fields as they are not used in 4D conjugate gradient.
 
 RTK provides several tools to reconstruct a 3D + time image without regularization. 4D conjugate gradient is one of them.
 
-The algorithm requires a set of projection images with the associated RTK geometry, and the respiratory phase of each projection image. Each piece of data is described in more detail below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the mechanical state of the chest depends on the respiratory phase only.
+The algorithm requires a set of projection images with the associated RTK geometry, and the respiratory phase of each projection image. Each piece of data is described in more detail below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the position of the chest depends on the respiratory phase only.
 
 ## Projection images
 
@@ -12,7 +12,7 @@ This example is illustrated with a set of projection images of the [POPI patient
 
 ## Respiratory signal
 
-The 4D conjugate gradient algorithm requires that we associate each projection image with the instant of the respiratory cycle at which it has been acquired.
+The 4D conjugate gradient algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired.
 See [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
 
 ## 4D conjugate gradient for cone-beam CT reconstruction
@@ -23,7 +23,7 @@ We now have all the pieces to perform a 3D + time reconstruction. The algorithm 
 rtkfourdconjugategradient \
   -p . \
   -r .*.his \
-  -o rooster.mha \
+  -o fourd_cg.mha \
   -g geometry.rtk \
   --signal sphase.txt \
   --niterations 30 \
@@ -39,7 +39,7 @@ Compared to FDK, which only performs a single back projection, it can therefore 
 rtkfourdconjugategradient \
   -p . \
   -r .*.his \
-  -o rooster.mha \
+  -o fourd_cg.mha \
   -g geometry.rtk \
   --signal sphase.txt \
   --fp CudaRayCast \

--- a/applications/rtkfourdfdk/README.md
+++ b/applications/rtkfourdfdk/README.md
@@ -1,0 +1,50 @@
+# 4D FDK
+
+Please start by reading the [main documentation page on 3D + time reconstruction](../../documentation/docs/3d_time.md) if you have not read it already. It gives the necessary background to understand the 3D + time reconstruction tools, including this one. You can skip the sections on known non-rigid motion and deformation vector fields as they are not used in 4D FDK.
+
+RTK provides several tools to reconstruct a 3D + time image without regularization. 4D FDK is one of them.
+
+The algorithm requires a set of projection images with the associated RTK geometry, and the respiratory phase of each projection image. Each piece of data is described in more detail below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the position of the chest depends on the respiratory phase only.
+
+## Projection images
+
+This example is illustrated with a set of projection images of the [POPI patient](https://github.com/open-vv/popi-model/blob/master/popi-model.md). You can [download the projections](https://data.kitware.com/api/v1/item/5be99af88d777f2179a2e144/download) and the required tables of the Elekta database, [FRAME.DBF](https://data.kitware.com/api/v1/item/5be99a068d777f2179a2cf4f/download) and [IMAGE.DBF](https://data.kitware.com/api/v1/item/5be99a078d777f2179a2cf65/download). See the [Elekta page](../rtkelektasynergygeometry/README.md) to find out how to produce a geometry file with them.
+
+## Respiratory signal
+
+The 4D FDK algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired.
+See [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
+
+## 4D FDK for cone-beam CT reconstruction
+
+We now have all the pieces to perform a 3D + time reconstruction. The algorithm performs one FDK per frame, and for each frame, it uses a single projection per respiratory/cardiac cycle, and discards the rest. It might therefore be even faster than a regular 3D FDK using all projections.
+```
+# Reconstruct from all projection images with 4D FDK
+rtkfourdfdk \
+  -p . \
+  -r .*.his \
+  -o fourd_fdk.mha \
+  -g geometry.rtk \
+  --signal sphase.txt \
+  --spacing 2 \
+  --size 256 \
+  --frames 5
+```
+
+To speed things up, it is recommended to use the CUDA version of the forward and back projectors by running this command instead:
+
+```
+# Reconstruct from all projection images with 4D FDK, using CUDA forward and back projectors
+rtkfourdfdk \
+  -p . \
+  -r .*.his \
+  -o fourd_fdk.mha \
+  -g geometry.rtk \
+  --signal sphase.txt \
+  --hardware cuda \
+  --spacing 2 \
+  --size 256 \
+  --frames 5
+```
+
+Note that the reconstructed volume in this example does not fully contain the attenuating object, causing hyper-attenuation artifacts at the borders of the result.

--- a/applications/rtkfourdrooster/README.md
+++ b/applications/rtkfourdrooster/README.md
@@ -1,8 +1,8 @@
-# 4DROOSTER: Total variation-regularized 3D + time reconstruction
+# 4D ROOSTER
 
 RTK provides a tool to reconstruct a 3D + time image which does not require explicit motion estimation. Instead, it uses total variation regularization along both space and time. The implementation is based on a paper that we have published ([article](https://hal.science/hal-01097456v1)). You should read the article to understand the basics of the algorithm before trying to use the software.
 
-The algorithm requires a set of projection images with the associated RTK geometry, the respiratory phase of each projection image and a motion mask in which the region of the space where movement is expected is set to 1 and the rest is set to 0. Each piece of data is described in more details below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the mechanical state of the chest depends only on the respiratory phase.
+The algorithm requires a set of projection images with the associated RTK geometry, the respiratory phase of each projection image and a motion mask in which the region of the space where movement is expected is set to 1 and the rest is set to 0. Each piece of data is described in more details below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the position of the chest depends only on the respiratory phase.
 
 ## Projection images
 
@@ -45,18 +45,18 @@ The next piece of data is a 3D motion mask: a volume that contains only zeros, w
 
 ## Respiratory signal
 
-The 4D ROOSTER algorithm requires that we associate each projection image with the instant of the respiratory cycle at which it has been acquired.
+The 4D ROOSTER algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired.
 See [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
 
 ## ROOSTER for conebeam CT reconstruction
 
-We now have all the pieces to perform a 3D + time reconstruction. The algorithm will perform "niter" iterations of the main loop, and run three inner loops at each iteration:
+We now have all the pieces to perform a 3D + time reconstruction. The algorithm will perform `niter` iterations of the main loop, and run three inner loops at each iteration:
 
-*   conjugate gradient reconstruction with "cgiter" iterations
-*   total-variation regularization in space, with parameter "gamma_space" (the higher, the more regularized) and "tviter" iterations
-*   total-variation regularization in time, with parameter "gamma_time" (the higher, the more regularized) and "tviter" iterations
+*   conjugate gradient reconstruction with `cgiter` iterations
+*   total-variation regularization in space, with parameter `gamma_space` (the higher, the more regularized) and `tviter` iterations
+*   total-variation regularization in time, with parameter `gamma_time` (the higher, the more regularized) and `tviter` iterations
 
-The number of iterations suggested here should work in most situations. The parameters gamma_space and gamma_time, on the other hand, must be adjusted carefully for each type of datasets (and, unfortunately, for each resolution). Unlike in analytical reconstruction methods like FDK, with 4D ROOSTER it is also very important that the reconstruction volume contains the whole patient's chest. You should therefore adapt the "size", "spacing" and "origin" parameters carefully, based on what you have observed on the blurry FDK reconstruction.
+The number of iterations suggested here should work in most situations. The parameters `gamma_space` and `gamma_time`, on the other hand, must be adjusted carefully for each type of datasets (and, unfortunately, for each resolution). Unlike in analytical reconstruction methods like FDK, with 4D ROOSTER it is also very important that the reconstruction volume contains the whole patient's chest. You should therefore adapt the `size`, `spacing` and `origin` parameters carefully, based on what you have observed on the blurry FDK reconstruction.
 
 ```
 # Reconstruct from all projection images with 4D ROOSTER
@@ -102,11 +102,11 @@ rtkfourdrooster \
 
 With a recent GPU, this should allow you to perform a standard resolution reconstruction in less than one hour.
 
-Note that the reconstructed volume in this example does not fully contain the attenuating object, causing hyper-attenuation artifacts on the borders of the result. To avoid these artifacts, reconstruct a larger volume (--size 256) should be fine. Note that you will have to resize your motion mask as well, as 3D the motion mask is expected to have the same size, spacing and origin as the first 3 dimensions of the 4D output.
+Note that the reconstructed volume in this example does not fully contain the attenuating object, causing hyper-attenuation artifacts on the borders of the result. To avoid these artifacts, reconstruct a larger volume (`--size 256`) should be fine. Note that you will have to resize your motion mask as well, as 3D the motion mask is expected to have the same size, spacing and origin as the first 3 dimensions of the 4D output.
 
 ## Motion-Aware 4D Rooster
 
-4D ROOSTER doesn't require explicit motion information, but can take advantage of it to guide TV-regularization if motion information is available. Please refer to the tutorial on Motion-Compensated FDK to learn how to obtain a valid 4D Displacement Vector Field (DVF). Once you have it, simply adding the option --dvf "4D_DVF_Filename" to the list of rtkfourdrooster arguments will run MA-ROOSTER instead of 4D ROOSTER.
+4D ROOSTER does not require explicit motion information, but it can take advantage of it to guide TV-regularization if motion information is available. Please refer to the tutorial on [motion-compensated FDK](../rtkfdk/README.md) to learn how to obtain a valid 4D displacement vector field (DVF). Once you have it, simply adding the option `--dvf 4D_DVF_Filename` to the list of `rtkfourdrooster` arguments will run MA-ROOSTER instead of 4D ROOSTER.
 
 ```
 # Reconstruct from all projection images with MA ROOSTER
@@ -128,14 +128,14 @@ rtkfourdrooster \
   --dvf deformationField_4D.mhd
 ```
 
-Making use of the motion information adds to computation time. If you have compiled RTK with RTK_USE_CUDA = ON and have a working and CUDA-enabled nVidia GPU, it will automatically be used to speed up that part of the process.
+Making use of the motion information adds to computation time. If you have compiled RTK with `RTK_USE_CUDA=ON` and have a working and CUDA-enabled nVidia GPU, it will automatically be used to speed up that part of the process.
 
-The article in which the theoretical foundations of MA-ROOSTER are presented (link to be added) contains results obtained on two patients. If you wish to reproduce these results, you can download all the necessary data here:
+[The article](https://hal.science/hal-01375767) in which the theoretical foundations of MA-ROOSTER are presented contains results obtained on two patients. If you wish to reproduce these results, you can download all the necessary data here:
 
 *   Original projections, log-transformed projections with the table removed, motion mask, respiratory signal, and transform matrices to change from CT to CBCT coordinates and back
     *   [Patient 1](https://data.kitware.com/api/v1/item/5be97d688d777f2179a28e39/download)
     *   [Patient 2](https://data.kitware.com/api/v1/item/5be99df68d777f2179a2e904/download)
-*   Inverse-consistent 4D Displacement Vector Fields, to the end-exhale phase and from the end-exhale phase
+*   Inverse-consistent 4D DVFs, to the end-exhale phase and from the end-exhale phase
     *   [Patient 1](https://data.kitware.com/api/v1/item/5be989e68d777f2179a29e95/download)
     *   [Patient 2](https://data.kitware.com/api/v1/item/5be9a1388d777f2179a2f44d/download)
 
@@ -155,9 +155,9 @@ rtkfourdrooster \
   --niter 10 \
   --cgiter 4 \
   --tviter 10 \
-  --spacing "1, 1, 1, 1" \
-  --size "220, 280, 370, 10" \
-  --origin "-140, -140, -75, 0" \
+  --spacing 1 \
+  --size 220,280,370,10 \
+  --origin -140,-140,-75,0 \
   --frames 10 \
   --dvf toPhase50_4D.mhd \
   --idvf fromPhase50_4D.mhd
@@ -179,19 +179,19 @@ rtkfourdrooster \
   --niter 10 \
   --cgiter 4 \
   --tviter 10 \
-  --spacing "1, 1, 1, 1" \
-  --size "285, 270, 307, 10" \
-  --origin "-167.5, -135, -205, 0" \
+  --spacing 1 \
+  --size 285,270,307,10 \
+  --origin -167.5,-135,-205,0 \
   --frames 10 \
   --dvf toPhase50_4D.mhd \
   --idvf fromPhase50_4D.mhd \
 ```
 
-Note the option "--idvf", which allows to provide the inverse DVF. It is used to inverse warp the 4D reconstruction after the temporal regularization. MA-ROOSTER will work with and without the inverse DVF, and yield almost the same results in both cases. Not using the inverse DVF is approximately two times slower, as it requires MA-ROOSTER to perform the inverse warping by an iterative method.
+Note the option `--idvf` to provide the inverse DVF. It is used to inverse warp the 4D reconstruction after the temporal regularization. MA-ROOSTER will work with and without the inverse DVF, and yield almost the same results in both cases. Not using the inverse DVF is approximately two times slower, as it requires MA-ROOSTER to perform the inverse warping by an iterative method.
 
-Again, if you have a CUDA-enabled GPU (in this case with at least 3 GB of VRAM), and have compiled RTK with RTK_USE_CUDA = ON, you can add the "--bp CudaVoxelBased" and "--fp CudaRayCast" to speed up the computation by performing the forward and back projections on the GPU.
+Again, if you have a CUDA-enabled GPU (in this case with at least 3 GB of VRAM), and have compiled RTK with `RTK_USE_CUDA=ON`, you can add the `--bp CudaVoxelBased` and `--fp CudaRayCast` to speed up the computation by performing the forward and back projections on the GPU.
 
-You do not need the 4D planning CT data to perform the MA-ROOSTER reconstructions. It is only required to compute the DVFs, which can be downloaded above. We do provide it anyway, in case you want to use your own method, or the one described in Motion-Compensated FDK, to extract a DVF from it:
+You do not need the 4D planning CT data to perform the MA-ROOSTER reconstructions. It is only required to compute the DVFs, which can be downloaded above. We do provide it anyway, in case you want to use your own method, or the one described in [motion-compensated FDK](../rtkfdk/README.md), to extract a DVF from it:
 
 *   4D planning CT
     *   [Patient 1](https://data.kitware.com/api/v1/item/5be98bd28d777f2179a2a279/download)

--- a/applications/rtkfourdsart/README.md
+++ b/applications/rtkfourdsart/README.md
@@ -1,0 +1,55 @@
+# 4D SART
+
+Please start by reading the [main documentation page on 3D + time reconstruction](../../documentation/docs/3d_time.md) if you have not read it already. It gives the necessary background to understand the 3D + time reconstruction tools, including this one. You can skip the sections on known non-rigid motion and deformation vector fields as they are not used in 4D SART.
+
+RTK provides several tools to reconstruct a 3D + time image without regularization. 4D SART is one of them. It is similar to [4D conjugate gradient](../rtkfourdconjugategradient/README.md) in the sense that it minimizes the same objective function, but with a different method.
+
+The algorithm requires a set of projection images with the associated RTK geometry, and the respiratory phase of each projection image. Each piece of data is described in more detail below and can be downloaded using [Girder](https://data.kitware.com/#collection/5a7706878d777f0649e04776). It is assumed that the breathing motion is periodic, which implies that the position of the chest depends on the respiratory phase only.
+
+## Projection images
+
+This example is illustrated with a set of projection images of the [POPI patient](https://github.com/open-vv/popi-model/blob/master/popi-model.md). You can [download the projections](https://data.kitware.com/api/v1/item/5be99af88d777f2179a2e144/download) and the required tables of the Elekta database, [FRAME.DBF](https://data.kitware.com/api/v1/item/5be99a068d777f2179a2cf4f/download) and [IMAGE.DBF](https://data.kitware.com/api/v1/item/5be99a078d777f2179a2cf65/download). See the [Elekta page](../rtkelektasynergygeometry/README.md) to find out how to produce a geometry file with them.
+
+## Respiratory signal
+
+The 4D SART algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired.
+See [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
+
+## 4D SART for cone-beam CT reconstruction
+
+We now have all the pieces to perform a 3D + time reconstruction. The algorithm will perform `niterations` iterations. 4D SART forward projects `nprojpersubset` projections, back projects them and updates the volume, then moves on to the next subset of projections. In RTK iterative reconstruction algorithms, we count one iteration when the full set of projections has been forward and back projected. 4D SART therefore performs several updates of the reconstructed volume in a single iteration.
+```
+# Reconstruct from all projection images with 4D SART
+rtkfourdsart \
+  -p . \
+  -r .*.his \
+  -o fourd_sart.mha \
+  -g geometry.rtk \
+  --signal sphase.txt \
+  --niterations 5 \
+  --nprojpersubset 10 \
+  --spacing 2 \
+  --size 160 \
+  --frames 5
+```
+
+To speed things up, it is recommended to use the CUDA version of the forward and back projectors by running this command instead:
+
+```
+# Reconstruct from all projection images with 4D SART, using CUDA forward and back projectors
+rtkfourdsart \
+  -p . \
+  -r .*.his \
+  -o fourd_sart.mha \
+  -g geometry.rtk \
+  --signal sphase.txt \
+  --fp CudaRayCast \
+  --bp CudaVoxelBased \
+  --niterations 5 \
+  --nprojpersubset 10 \
+  --spacing 2 \
+  --size 160 \
+  --frames 5
+```
+
+Note that the reconstructed volume in this example does not fully contain the attenuating object, causing hyper-attenuation artifacts at the borders of the result. To avoid these artifacts, reconstructing a larger volume with `--size 256` should help.

--- a/applications/rtkmcrooster/README.md
+++ b/applications/rtkmcrooster/README.md
@@ -1,0 +1,51 @@
+# Motion-compensated ROOSTER
+
+Please start by reading the [main documentation page on 3D + time reconstruction](../../documentation/docs/3d_time.md) if you have not read it already. It gives the necessary background to understand the 3D + time reconstruction tools, including this one.
+
+RTK provides several tools to reconstruct a 3D + time image using a known motion estimate. Motion-compensated ROOSTER is one of them.
+
+The algorithm requires a set of projection images with the associated RTK geometry, the respiratory phase of each projection image and a 3D + time displacement vector field (DVF) representing the estimated motion. Each piece of data is described in more details below. It is assumed that the breathing motion is periodic, which implies that the position of the chest depends only on the respiratory phase.
+
+## Projection images
+
+This example is illustrated with a dataset of a patient used in the [MA-ROOSTER paper](https://hal.science/hal-01375767). You can [download the projections](https://data.kitware.com/api/v1/item/5be97d688d777f2179a28e39/download), which also contain the RTK geometry file.
+
+## Respiratory signal
+
+The algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired. The cphase.txt is already zipped together with the projections, but you can visit [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
+
+## Motion mask
+
+The next piece of data is a 3D motion mask: a volume that contains only zeros where no movement is expected to occur, and ones where movement is expected.
+Here the motion mask is the couple of files dilated_resampled_mm.mhd/.raw provided along with the projections.
+
+## 4D displacement vector field (DVF)
+
+The forward and inverse 4D DVFs for this patient can be downloaded [here](https://data.kitware.com/api/v1/item/5be989e68d777f2179a29e95/download). Please refer to the tutorial on [Motion-Compensated FDK](../rtkfdk/README.md) if you wish to learn how to obtain a valid 4D DVF.
+Copy paste the projections and DVFs in the same folder, then from that folder, run
+
+```
+# Reconstruct with motion-compensated ROOSTER
+rtkmcrooster \
+-p . \
+-r correctedProjs.mha \
+-o mcrooster.mha \
+-g geom.xml \
+--signal cphase.txt \
+--motionmask dilated_resampled_mm.mhd \
+--gamma_time 0.0002 \
+--gamma_space 0.00005 \
+--niter 10 \
+--cgiter 4 \
+--tviter 10 \
+--spacing "1, 1, 1, 1" \
+--size "220, 280, 370, 10" \
+--origin "-140, -140, -75, 0" \
+--frames 10 \
+--dvf toPhase50_4D.mhd \
+--idvf fromPhase50_4D.mhd \
+--cudacg
+```
+
+Compiling RTK with `RTK_USE_CUDA=ON` and having a working and CUDA-enabled nVidia GPU is mandatory for motion-compensated 4D conjugate gradient, and so is the --cudacg option, as the filters for [warped back projection](https://www.openrtk.org/Doxygen/classrtk_1_1WarpProjectionStackToFourDImageFilter.html) and [warped forward projection](https://www.openrtk.org/Doxygen/classrtk_1_1WarpFourDToProjectionStackImageFilter.html) are only implemented using CUDA. If one of these conditions is missing, the algorithm does not crash, but reverts to CPU-based non-motion-compensated forward and back projections.
+Note the option "--idvf", to provide the inverse DVF. It is also mandatory, as it is needed to perform the warped forward projections.

--- a/applications/rtkmcrooster/rtkmcrooster.cxx
+++ b/applications/rtkmcrooster/rtkmcrooster.cxx
@@ -113,7 +113,7 @@ main(int argc, char * argv[])
     inputFilter->GetOutput()->GetLargestPossibleRegion().GetSize(3));
   TRY_AND_EXIT_ON_ITK_EXCEPTION(signalToInterpolationWeights->Update())
 
-  // Create the 4DROOSTER filter, connect the basic inputs, and set the basic parameters
+  // Create the MCROOSTER filter, connect the basic inputs, and set the basic parameters
   auto mcrooster =
     rtk::MotionCompensatedFourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::New();
   SetForwardProjectionFromGgo(args_info, mcrooster.GetPointer());

--- a/applications/rtkmcrooster/rtkmcrooster.cxx
+++ b/applications/rtkmcrooster/rtkmcrooster.cxx
@@ -114,10 +114,11 @@ main(int argc, char * argv[])
   TRY_AND_EXIT_ON_ITK_EXCEPTION(signalToInterpolationWeights->Update())
 
   // Create the MCROOSTER filter, connect the basic inputs, and set the basic parameters
-  auto mcrooster =
-    rtk::MotionCompensatedFourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>::New();
-  SetForwardProjectionFromGgo(args_info, mcrooster.GetPointer());
-  SetBackProjectionFromGgo(args_info, mcrooster.GetPointer());
+  using MCFourDROOSTERTYPE =
+    rtk::MotionCompensatedFourDROOSTERConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>;
+  auto mcrooster = MCFourDROOSTERTYPE::New();
+  mcrooster->SetForwardProjectionFilter(MCFourDROOSTERTYPE::FP_CUDAWARP);
+  mcrooster->SetBackProjectionFilter(MCFourDROOSTERTYPE::BP_CUDAWARP);
   mcrooster->SetInputVolumeSeries(inputFilter->GetOutput());
   mcrooster->SetCG_iterations(args_info.cgiter_arg);
   mcrooster->SetMainLoop_iterations(args_info.niter_arg);

--- a/applications/rtkmotioncompensatedfourdconjugategradient/README.md
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/README.md
@@ -1,0 +1,41 @@
+# Motion-compensated 4D conjugate gradient
+
+Please start by reading the [main documentation page on 3D + time reconstruction](../../documentation/docs/3d_time.md) if you have not read it already. It gives the necessary background to understand the 3D + time reconstruction tools, including this one.
+
+RTK provides several tools to reconstruct a 3D + time image using a known motion estimate. Motion-compensated 4D conjugate gradient is one of them.
+
+The algorithm requires a set of projection images with the associated RTK geometry, the respiratory phase of each projection image and a 3D + time displacement vector field (DVF) representing the estimated motion. Each piece of data is described in more details below. It is assumed that the breathing motion is periodic, which implies that the position of the chest depends only on the respiratory phase.
+
+## Projection images
+
+This example is illustrated with a dataset of a patient used in the [MA-ROOSTER paper](https://hal.science/hal-01375767). You can [download the projections](https://data.kitware.com/api/v1/item/5be97d688d777f2179a28e39/download), which also contain the RTK geometry file.
+
+## Respiratory signal
+
+The algorithm requires that we associate each projection image with its position in the respiratory cycle when it has been acquired. The cphase.txt is already zipped together with the projections, but you can visit [this page](../rtkamsterdamshroud/README.md) to learn how to generate it from the projections using the Amsterdam Shroud.
+
+## 4D displacement vector field (DVF)
+
+The forward and inverse 4D DVFs for this patient can be downloaded [here](https://data.kitware.com/api/v1/item/5be989e68d777f2179a29e95/download). Please refer to the tutorial on [Motion-Compensated FDK](../rtkfdk/README.md) if you wish to learn how to obtain a valid 4D DVF.
+Copy paste the projections and DVFs in the same folder, then from that folder, run
+
+```
+# Reconstruct with motion-compensated 4D conjugate gradient
+rtkmotioncompensatedfourdconjugategradient \
+-p . \
+-r correctedProjs.mha \
+-o mc_fourdcg.mha \
+-g geom.xml \
+--signal cphase.txt \
+--niter 2 \
+--spacing "1, 1, 1, 1" \
+--size "220, 280, 370, 10" \
+--origin "-140, -140, -75, 0" \
+--frames 10 \
+--dvf toPhase50_4D.mhd \
+--idvf fromPhase50_4D.mhd \
+--cudacg
+```
+
+Compiling RTK with `RTK_USE_CUDA=ON` and having a working and CUDA-enabled nVidia GPU is mandatory for motion-compensated 4D conjugate gradient, and so is the `--cudacg` option, as the filters for [warped back projection](https://www.openrtk.org/Doxygen/classrtk_1_1WarpProjectionStackToFourDImageFilter.html) and [warped forward projection](https://www.openrtk.org/Doxygen/classrtk_1_1WarpFourDToProjectionStackImageFilter.html) are only implemented using CUDA. If one of these conditions is missing, the algorithm does not crash, but reverts to CPU-based non-motion-compensated forward and back projections.
+Note the option `--idvf` to provide the inverse DVF. It is also mandatory, as it is needed to perform the warped forward projections.

--- a/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
@@ -109,8 +109,8 @@ main(int argc, char * argv[])
   mcfourdcg->SetNumberOfIterations(args_info.niter_arg);
   mcfourdcg->SetCudaConjugateGradient(args_info.cudacg_flag);
   mcfourdcg->SetSignal(rtk::ReadSignalFile(args_info.signal_arg));
+  mcfourdcg->SetUseCudaCyclicDeformation(args_info.cudadvfinterpolation_flag);
   mcfourdcg->SetDisableDisplacedDetectorFilter(args_info.nodisplaced_flag);
-
   REPORT_ITERATIONS(mcfourdcg, MCFourDCGFilterType, VolumeSeriesType)
 
   // Read DVF

--- a/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.cxx
@@ -102,6 +102,8 @@ main(int argc, char * argv[])
   using MCFourDCGFilterType =
     rtk::MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>;
   auto mcfourdcg = MCFourDCGFilterType::New();
+  mcfourdcg->SetForwardProjectionFilter(MCFourDCGFilterType::FP_CUDAWARP);
+  mcfourdcg->SetBackProjectionFilter(MCFourDCGFilterType::BP_CUDAWARP);
   mcfourdcg->SetInputVolumeSeries(inputFilter->GetOutput());
   mcfourdcg->SetInputProjectionStack(reader->GetOutput());
   mcfourdcg->SetGeometry(geometry);

--- a/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.ggo
+++ b/applications/rtkmotioncompensatedfourdconjugategradient/rtkmotioncompensatedfourdconjugategradient.ggo
@@ -5,6 +5,7 @@ option "input"       i "Input volume"                                          s
 option "output"      o "Output file name"                                      string yes
 option "niter"       n "Number of main loop iterations"                        int    no   default="5"
 option "cudacg"      - "Perform conjugate gradient calculations on GPU"        flag   off
+option "cudadvfinterpolation"   - "Perform DVF interpolation calculations on GPU"        flag   off
 option "nodisplaced" - "Disable the displaced detector filter"                 flag   off
 
 section "Phase gating"

--- a/include/rtkIterativeConeBeamReconstructionFilter.h
+++ b/include/rtkIterativeConeBeamReconstructionFilter.h
@@ -31,7 +31,9 @@
 
 #ifdef RTK_USE_CUDA
 #  include "rtkCudaForwardProjectionImageFilter.h"
+#  include "rtkCudaWarpForwardProjectionImageFilter.h"
 #  include "rtkCudaBackProjectionImageFilter.h"
+#  include "rtkCudaWarpBackProjectionImageFilter.h"
 #  include "rtkCudaRayCastBackProjectionImageFilter.h"
 #endif
 
@@ -74,7 +76,8 @@ public:
     FP_JOSEPH = 0,
     FP_CUDARAYCAST = 2,
     FP_JOSEPHATTENUATED = 3,
-    FP_ZENG = 4
+    FP_ZENG = 4,
+    FP_CUDAWARP = 5
   } ForwardProjectionType;
   typedef enum
   {
@@ -83,7 +86,8 @@ public:
     BP_CUDAVOXELBASED = 2,
     BP_CUDARAYCAST = 4,
     BP_JOSEPHATTENUATED = 5,
-    BP_ZENG = 6
+    BP_ZENG = 6,
+    BP_CUDAWARP = 7
   } BackProjectionType;
 
   /** Typedefs of each subfilter of this composite filter */
@@ -258,6 +262,29 @@ protected:
   }
 
 
+  template <typename ImageType, EnableCudaScalarType<ImageType> * = nullptr>
+  ForwardProjectionPointerType
+  InstantiateCudaWarpForwardProjection()
+  {
+    ForwardProjectionPointerType fw;
+#ifdef RTK_USE_CUDA
+    fw = CudaWarpForwardProjectionImageFilter::New();
+    dynamic_cast<rtk::CudaWarpForwardProjectionImageFilter *>(fw.GetPointer())->SetStepSize(m_StepSize);
+#endif
+    return fw;
+  }
+
+
+  template <typename ImageType, DisableCudaScalarType<ImageType> * = nullptr>
+  ForwardProjectionPointerType
+  InstantiateCudaWarpForwardProjection()
+  {
+    itkGenericExceptionMacro(
+      << "CudaWarpForwardProjectionImageFilter only available with 3D CudaImage of float or itk::Vector<float,3>.");
+    return nullptr;
+  }
+
+
   template <typename ImageType, EnableVectorType<ImageType> * = nullptr>
   ForwardProjectionPointerType
   InstantiateJosephForwardAttenuatedProjection()
@@ -344,6 +371,27 @@ protected:
     return nullptr;
   }
 
+
+  template <typename ImageType, EnableCudaScalarType<ImageType> * = nullptr>
+  BackProjectionPointerType
+  InstantiateCudaWarpBackProjection()
+  {
+    BackProjectionPointerType bp;
+#ifdef RTK_USE_CUDA
+    bp = CudaWarpBackProjectionImageFilter::New();
+#endif
+    return bp;
+  }
+
+
+  template <typename ImageType, DisableCudaScalarType<ImageType> * = nullptr>
+  BackProjectionPointerType
+  InstantiateCudaWarpBackProjection()
+  {
+    itkGenericExceptionMacro(
+      << "CudaWarpBackProjectionImageFilter only available with 3D CudaImage of float or itk::Vector<float,3>.");
+    return nullptr;
+  }
 
   template <typename ImageType, EnableCudaScalarType<ImageType> * = nullptr>
   BackProjectionPointerType

--- a/include/rtkIterativeConeBeamReconstructionFilter.hxx
+++ b/include/rtkIterativeConeBeamReconstructionFilter.hxx
@@ -59,6 +59,9 @@ IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::Instan
     case (FP_ZENG):
       fw = InstantiateZengForwardProjection<ProjectionStackType>();
       break;
+    case (FP_CUDAWARP):
+      fw = InstantiateCudaWarpForwardProjection<ProjectionStackType>();
+      break;
     default:
       itkGenericExceptionMacro(<< "Unhandled --fp value.");
   }
@@ -89,6 +92,9 @@ IterativeConeBeamReconstructionFilter<TOutputImage, ProjectionStackType>::Instan
       break;
     case (BP_ZENG):
       bp = InstantiateZengBackProjection<ProjectionStackType>();
+      break;
+    case (BP_CUDAWARP):
+      bp = InstantiateCudaWarpBackProjection<ProjectionStackType>();
       break;
     default:
       itkGenericExceptionMacro(<< "Unhandled --bp value.");

--- a/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter.h
@@ -100,18 +100,6 @@ public:
   /** Runtime information support. */
   itkOverrideGetNameOfClassMacro(MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter);
 
-  /** Neither the Forward nor the Back projection filters can be set by the user */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType itkNotUsed(_arg)) override
-  {
-    itkExceptionMacro(<< "ForwardProjection cannot be changed");
-  }
-  void
-  SetBackProjectionFilter(BackProjectionType itkNotUsed(_arg)) override
-  {
-    itkExceptionMacro(<< "BackProjection cannot be changed");
-  }
-
   /** The ND + time motion vector field */
   void
   SetDisplacementField(const DVFSequenceImageType * DisplacementField);

--- a/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
+++ b/include/rtkMotionCompensatedFourDROOSTERConeBeamReconstructionFilter.h
@@ -174,18 +174,6 @@ public:
   using MotionCompensatedFourDCGFilterType =
     rtk::MotionCompensatedFourDConjugateGradientConeBeamReconstructionFilter<VolumeSeriesType, ProjectionStackType>;
 
-  /** Neither the forward nor the back projection filter can be set by the user */
-  void
-  SetForwardProjectionFilter(ForwardProjectionType itkNotUsed(fwtype)) override
-  {
-    itkExceptionMacro(<< "ForwardProjection cannot be changed");
-  }
-  void
-  SetBackProjectionFilter(BackProjectionType itkNotUsed(bptype)) override
-  {
-    itkExceptionMacro(<< "BackProjection cannot be changed");
-  }
-
   /** Set the vector containing the signal in the sub-filters */
   void
   SetSignal(const std::vector<double> signal) override;


### PR DESCRIPTION
Add documentation pages for 4D SART, 4D FDK, MCROOSTER and MC4DCG
Add cudadvfinterpolation option to MC4DCG to make it more uniform with MCROOSTER
The command line proposed in the documentation for MCROOSTER and MC4DCG currently crash for two different reasons, which may be linked together. I'll open an issue on this