### PR TITLE
COMP: Add missing itkImageRegionIteratorWithIndex.h include

### DIFF
--- a/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
+++ b/include/rtkLUTbasedVariableI0RawToAttenuationImageFilter.hxx
@@ -20,8 +20,7 @@
 #define rtkLUTbasedVariableI0RawToAttenuationImageFilter_hxx
 
 
-#include <itkImageRegionConstIterator.h>
-#include <itkImageRegionIterator.h>
+#include <itkImageRegionIteratorWithIndex.h>
 #include "rtkI0EstimationProjectionFilter.h"
 
 namespace rtk


### PR DESCRIPTION
The problem has been introduced by f2e10aad71c639d2fa421a1ba6784f86ed4a1b39.