### PR TITLE
BUG: Include Test depends in test directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,13 @@ configure_file(
 if(NOT ITK_DIR)
   set(ITK_DIR ${ITK_BINARY_DIR}/CMakeTmp)
 endif()
-find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    ${ITK_MODULE_RTK_DEPENDS}
+    ${RTK_TEST_DEPENDS}
+)
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Addresses build issue with the ITK CMake interfaces library PR.

This fixes missing module dependencies in the test directory that were causing compilation errors when building with updated ITK CMake infrastructure.

The compilation error due to not being able to find the "itkTestingMacros.h" header when building tests.

InsightSoftwareConsortium/ITK#5721