### PR TITLE
ENH: Update to ITK v5.4.5 release

### DIFF
--- a/.github/workflows/build-test-cxx-cuda.yml
+++ b/.github/workflows/build-test-cxx-cuda.yml
@@ -3,7 +3,7 @@ name: 'Build, Test RTK with CUDA'
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.4.4"
+  itk-git-tag: "v5.4.5"
   itk-module-deps: "CudaCommon@main"
 
 concurrency:

--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -3,7 +3,7 @@ name: 'Package RTK with CUDA'
 on: [push,pull_request]
 
 env:
-  itk-wheel-tag: 'v5.4.4'
+  itk-wheel-tag: 'v5.4.5'
   itk-python-package-tag: 'release-5.4'
   itk-python-package-org: 'InsightSoftwareConsortium'
   itk-module-deps: "RTKConsortium/ITKCudaCommon@main"

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,10 +8,10 @@ concurrency:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.4
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.4
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       cmake-options: '-DRTK_BUILD_APPLICATIONS:BOOL=OFF'
       python3-minor-versions: ${{ github.event_name == 'pull_request' && '["11"]' || '["9","10","11"]' }}


### PR DESCRIPTION
Use the updated  workflows to avoid macos-13 runner deprecation (migrate to macos-15-intel).