### PR TITLE
Fix typo in rtk3Doutputimage_group.py

### DIFF
--- a/applications/rtk3Doutputimage_group.py
+++ b/applications/rtk3Doutputimage_group.py
@@ -46,7 +46,7 @@ def SetConstantImageSourceFromArgParse(source, args_info):
     ImageType = type(source.GetOutput())
 
     # Handle deprecated --dimension argument
-    if args_info.dimension is not None and args_info.Size is None:
+    if args_info.dimension is not None and args_info.size is None:
         print(
             "Warning: '--dimension' is deprecated and will be removed in a future release. "
             "Please use '--size' instead."


### PR DESCRIPTION
When `--size` is provided, the variable is set to `args_info.size` and not `args_info.Size`, as added by #833. This fix avoids `AttributeError`s when the check is triggered.

```
AttributeError: 'Namespace' object has no attribute 'Size'. Did you mean: 'size'?
```