### PR TITLE
ENH: Adjust RTK applications and example to modern CMake interface

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -29,6 +29,15 @@ find_package(ITK REQUIRED COMPONENTS ${ITK_MODULE_RTK_DEPENDS})
 include(itkVersion)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_APPLICATION_TARGETS ${RTK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_APPLICATION_TARGETS
+    ITK::RTKModule
+    ITK::ITKImageIO
+    ITK::ITKFFTImageFilterInit
+  )
 endif()
 
 #-----------------------------------------------------------------------------

--- a/applications/rtkadmmtotalvariation/CMakeLists.txt
+++ b/applications/rtkadmmtotalvariation/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkadmmtotalvariation.cxx
   ${rtkadmmtotalvariation_GGO_C}
 )
-target_link_libraries(rtkadmmtotalvariation RTK)
+target_link_libraries(rtkadmmtotalvariation ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkadmmtotalvariation

--- a/applications/rtkadmmwavelets/CMakeLists.txt
+++ b/applications/rtkadmmwavelets/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkadmmwavelets.cxx
   ${rtkadmmwavelets_GGO_C}
 )
-target_link_libraries(rtkadmmwavelets RTK)
+target_link_libraries(rtkadmmwavelets ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkadmmwavelets

--- a/applications/rtkamsterdamshroud/CMakeLists.txt
+++ b/applications/rtkamsterdamshroud/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkamsterdamshroud.cxx
   ${rtkamsterdamshroud_GGO_C}
 )
-target_link_libraries(rtkamsterdamshroud RTK)
+target_link_libraries(rtkamsterdamshroud ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkamsterdamshroud

--- a/applications/rtkbackprojections/CMakeLists.txt
+++ b/applications/rtkbackprojections/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkbackprojections.cxx
   ${rtkbackprojections_GGO_C}
 )
-target_link_libraries(rtkbackprojections RTK)
+target_link_libraries(rtkbackprojections ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkbackprojections

--- a/applications/rtkbioscangeometry/CMakeLists.txt
+++ b/applications/rtkbioscangeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkbioscangeometry.cxx
   ${rtkbioscangeometry_GGO_C}
 )
-target_link_libraries(rtkbioscangeometry RTK)
+target_link_libraries(rtkbioscangeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkbioscangeometry

--- a/applications/rtkcheckimagequality/CMakeLists.txt
+++ b/applications/rtkcheckimagequality/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkcheckimagequality.cxx
   ${rtkcheckimagequality_GGO_C}
 )
-target_link_libraries(rtkcheckimagequality RTK)
+target_link_libraries(rtkcheckimagequality ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkcheckimagequality

--- a/applications/rtkconjugategradient/CMakeLists.txt
+++ b/applications/rtkconjugategradient/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkconjugategradient.cxx
   ${rtkconjugategradient_GGO_C}
 )
-target_link_libraries(rtkconjugategradient RTK)
+target_link_libraries(rtkconjugategradient ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkconjugategradient

--- a/applications/rtkdigisensgeometry/CMakeLists.txt
+++ b/applications/rtkdigisensgeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkdigisensgeometry.cxx
   ${rtkdigisensgeometry_GGO_C}
 )
-target_link_libraries(rtkdigisensgeometry RTK)
+target_link_libraries(rtkdigisensgeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkdigisensgeometry

--- a/applications/rtkdrawgeometricphantom/CMakeLists.txt
+++ b/applications/rtkdrawgeometricphantom/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkdrawgeometricphantom.cxx
   ${rtkdrawgeometricphantom_GGO_C}
 )
-target_link_libraries(rtkdrawgeometricphantom RTK)
+target_link_libraries(rtkdrawgeometricphantom ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkdrawgeometricphantom

--- a/applications/rtkdrawshepploganphantom/CMakeLists.txt
+++ b/applications/rtkdrawshepploganphantom/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkdrawshepploganphantom.cxx
   ${rtkdrawshepploganphantom_GGO_C}
 )
-target_link_libraries(rtkdrawshepploganphantom RTK)
+target_link_libraries(rtkdrawshepploganphantom ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkdrawshepploganphantom

--- a/applications/rtkelektasynergygeometry/CMakeLists.txt
+++ b/applications/rtkelektasynergygeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkelektasynergygeometry.cxx
   ${rtkelektasynergygeometry_GGO_C}
 )
-target_link_libraries(rtkelektasynergygeometry RTK)
+target_link_libraries(rtkelektasynergygeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkelektasynergygeometry

--- a/applications/rtkextractphasesignal/CMakeLists.txt
+++ b/applications/rtkextractphasesignal/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkextractphasesignal.cxx
   ${rtkextractphasesignal_GGO_C}
 )
-target_link_libraries(rtkextractphasesignal RTK)
+target_link_libraries(rtkextractphasesignal ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkextractphasesignal

--- a/applications/rtkextractshroudsignal/CMakeLists.txt
+++ b/applications/rtkextractshroudsignal/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkextractshroudsignal.cxx
   ${rtkextractshroudsignal_GGO_C}
 )
-target_link_libraries(rtkextractshroudsignal RTK)
+target_link_libraries(rtkextractshroudsignal ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkextractshroudsignal

--- a/applications/rtkfdk/CMakeLists.txt
+++ b/applications/rtkfdk/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfdk.cxx
   ${rtkfdk_GGO_C}
 )
-target_link_libraries(rtkfdk RTK)
+target_link_libraries(rtkfdk ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfdk

--- a/applications/rtkfieldofview/CMakeLists.txt
+++ b/applications/rtkfieldofview/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfieldofview.cxx
   ${rtkfieldofview_GGO_C}
 )
-target_link_libraries(rtkfieldofview RTK)
+target_link_libraries(rtkfieldofview ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfieldofview

--- a/applications/rtkforwardprojections/CMakeLists.txt
+++ b/applications/rtkforwardprojections/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkforwardprojections.cxx
   ${rtkforwardprojections_GGO_C}
 )
-target_link_libraries(rtkforwardprojections RTK)
+target_link_libraries(rtkforwardprojections ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkforwardprojections

--- a/applications/rtkfourdconjugategradient/CMakeLists.txt
+++ b/applications/rtkfourdconjugategradient/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfourdconjugategradient.cxx
   ${rtkfourdconjugategradient_GGO_C}
 )
-target_link_libraries(rtkfourdconjugategradient RTK)
+target_link_libraries(rtkfourdconjugategradient ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfourdconjugategradient

--- a/applications/rtkfourdfdk/CMakeLists.txt
+++ b/applications/rtkfourdfdk/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfourdfdk.cxx
   ${rtkfourdfdk_GGO_C}
 )
-target_link_libraries(rtkfourdfdk RTK)
+target_link_libraries(rtkfourdfdk ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfourdfdk

--- a/applications/rtkfourdrooster/CMakeLists.txt
+++ b/applications/rtkfourdrooster/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfourdrooster.cxx
   ${rtkfourdrooster_GGO_C}
 )
-target_link_libraries(rtkfourdrooster RTK)
+target_link_libraries(rtkfourdrooster ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfourdrooster

--- a/applications/rtkfourdsart/CMakeLists.txt
+++ b/applications/rtkfourdsart/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkfourdsart.cxx
   ${rtkfourdsart_GGO_C}
 )
-target_link_libraries(rtkfourdsart RTK)
+target_link_libraries(rtkfourdsart ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkfourdsart

--- a/applications/rtkgaincorrection/CMakeLists.txt
+++ b/applications/rtkgaincorrection/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkgaincorrection.cxx
   ${rtkgaincorrection_GGO_C}
 )
-target_link_libraries(rtkgaincorrection RTK)
+target_link_libraries(rtkgaincorrection ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkgaincorrection

--- a/applications/rtkimagxgeometry/CMakeLists.txt
+++ b/applications/rtkimagxgeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkimagxgeometry.cxx
   ${rtkimagxgeometry_GGO_C}
 )
-target_link_libraries(rtkimagxgeometry RTK)
+target_link_libraries(rtkimagxgeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkimagxgeometry

--- a/applications/rtkiterativefdk/CMakeLists.txt
+++ b/applications/rtkiterativefdk/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkiterativefdk.cxx
   ${rtkiterativefdk_GGO_C}
 )
-target_link_libraries(rtkiterativefdk RTK)
+target_link_libraries(rtkiterativefdk ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkiterativefdk

--- a/applications/rtklagcorrection/CMakeLists.txt
+++ b/applications/rtklagcorrection/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtklagcorrection.cxx
   ${rtklagcorrection_GGO_C}
 )
-target_link_libraries(rtklagcorrection RTK)
+target_link_libraries(rtklagcorrection ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtklagcorrection

--- a/applications/rtkmaskcollimation/CMakeLists.txt
+++ b/applications/rtkmaskcollimation/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkmaskcollimation.cxx
   ${rtkmaskcollimation_GGO_C}
 )
-target_link_libraries(rtkmaskcollimation RTK)
+target_link_libraries(rtkmaskcollimation ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkmaskcollimation

--- a/applications/rtkmcfourdconjugategradient/CMakeLists.txt
+++ b/applications/rtkmcfourdconjugategradient/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkmcfourdconjugategradient.cxx
   ${rtkmcfourdconjugategradient_GGO_C}
 )
-target_link_libraries(rtkmcfourdconjugategradient RTK)
+target_link_libraries(rtkmcfourdconjugategradient ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkmcfourdconjugategradient

--- a/applications/rtkmcrooster/CMakeLists.txt
+++ b/applications/rtkmcrooster/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkmcrooster.cxx
   ${rtkmcrooster_GGO_C}
 )
-target_link_libraries(rtkmcrooster RTK)
+target_link_libraries(rtkmcrooster ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkmcrooster

--- a/applications/rtkorageometry/CMakeLists.txt
+++ b/applications/rtkorageometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkorageometry.cxx
   ${rtkorageometry_GGO_C}
 )
-target_link_libraries(rtkorageometry RTK)
+target_link_libraries(rtkorageometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkorageometry

--- a/applications/rtkosem/CMakeLists.txt
+++ b/applications/rtkosem/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkosem.cxx
   ${rtkosem_GGO_C}
 )
-target_link_libraries(rtkosem RTK)
+target_link_libraries(rtkosem ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkosem

--- a/applications/rtkoverlayphaseandshroud/CMakeLists.txt
+++ b/applications/rtkoverlayphaseandshroud/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkoverlayphaseandshroud.cxx
   ${rtkoverlayphaseandshroud_GGO_C}
 )
-target_link_libraries(rtkoverlayphaseandshroud RTK)
+target_link_libraries(rtkoverlayphaseandshroud ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkoverlayphaseandshroud

--- a/applications/rtkprojectgeometricphantom/CMakeLists.txt
+++ b/applications/rtkprojectgeometricphantom/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkprojectgeometricphantom.cxx
   ${rtkprojectgeometricphantom_GGO_C}
 )
-target_link_libraries(rtkprojectgeometricphantom RTK)
+target_link_libraries(rtkprojectgeometricphantom ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkprojectgeometricphantom

--- a/applications/rtkprojectionmatrix/CMakeLists.txt
+++ b/applications/rtkprojectionmatrix/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkprojectionmatrix.cxx
   ${rtkprojectionmatrix_GGO_C}
 )
-target_link_libraries(rtkprojectionmatrix RTK)
+target_link_libraries(rtkprojectionmatrix ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkprojectionmatrix

--- a/applications/rtkprojections/CMakeLists.txt
+++ b/applications/rtkprojections/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkprojections.cxx
   ${rtkprojections_GGO_C}
 )
-target_link_libraries(rtkprojections RTK)
+target_link_libraries(rtkprojections ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkprojections

--- a/applications/rtkprojectshepploganphantom/CMakeLists.txt
+++ b/applications/rtkprojectshepploganphantom/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkprojectshepploganphantom.cxx
   ${rtkprojectshepploganphantom_GGO_C}
 )
-target_link_libraries(rtkprojectshepploganphantom RTK)
+target_link_libraries(rtkprojectshepploganphantom ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkprojectshepploganphantom

--- a/applications/rtkregularizedconjugategradient/CMakeLists.txt
+++ b/applications/rtkregularizedconjugategradient/CMakeLists.txt
@@ -4,7 +4,10 @@ add_executable(
   rtkregularizedconjugategradient.cxx
   ${rtkregularizedconjugategradient_GGO_C}
 )
-target_link_libraries(rtkregularizedconjugategradient RTK)
+target_link_libraries(
+  rtkregularizedconjugategradient
+  ${RTK_APPLICATION_TARGETS}
+)
 
 set_target_properties(
   rtkregularizedconjugategradient

--- a/applications/rtksart/CMakeLists.txt
+++ b/applications/rtksart/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtksart.cxx
   ${rtksart_GGO_C}
 )
-target_link_libraries(rtksart RTK)
+target_link_libraries(rtksart ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtksart

--- a/applications/rtkscatterglarecorrection/CMakeLists.txt
+++ b/applications/rtkscatterglarecorrection/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkscatterglarecorrection.cxx
   ${rtkscatterglarecorrection_GGO_C}
 )
-target_link_libraries(rtkscatterglarecorrection RTK)
+target_link_libraries(rtkscatterglarecorrection ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkscatterglarecorrection

--- a/applications/rtksimulatedgeometry/CMakeLists.txt
+++ b/applications/rtksimulatedgeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtksimulatedgeometry.cxx
   ${rtksimulatedgeometry_GGO_C}
 )
-target_link_libraries(rtksimulatedgeometry RTK)
+target_link_libraries(rtksimulatedgeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtksimulatedgeometry

--- a/applications/rtkspectraldenoiseprojections/CMakeLists.txt
+++ b/applications/rtkspectraldenoiseprojections/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkspectraldenoiseprojections.cxx
   ${rtkspectraldenoiseprojections_GGO_C}
 )
-target_link_libraries(rtkspectraldenoiseprojections RTK)
+target_link_libraries(rtkspectraldenoiseprojections ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkspectraldenoiseprojections

--- a/applications/rtkspectralforwardmodel/CMakeLists.txt
+++ b/applications/rtkspectralforwardmodel/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkspectralforwardmodel.cxx
   ${rtkspectralforwardmodel_GGO_C}
 )
-target_link_libraries(rtkspectralforwardmodel RTK)
+target_link_libraries(rtkspectralforwardmodel ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkspectralforwardmodel

--- a/applications/rtkspectralonestep/CMakeLists.txt
+++ b/applications/rtkspectralonestep/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkspectralonestep.cxx
   ${rtkspectralonestep_GGO_C}
 )
-target_link_libraries(rtkspectralonestep RTK)
+target_link_libraries(rtkspectralonestep ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkspectralonestep

--- a/applications/rtkspectralrooster/CMakeLists.txt
+++ b/applications/rtkspectralrooster/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkspectralrooster.cxx
   ${rtkspectralrooster_GGO_C}
 )
-target_link_libraries(rtkspectralrooster RTK)
+target_link_libraries(rtkspectralrooster ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkspectralrooster

--- a/applications/rtkspectralsimplexdecomposition/CMakeLists.txt
+++ b/applications/rtkspectralsimplexdecomposition/CMakeLists.txt
@@ -4,7 +4,10 @@ add_executable(
   rtkspectralsimplexdecomposition.cxx
   ${rtkspectralsimplexdecomposition_GGO_C}
 )
-target_link_libraries(rtkspectralsimplexdecomposition RTK)
+target_link_libraries(
+  rtkspectralsimplexdecomposition
+  ${RTK_APPLICATION_TARGETS}
+)
 
 set_target_properties(
   rtkspectralsimplexdecomposition

--- a/applications/rtksubselect/CMakeLists.txt
+++ b/applications/rtksubselect/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtksubselect.cxx
   ${rtksubselect_GGO_C}
 )
-target_link_libraries(rtksubselect RTK)
+target_link_libraries(rtksubselect ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtksubselect

--- a/applications/rtktotalnuclearvariationdenoising/CMakeLists.txt
+++ b/applications/rtktotalnuclearvariationdenoising/CMakeLists.txt
@@ -4,7 +4,10 @@ add_executable(
   rtktotalnuclearvariationdenoising.cxx
   ${rtktotalnuclearvariationdenoising_GGO_C}
 )
-target_link_libraries(rtktotalnuclearvariationdenoising RTK)
+target_link_libraries(
+  rtktotalnuclearvariationdenoising
+  ${RTK_APPLICATION_TARGETS}
+)
 
 set_target_properties(
   rtktotalnuclearvariationdenoising

--- a/applications/rtktotalvariationdenoising/CMakeLists.txt
+++ b/applications/rtktotalvariationdenoising/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtktotalvariationdenoising.cxx
   ${rtktotalvariationdenoising_GGO_C}
 )
-target_link_libraries(rtktotalvariationdenoising RTK)
+target_link_libraries(rtktotalvariationdenoising ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtktotalvariationdenoising

--- a/applications/rtktutorialapplication/CMakeLists.txt
+++ b/applications/rtktutorialapplication/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtktutorialapplication.cxx
   ${rtktutorialapplication_GGO_C}
 )
-target_link_libraries(rtktutorialapplication RTK)
+target_link_libraries(rtktutorialapplication ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtktutorialapplication

--- a/applications/rtkvarianobigeometry/CMakeLists.txt
+++ b/applications/rtkvarianobigeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkvarianobigeometry.cxx
   ${rtkvarianobigeometry_GGO_C}
 )
-target_link_libraries(rtkvarianobigeometry RTK)
+target_link_libraries(rtkvarianobigeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkvarianobigeometry

--- a/applications/rtkvarianprobeamgeometry/CMakeLists.txt
+++ b/applications/rtkvarianprobeamgeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkvarianprobeamgeometry.cxx
   ${rtkvarianprobeamgeometry_GGO_C}
 )
-target_link_libraries(rtkvarianprobeamgeometry RTK)
+target_link_libraries(rtkvarianprobeamgeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkvarianprobeamgeometry

--- a/applications/rtkvectorconjugategradient/CMakeLists.txt
+++ b/applications/rtkvectorconjugategradient/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkvectorconjugategradient.cxx
   ${rtkvectorconjugategradient_GGO_C}
 )
-target_link_libraries(rtkvectorconjugategradient RTK)
+target_link_libraries(rtkvectorconjugategradient ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkvectorconjugategradient

--- a/applications/rtkwaveletsdenoising/CMakeLists.txt
+++ b/applications/rtkwaveletsdenoising/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkwaveletsdenoising.cxx
   ${rtkwaveletsdenoising_GGO_C}
 )
-target_link_libraries(rtkwaveletsdenoising RTK)
+target_link_libraries(rtkwaveletsdenoising ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkwaveletsdenoising

--- a/applications/rtkxradgeometry/CMakeLists.txt
+++ b/applications/rtkxradgeometry/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
   rtkxradgeometry.cxx
   ${rtkxradgeometry_GGO_C}
 )
-target_link_libraries(rtkxradgeometry RTK)
+target_link_libraries(rtkxradgeometry ${RTK_APPLICATION_TARGETS})
 
 set_target_properties(
   rtkxradgeometry

--- a/examples/AddNoise/CMakeLists.txt
+++ b/examples/AddNoise/CMakeLists.txt
@@ -4,12 +4,25 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(AddNoise)
 
 # Find ITK with RTK
-find_package(ITK REQUIRED COMPONENTS RTK)
-include(itkVersion)
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    RTK
+    ITKImageIO
+)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_EXAMPLE_TARGETS ${ITK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_EXAMPLE_TARGETS
+    ${ITK_INTERFACE_LIBRARIES}
+    ITK::ITKImageIO
+  )
 endif()
 
 # Executable(s)
 add_executable(AddNoise AddNoise.cxx)
-target_link_libraries(AddNoise ${ITK_LIBRARIES})
+target_link_libraries(AddNoise ${RTK_EXAMPLE_TARGETS})

--- a/examples/ConjugateGradient/CMakeLists.txt
+++ b/examples/ConjugateGradient/CMakeLists.txt
@@ -4,12 +4,25 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(ConjugateGradient)
 
 # Find ITK with RTK
-find_package(ITK REQUIRED COMPONENTS RTK)
-include(itkVersion)
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    RTK
+    ITKImageIO
+)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_EXAMPLE_TARGETS ${ITK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_EXAMPLE_TARGETS
+    ${ITK_INTERFACE_LIBRARIES}
+    ITK::ITKImageIO
+  )
 endif()
 
 # Executable(s)
 add_executable(ConjugateGradient ConjugateGradient.cxx)
-target_link_libraries(ConjugateGradient ${ITK_LIBRARIES})
+target_link_libraries(ConjugateGradient ${RTK_EXAMPLE_TARGETS})

--- a/examples/FirstReconstruction/CMakeLists.txt
+++ b/examples/FirstReconstruction/CMakeLists.txt
@@ -4,16 +4,32 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(FirstReconstruction)
 
 # Find ITK with RTK
-find_package(ITK REQUIRED COMPONENTS RTK)
-include(itkVersion)
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    RTK
+    ITKImageIO
+)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_EXAMPLE_TARGETS ${ITK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_EXAMPLE_TARGETS
+    ${ITK_INTERFACE_LIBRARIES}
+    ITK::ITKImageIO
+    ITK::ITKFFTImageFilterInit
+  )
+  message(ITK_INTERFACE_LIBRARIES=${ITK_INTERFACE_LIBRARIES})
 endif()
 
 # Executable(s)
 add_executable(FirstReconstruction FirstReconstruction.cxx)
-target_link_libraries(FirstReconstruction ${ITK_LIBRARIES})
+target_link_libraries(FirstReconstruction ${RTK_EXAMPLE_TARGETS})
+
 if(${RTK_USE_CUDA})
   add_executable(FirstCudaReconstruction FirstCudaReconstruction.cxx)
-  target_link_libraries(FirstCudaReconstruction ${ITK_LIBRARIES})
+  target_link_libraries(FirstCudaReconstruction ${RTK_EXAMPLE_TARGETS})
 endif()

--- a/examples/GeometricPhantom/CMakeLists.txt
+++ b/examples/GeometricPhantom/CMakeLists.txt
@@ -4,12 +4,26 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(GeometricPhantom)
 
 # Find ITK with RTK
-find_package(ITK REQUIRED COMPONENTS RTK)
-include(itkVersion)
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    RTK
+    ITKImageIO
+)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_EXAMPLE_TARGETS ${ITK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_EXAMPLE_TARGETS
+    ${ITK_INTERFACE_LIBRARIES}
+    ITK::ITKImageIO
+    ITK::ITKFFTImageFilterInit
+  )
 endif()
 
 # Executable(s)
 add_executable(GeometricPhantom GeometricPhantom.cxx)
-target_link_libraries(GeometricPhantom ${ITK_LIBRARIES})
+target_link_libraries(GeometricPhantom ${RTK_EXAMPLE_TARGETS})

--- a/examples/InlineReconstruction/CMakeLists.txt
+++ b/examples/InlineReconstruction/CMakeLists.txt
@@ -4,12 +4,26 @@ cmake_minimum_required(VERSION 3.9.5 FATAL_ERROR)
 project(InlineReconstruction)
 
 # Find ITK with RTK
-find_package(ITK REQUIRED COMPONENTS RTK)
-include(itkVersion)
+find_package(
+  ITK
+  REQUIRED
+  COMPONENTS
+    RTK
+    ITKImageIO
+)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(RTK_EXAMPLE_TARGETS ${ITK_LIBRARIES})
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_EXAMPLE_TARGETS
+    ${ITK_INTERFACE_LIBRARIES}
+    ITK::ITKImageIO
+    ITK::ITKFFTImageFilterInit
+  )
 endif()
 
 # Executable(s)
 add_executable(InlineReconstruction InlineReconstruction.cxx)
-target_link_libraries(InlineReconstruction ${ITK_LIBRARIES})
+target_link_libraries(InlineReconstruction ${RTK_EXAMPLE_TARGETS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,20 @@ find_package(
 include(itkVersion)
 if("${ITK_VERSION_MAJOR}" VERSION_LESS "6")
   include(${ITK_USE_FILE})
+  set(
+    RTK_TEST_TARGETS
+    ${RTK_LIBRARIES}
+    ${ITK_LIBRARIES}
+  )
+else()
+  itk_generate_factory_registration()
+  set(
+    RTK_TEST_TARGETS
+    ITK::RTKModule
+    ITK::ITKImageIO
+    ITK::ITKFFTImageFilterInit
+    ITK::ITKTestKernel
+  )
 endif()
 
 #-----------------------------------------------------------------------------
@@ -34,11 +48,7 @@ endif()
 # Add regular test as opposed to tests depending on CUDA
 function(rtk_add_test testname testfile)
   add_executable(${testname} ${testfile})
-  target_link_libraries(
-    ${testname}
-    ${RTK_LIBRARIES}
-    ${ITK_LIBRARIES}
-  )
+  target_link_libraries(${testname} ${RTK_TEST_TARGETS})
   itk_add_test(NAME ${testname}
     COMMAND itkTestDriver
     $<TARGET_FILE:${testname}>
@@ -52,11 +62,7 @@ endfunction()
 function(rtk_add_cuda_test testname testfile)
   if(RTK_USE_CUDA)
     add_executable(${testname} ${testfile})
-    target_link_libraries(
-      ${testname}
-      ${RTK_LIBRARIES}
-      ${ITK_LIBRARIES}
-    )
+    target_link_libraries(${testname} ${RTK_TEST_TARGETS})
     itk_add_test(NAME ${testname}
       COMMAND itkTestDriver
       $<TARGET_FILE:${testname}>


### PR DESCRIPTION
See
https://docs.itk.org/en/latest/migration_guides/itk_6_migration_guide.html#migration-for-itk-modules for a detailed explanation.