### PR TITLE
BUG: Remove cuda InlineReconstructionExample test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -365,9 +365,6 @@ rtk_add_cuda_test(rtkFirstCudaReconstructionExampleTest
 rtk_add_test(rtkInlineReconstructionExampleTest
   ../examples/InlineReconstruction/InlineReconstruction.cxx
 )
-rtk_add_cuda_test(rtkCudaInlineReconstructionExampleTest
-  ../examples/InlineReconstruction/InlineReconstruction.cxx
-)
 rtk_add_test(rtkAddNoiseExampleTest
   ../examples/AddNoise/AddNoise.cxx
 )


### PR DESCRIPTION
The cuda version of InlineReconstructionExample is tested already on the cuda workflow
Fix #878 