### PR TITLE
ENH: Allow no cropping for Elekta projections

### DIFF
--- a/include/rtkGgoFunctions.h
+++ b/include/rtkGgoFunctions.h
@@ -226,15 +226,17 @@ SetProjectionsReaderFromGgo(TProjectionsReaderType * reader, const TArgsInfo & a
   }
 
   // Crop boundaries
-  typename TProjectionsReaderType::OutputImageSizeType upperCrop, lowerCrop;
-  upperCrop.Fill(0);
-  lowerCrop.Fill(0);
+  auto lowerCrop = itk::MakeFilled<typename TProjectionsReaderType::OutputImageSizeType>(0);
   for (unsigned int i = 0; i < args_info.lowercrop_given; i++)
     lowerCrop[i] = args_info.lowercrop_arg[i];
-  reader->SetLowerBoundaryCropSize(lowerCrop);
+  if (args_info.lowercrop_given)
+    reader->SetLowerBoundaryCropSize(lowerCrop);
+
+  auto upperCrop = itk::MakeFilled<typename TProjectionsReaderType::OutputImageSizeType>(0);
   for (unsigned int i = 0; i < args_info.uppercrop_given; i++)
     upperCrop[i] = args_info.uppercrop_arg[i];
-  reader->SetUpperBoundaryCropSize(upperCrop);
+  if (args_info.uppercrop_given)
+    reader->SetUpperBoundaryCropSize(upperCrop);
 
   // Conditional median
   typename TProjectionsReaderType::MedianRadiusType medianRadius;

--- a/include/rtkProjectionsReader.h
+++ b/include/rtkProjectionsReader.h
@@ -322,19 +322,21 @@ private:
   /** Copy of parameters for the mini-pipeline. Parameters are checked and
    * propagated when required in the GenerateOutputInformation. Refer to the
    * documentation of the corresponding filter for more information. */
-  OutputImagePointType         m_Origin;
-  OutputImageSpacingType       m_Spacing;
-  OutputImageDirectionType     m_Direction;
-  OutputImageSizeType          m_LowerBoundaryCropSize;
-  OutputImageSizeType          m_UpperBoundaryCropSize;
-  ShrinkFactorsType            m_ShrinkFactors;
-  MedianRadiusType             m_MedianRadius;
-  double                       m_AirThreshold{ 32000 };
-  double                       m_ScatterToPrimaryRatio{ 0. };
-  double                       m_NonNegativityConstraintThreshold{ itk::NumericTraits<double>::NonpositiveMin() };
-  double                       m_I0{ itk::NumericTraits<double>::NonpositiveMin() };
-  double                       m_IDark{ 0. };
-  double                       m_ConditionalMedianThresholdMultiplier{ 1. };
+  OutputImagePointType     m_Origin;
+  OutputImageSpacingType   m_Spacing;
+  OutputImageDirectionType m_Direction;
+  itk::SizeValueType       m_DefaultBoundaryCropValue{ itk::NumericTraits<itk::SizeValueType>::max() };
+  OutputImageSizeType      m_DefaultBoundaryCropSize = itk::MakeFilled<OutputImageSizeType>(m_DefaultBoundaryCropValue);
+  OutputImageSizeType      m_LowerBoundaryCropSize{ m_DefaultBoundaryCropSize };
+  OutputImageSizeType      m_UpperBoundaryCropSize{ m_DefaultBoundaryCropSize };
+  ShrinkFactorsType        m_ShrinkFactors;
+  MedianRadiusType         m_MedianRadius;
+  double                   m_AirThreshold{ 32000 };
+  double                   m_ScatterToPrimaryRatio{ 0. };
+  double                   m_NonNegativityConstraintThreshold{ itk::NumericTraits<double>::NonpositiveMin() };
+  double                   m_I0{ itk::NumericTraits<double>::NonpositiveMin() };
+  double                   m_IDark{ 0. };
+  double                   m_ConditionalMedianThresholdMultiplier{ 1. };
   WaterPrecorrectionVectorType m_WaterPrecorrectionCoefficients;
   bool                         m_ComputeLineIntegral{ true };
   unsigned int                 m_VectorComponent{ 0 };


### PR DESCRIPTION
Previously, the default value was 0 for the cropping except for Elekta for which it was 4. Setting the default value to the numerical max allows detecting if 0 is explicitely set for Elekta projections.