### PR TITLE
COMP: Drop use of itk::Math::Absolute to fix compilation warnings

### DIFF
--- a/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
+++ b/applications/rtkprojectionmatrix/rtkprojectionmatrix.cxx
@@ -114,7 +114,7 @@ main(int argc, char * argv[])
     return EXIT_FAILURE;
   }
   const OutputImageType::DirectionType dir = reader->GetOutput()->GetDirection();
-  if (itk::Math::Absolute(dir[0][0]) != 1. || itk::Math::Absolute(dir[1][1]) != 1.)
+  if (std::abs(dir[0][0]) != 1. || std::abs(dir[1][1]) != 1.)
   {
     std::cerr << "Projections with non-diagonal Direction is not handled." << std::endl;
     return EXIT_FAILURE;

--- a/include/rtkBackProjectionImageFilter.hxx
+++ b/include/rtkBackProjectionImageFilter.hxx
@@ -235,12 +235,12 @@ BackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerateDat
     }
 
     // Optimized version
-    if (itk::Math::Absolute(matrix[1][0]) < 1e-10 && itk::Math::Absolute(matrix[2][0]) < 1e-10)
+    if (std::abs(matrix[1][0]) < 1e-10 && std::abs(matrix[2][0]) < 1e-10)
     {
       OptimizedBackprojectionX(outputRegionForThread, matrix, projection);
       continue;
     }
-    if (itk::Math::Absolute(matrix[1][1]) < 1e-10 && itk::Math::Absolute(matrix[2][1]) < 1e-10)
+    if (std::abs(matrix[1][1]) < 1e-10 && std::abs(matrix[2][1]) < 1e-10)
     {
       OptimizedBackprojectionY(outputRegionForThread, matrix, projection);
       continue;

--- a/include/rtkConditionalMedianImageFilter.hxx
+++ b/include/rtkConditionalMedianImageFilter.hxx
@@ -95,7 +95,7 @@ ConditionalMedianImageFilter<TInputImage>::DynamicThreadedGenerateData(
     std::nth_element(pixels.begin(), pixels.begin() + pixels.size() / 2, pixels.end());
 
     // If the pixel value is too far from the median, replace it by the median
-    if (itk::Math::Absolute(pixels[pixels.size() / 2] - nIt.GetCenterPixel()) > (m_ThresholdMultiplier * stdev))
+    if (std::abs<double>(pixels[pixels.size() / 2] - nIt.GetCenterPixel()) > (m_ThresholdMultiplier * stdev))
       outIt.Set(pixels[pixels.size() / 2]);
     else // Otherwise, leave it as is
       outIt.Set(nIt.GetCenterPixel());

--- a/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
+++ b/include/rtkDisplacedDetectorForOffsetFieldOfViewImageFilter.hxx
@@ -84,7 +84,7 @@ DisplacedDetectorForOffsetFieldOfViewImageFilter<TInputImage, TOutputImage>::Gen
                              << " space must be covered by all projections.");
   }
   // Case 2: Not displaced if less than 10% relative difference between radii
-  else if (200. * itk::Math::Absolute(ri - rs) / (ri + rs) < 10.)
+  else if (200. * std::abs(ri - rs) / (ri + rs) < 10.)
   {
   }
   else if (rs > ri)

--- a/include/rtkDisplacedDetectorImageFilter.hxx
+++ b/include/rtkDisplacedDetectorImageFilter.hxx
@@ -150,8 +150,7 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::GenerateOutputInformati
                              << " Corner inf=" << m_InferiorCorner << " and corner sup=" << m_SuperiorCorner);
   }
   // Case 2: Not displaced, or explicit request not to pad: default outputLargestPossibleRegion is fine
-  else if ((itk::Math::Absolute(m_InferiorCorner + m_SuperiorCorner) <
-            0.1 * itk::Math::Absolute(m_SuperiorCorner - m_InferiorCorner)) ||
+  else if ((std::abs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * std::abs(m_SuperiorCorner - m_InferiorCorner)) ||
            !m_PadOnTruncatedSide)
   {
   }
@@ -197,8 +196,7 @@ DisplacedDetectorImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
   }
 
   // Not displaced, nothing to do
-  if ((itk::Math::Absolute(m_InferiorCorner + m_SuperiorCorner) <
-       0.1 * itk::Math::Absolute(m_SuperiorCorner - m_InferiorCorner)) ||
+  if ((std::abs(m_InferiorCorner + m_SuperiorCorner) < 0.1 * std::abs(m_SuperiorCorner - m_InferiorCorner)) ||
       m_Disable)
   {
     // If not in place, copy is required

--- a/include/rtkFDKBackProjectionImageFilter.hxx
+++ b/include/rtkFDKBackProjectionImageFilter.hxx
@@ -104,12 +104,12 @@ FDKBackProjectionImageFilter<TInputImage, TOutputImage>::DynamicThreadedGenerate
     matrix /= perspFactor;
 
     // Optimized version
-    if (itk::Math::Absolute(matrix[1][0]) < 1e-10 && itk::Math::Absolute(matrix[2][0]) < 1e-10)
+    if (std::abs(matrix[1][0]) < 1e-10 && std::abs(matrix[2][0]) < 1e-10)
     {
       OptimizedBackprojectionX(outputRegionForThread, matrix, projection);
       continue;
     }
-    if (itk::Math::Absolute(matrix[1][1]) < 1e-10 && itk::Math::Absolute(matrix[2][1]) < 1e-10)
+    if (std::abs(matrix[1][1]) < 1e-10 && std::abs(matrix[2][1]) < 1e-10)
     {
       OptimizedBackprojectionY(outputRegionForThread, matrix, projection);
       continue;

--- a/include/rtkFDKWeightProjectionFilter.hxx
+++ b/include/rtkFDKWeightProjectionFilter.hxx
@@ -56,7 +56,7 @@ FDKWeightProjectionFilter<TInputImage, TOutputImage>::BeforeThreadedGenerateData
       sp = m_Geometry->GetSourcePosition(k);
       sp[3] = 0.;
       const double sid = m_Geometry->GetSourceToIsocenterDistances()[k];
-      m_ConstantProjectionFactor[k] *= itk::Math::Absolute(sdd) / (2. * sid * sid);
+      m_ConstantProjectionFactor[k] *= std::abs(sdd) / (2. * sid * sid);
       m_ConstantProjectionFactor[k] *= sp.GetNorm();
     }
   }

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -274,7 +274,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
   {
     for (int proj = FirstProj + 1; proj < FirstProj + NumberProjs; proj++)
     {
-      if (itk::Math::Absolute(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
+      if (std::abs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
       {
         // Compute the number of projections in the current slab
         sizeOfSlabs.push_back(proj - firstProjectionInSlabs[firstProjectionInSlabs.size() - 1]);

--- a/include/rtkImagXGeometryReader.hxx
+++ b/include/rtkImagXGeometryReader.hxx
@@ -643,7 +643,7 @@ ImagXGeometryReader<TInputImage>::interpolate(const std::vector<float> & flexAng
   float delta = 0.f; // to closest angle in flexmap
   for (int i = 0; i < N; ++i)
   {
-    float absdelta = itk::Math::Absolute(angleDegree - flexAngles[i]);
+    float absdelta = std::abs(angleDegree - flexAngles[i]);
     if (absdelta <= minv)
     {
       idc = i;
@@ -675,7 +675,7 @@ ImagXGeometryReader<TInputImage>::interpolate(const std::vector<float> & flexAng
   {
     if (delta > 0.f)
     {
-      float a = itk::Math::Absolute(delta / (flexAngles[idc + 1] - flexAngles[idc]));
+      float a = std::abs(delta / (flexAngles[idc + 1] - flexAngles[idc]));
       ires.id0 = idc;
       ires.id1 = idc + 1;
       ires.a0 = 1.f - a;
@@ -683,7 +683,7 @@ ImagXGeometryReader<TInputImage>::interpolate(const std::vector<float> & flexAng
     }
     else if (delta < 0.f)
     {
-      float a = itk::Math::Absolute(delta / (flexAngles[idc] - flexAngles[idc - 1]));
+      float a = std::abs(delta / (flexAngles[idc] - flexAngles[idc - 1]));
       ires.id0 = idc - 1;
       ires.id1 = idc;
       ires.a0 = a;
@@ -694,7 +694,7 @@ ImagXGeometryReader<TInputImage>::interpolate(const std::vector<float> & flexAng
   {
     if (delta < 0.f)
     {
-      float a = itk::Math::Absolute(delta / (flexAngles[idc + 1] - flexAngles[idc]));
+      float a = std::abs(delta / (flexAngles[idc + 1] - flexAngles[idc]));
       ires.id0 = idc;
       ires.id1 = idc + 1;
       ires.a0 = 1.f - a;
@@ -702,7 +702,7 @@ ImagXGeometryReader<TInputImage>::interpolate(const std::vector<float> & flexAng
     }
     else if (delta > 0.f)
     {
-      float a = itk::Math::Absolute(delta / (flexAngles[idc] - flexAngles[idc - 1]));
+      float a = std::abs(delta / (flexAngles[idc] - flexAngles[idc - 1]));
       ires.id0 = idc - 1;
       ires.id1 = idc;
       ires.a0 = a;

--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.hxx
@@ -112,8 +112,8 @@ JosephBackAttenuatedProjectionImageFilter<TInputImage,
 
         // tolerance for origin and spacing depends on the size of pixel
         // tolerance for directions a fraction of the unit cube.
-        const double coordinateTol = itk::Math::Absolute(Self::GetGlobalDefaultCoordinateTolerance() *
-                                                         inputPtr1->GetSpacing()[0]); // use first dimension spacing
+        const double coordinateTol = std::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                              inputPtr1->GetSpacing()[0]); // use first dimension spacing
 
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
             !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -138,7 +138,7 @@ JosephBackProjectionImageFilter<TInputImage,
     BoxShape::VectorType dirVoxAbs;
     for (unsigned int i = 0; i < Dimension; i++)
     {
-      dirVoxAbs[i] = itk::Math::Absolute(dirVox[i]);
+      dirVoxAbs[i] = std::abs(dirVox[i]);
       if (dirVoxAbs[i] > dirVoxAbs[mainDir])
         mainDir = i;
     }
@@ -209,7 +209,7 @@ JosephBackProjectionImageFilter<TInputImage,
       bool isNewRay = true;
       if (fs == ns) // If the voxel is a corner, we can skip most steps
       {
-        attenuationRay += BilinearInterpolationOnBorders(itk::Math::Absolute(fp[mainDir] - np[mainDir]),
+        attenuationRay += BilinearInterpolationOnBorders(std::abs(fp[mainDir] - np[mainDir]),
                                                          pxiyi,
                                                          pxsyi,
                                                          pxiys,
@@ -225,7 +225,7 @@ JosephBackProjectionImageFilter<TInputImage,
         const typename TInputImage::PixelType & rayValue =
           m_SumAlongRay(itIn->Value(), attenuationRay, stepMM, isNewRay);
         BilinearSplatOnBorders(rayValue,
-                               itk::Math::Absolute(fp[mainDir] - np[mainDir]),
+                               std::abs(fp[mainDir] - np[mainDir]),
                                stepMM.GetNorm(),
                                pxiyi,
                                pxsyi,
@@ -274,7 +274,7 @@ JosephBackProjectionImageFilter<TInputImage,
         currenty += stepy;
 
         // Middle steps
-        for (int i{ 0 }; i < itk::Math::Absolute(fs - ns) - 1; ++i)
+        for (int i{ 0 }; i < std::abs(fs - ns) - 1; ++i)
         {
           attenuationRay += BilinearInterpolation(1., pxiyi, pxsyi, pxiys, pxsys, currentx, currenty, offsetx, offsety);
 

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.hxx
@@ -118,8 +118,8 @@ JosephForwardAttenuatedProjectionImageFilter<TInputImage,
 
         // tolerance for origin and spacing depends on the size of pixel
         // tolerance for directions a fraction of the unit cube.
-        const double coordinateTol = itk::Math::Absolute(Self::GetGlobalDefaultCoordinateTolerance() *
-                                                         inputPtr1->GetSpacing()[0]); // use first dimension spacing
+        const double coordinateTol = std::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                              inputPtr1->GetSpacing()[0]); // use first dimension spacing
 
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
             !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -126,8 +126,8 @@ JosephForwardProjectionImageFilter<TInputImage,
 
         // tolerance for origin and spacing depends on the size of pixel
         // tolerance for directions a fraction of the unit cube.
-        const double coordinateTol = itk::Math::Absolute(Self::GetGlobalDefaultCoordinateTolerance() *
-                                                         inputPtr1->GetSpacing()[0]); // use first dimension spacing
+        const double coordinateTol = std::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                              inputPtr1->GetSpacing()[0]); // use first dimension spacing
 
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
             !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||
@@ -250,7 +250,7 @@ JosephForwardProjectionImageFilter<TInputImage,
     typename BoxShape::VectorType dirVoxAbs;
     for (unsigned int i = 0; i < Dimension; i++)
     {
-      dirVoxAbs[i] = itk::Math::Absolute(dirVox[i]);
+      dirVoxAbs[i] = std::abs(dirVox[i]);
       if (dirVoxAbs[i] > dirVoxAbs[mainDir])
         mainDir = i;
     }
@@ -337,7 +337,7 @@ JosephForwardProjectionImageFilter<TInputImage,
       if (fs == ns) // If the voxel is a corner, we can skip most steps
       {
         volumeValue = BilinearInterpolationOnBorders(threadId,
-                                                     itk::Math::Absolute(fp[mainDir] - np[mainDir]),
+                                                     std::abs(fp[mainDir] - np[mainDir]),
                                                      pxiyi,
                                                      pxsyi,
                                                      pxiys,
@@ -380,7 +380,7 @@ JosephForwardProjectionImageFilter<TInputImage,
         currenty += stepy;
 
         // Middle steps
-        for (int i{ 0 }; i < itk::Math::Absolute(fs - ns) - 1; ++i)
+        for (int i{ 0 }; i < std::abs(fs - ns) - 1; ++i)
         {
           volumeValue =
             BilinearInterpolation(threadId, 1., pxiyi, pxsyi, pxiys, pxsys, currentx, currenty, offsetx, offsety);

--- a/include/rtkParkerShortScanImageFilter.hxx
+++ b/include/rtkParkerShortScanImageFilter.hxx
@@ -95,8 +95,8 @@ ParkerShortScanImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedReg
     double invsid = 1. / sqrt(sid * sid + sox * sox);
 
     // Check that Parker weighting is relevant for this projection
-    double halfDetectorWidth1 = itk::Math::Absolute(m_Geometry->ToUntiltedCoordinateAtIsocenter(k, corner1[0]));
-    double halfDetectorWidth2 = itk::Math::Absolute(m_Geometry->ToUntiltedCoordinateAtIsocenter(k, corner2[0]));
+    double halfDetectorWidth1 = std::abs(m_Geometry->ToUntiltedCoordinateAtIsocenter(k, corner1[0]));
+    double halfDetectorWidth2 = std::abs(m_Geometry->ToUntiltedCoordinateAtIsocenter(k, corner2[0]));
     double halfDetectorWidth = std::min(halfDetectorWidth1, halfDetectorWidth2);
     if (m_Delta < atan(halfDetectorWidth * invsid))
     {

--- a/include/rtkPhaseGatingImageFilter.hxx
+++ b/include/rtkPhaseGatingImageFilter.hxx
@@ -50,9 +50,8 @@ PhaseGatingImageFilter<ProjectionStackType>::ComputeWeights()
   // Compute the gating weights
   for (float m_Phase : m_Phases)
   {
-    distance = std::min(itk::Math::Absolute(m_GatingWindowCenter - 1 - m_Phase),
-                        itk::Math::Absolute(m_GatingWindowCenter - m_Phase));
-    distance = std::min(distance, itk::Math::Absolute(m_GatingWindowCenter + 1.f - m_Phase));
+    distance = std::min(std::abs(m_GatingWindowCenter - 1 - m_Phase), std::abs(m_GatingWindowCenter - m_Phase));
+    distance = std::min(distance, std::abs(m_GatingWindowCenter + 1.f - m_Phase));
 
     switch (m_GatingWindowShape)
     {

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -226,7 +226,7 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
   {
     for (int proj = FirstProj + 1; proj < FirstProj + NumberProjs; proj++)
     {
-      if (itk::Math::Absolute(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
+      if (std::abs(m_Signal[proj] - m_Signal[proj - 1]) > 1e-4)
       {
         // Compute the number of projections in the current slab
         sizeOfSlabs.push_back(proj - firstProjectionInSlabs[firstProjectionInSlabs.size() - 1]);

--- a/include/rtkScatterGlareCorrectionImageFilter.hxx
+++ b/include/rtkScatterGlareCorrectionImageFilter.hxx
@@ -79,8 +79,8 @@ ScatterGlareCorrectionImageFilter<TInputImage, TOutputImage, TFFTPrecision>::Upd
   while (!itK.IsAtEnd())
   {
     idx = itK.GetIndex();
-    double xx = halfXSz - itk::Math::Absolute(halfXSz - idx[0]); // Distance to nearest x border
-    double yy = halfYSz - itk::Math::Absolute(halfYSz - idx[1]); // Distance to nearest y border
+    double xx = halfXSz - std::abs(halfXSz - idx[0]); // Distance to nearest x border
+    double yy = halfYSz - std::abs(halfYSz - idx[1]); // Distance to nearest y border
     double rr2 = (xx * xx + yy * yy);
     g = (a3 * dx * dy / (2. * itk::Math::pi * b3sq)) / std::pow((1. + rr2 / b3sq), 1.5);
     itK.Set(g);

--- a/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
+++ b/include/rtkSelectOneProjectionPerCycleImageFilter.hxx
@@ -57,7 +57,7 @@ SelectOneProjectionPerCycleImageFilter<ProjectionStackType>::GenerateOutputInfor
     // Frame is selected if phase is increasing and has opposite signs
     if (valPrev < valAfter && valAfter * valPrev <= 0.)
     {
-      if (itk::Math::Absolute(valPrev) > itk::Math::Absolute(valAfter))
+      if (std::abs(valPrev) > std::abs(valAfter))
       {
         this->m_SelectedProjections[i + 1] = true;
         this->m_NbSelectedProjs++;

--- a/include/rtkSoftThresholdImageFilter.h
+++ b/include/rtkSoftThresholdImageFilter.h
@@ -72,7 +72,7 @@ public:
   inline TOutput
   operator()(const TInput & A) const
   {
-    return (itk::Math::sgn(A) * std::max((TInput)itk::Math::Absolute(A) - m_Threshold, (TInput)0.0));
+    return (itk::Math::sgn(A) * std::max((TInput)std::abs(A) - m_Threshold, (TInput)0.0));
   }
 
 private:

--- a/include/rtkZengBackProjectionImageFilter.hxx
+++ b/include/rtkZengBackProjectionImageFilter.hxx
@@ -120,8 +120,8 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::VerifyInputInformation
 
         // tolerance for origin and spacing depends on the size of pixel
         // tolerance for directions a fraction of the unit cube.
-        const double coordinateTol = itk::Math::Absolute(Self::GetGlobalDefaultCoordinateTolerance() *
-                                                         inputPtr1->GetSpacing()[0]); // use first dimension spacing
+        const double coordinateTol = std::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                              inputPtr1->GetSpacing()[0]); // use first dimension spacing
 
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
             !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||

--- a/include/rtkZengForwardProjectionImageFilter.hxx
+++ b/include/rtkZengForwardProjectionImageFilter.hxx
@@ -121,8 +121,8 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::VerifyInputInformat
 
         // tolerance for origin and spacing depends on the size of pixel
         // tolerance for directions a fraction of the unit cube.
-        const double coordinateTol = itk::Math::Absolute(Self::GetGlobalDefaultCoordinateTolerance() *
-                                                         inputPtr1->GetSpacing()[0]); // use first dimension spacing
+        const double coordinateTol = std::abs(Self::GetGlobalDefaultCoordinateTolerance() *
+                                              inputPtr1->GetSpacing()[0]); // use first dimension spacing
 
         if (!inputPtr1->GetOrigin().GetVnlVector().is_equal(inputPtrN->GetOrigin().GetVnlVector(), coordinateTol) ||
             !inputPtr1->GetSpacing().GetVnlVector().is_equal(inputPtrN->GetSpacing().GetVnlVector(), coordinateTol) ||

--- a/rtkConfiguration.h.in
+++ b/rtkConfiguration.h.in
@@ -55,19 +55,6 @@ using ThreadIdType = itk::ThreadIdType;
 #  define USE_FFTWD
 #endif
 
-/* Fix for ITK5 */
-#if ITK_VERSION_MAJOR<6
-namespace itk::Math
-{
-template <typename T>
-auto
-Absolute(T x)
-{
-  return itk::Math::abs(x);
-}
-}
-#endif
-
 #define RTK_VERSION_MAJOR @RTK_VERSION_MAJOR@
 #define RTK_VERSION_MINOR @RTK_VERSION_MINOR@
 #define RTK_VERSION_PATCH @RTK_VERSION_PATCH@

--- a/src/rtkConditionalMedianImageFilter.cxx
+++ b/src/rtkConditionalMedianImageFilter.cxx
@@ -60,8 +60,7 @@ rtk::ConditionalMedianImageFilter<itk::VectorImage<float, 3>>::DynamicThreadedGe
       std::nth_element(pixels[mat].begin(), pixels[mat].begin() + pixels[mat].size() / 2, pixels[mat].end());
 
       // If the pixel value is too far from the median, replace it by the median
-      if (itk::Math::Absolute(pixels[mat][pixels[mat].size() / 2] - nIt.GetCenterPixel()[mat]) >
-          (m_ThresholdMultiplier * stdev))
+      if (std::abs(pixels[mat][pixels[mat].size() / 2] - nIt.GetCenterPixel()[mat]) > (m_ThresholdMultiplier * stdev))
         vlv[mat] = pixels[mat][pixels[mat].size() / 2];
       else // Otherwise, leave it as is
         vlv[mat] = nIt.GetCenterPixel()[mat];

--- a/src/rtkCudaDisplacedDetectorImageFilter.cxx
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cxx
@@ -48,8 +48,8 @@ CudaDisplacedDetectorImageFilter ::GPUGenerateData()
   outBuffer += this->GetOutput()->ComputeOffset(this->GetOutput()->GetRequestedRegion().GetIndex());
 
   // nothing to do
-  if ((itk::Math::Absolute(this->GetInferiorCorner() + this->GetSuperiorCorner()) <
-       0.1 * itk::Math::Absolute(this->GetSuperiorCorner() - this->GetInferiorCorner())) ||
+  if ((std::abs(this->GetInferiorCorner() + this->GetSuperiorCorner()) <
+       0.1 * std::abs(this->GetSuperiorCorner() - this->GetInferiorCorner())) ||
       this->GetDisable())
   {
     if (outBuffer != inBuffer)

--- a/src/rtkCudaFDKWeightProjectionFilter.cxx
+++ b/src/rtkCudaFDKWeightProjectionFilter.cxx
@@ -48,7 +48,7 @@ CudaFDKWeightProjectionFilter ::GPUGenerateData()
       sp = this->GetGeometry()->GetSourcePosition(g);
       sp[3] = 0.;
       const double sid = this->GetGeometry()->GetSourceToIsocenterDistances()[g];
-      constantProjectionFactor[g] *= itk::Math::Absolute(sdd) / (2. * sid * sid);
+      constantProjectionFactor[g] *= std::abs(sdd) / (2. * sid * sid);
       constantProjectionFactor[g] *= sp.GetNorm();
     }
   }

--- a/src/rtkDigisensGeometryReader.cxx
+++ b/src/rtkDigisensGeometryReader.cxx
@@ -66,8 +66,8 @@ rtk::DigisensGeometryReader ::GenerateData()
   }
 
   // Source / Detector / Center distances
-  double sdd = itk::Math::Absolute(sourcePosition[2] - detectorPosition[2]);
-  double sid = itk::Math::Absolute(sourcePosition[2] - rotationCenter[2]);
+  double sdd = std::abs(sourcePosition[2] - detectorPosition[2]);
+  double sid = std::abs(sourcePosition[2] - rotationCenter[2]);
 
   // Scaling
   using MetaDataIntegerType = itk::MetaDataObject<int>;

--- a/src/rtkForbildPhantomFileReader.cxx
+++ b/src/rtkForbildPhantomFileReader.cxx
@@ -424,7 +424,7 @@ ForbildPhantomFileReader::ComputeRotationMatrixBetweenVectors(const VectorType &
   RotationMatrixType r;
   r.SetIdentity();
   ScalarType c = s * d;
-  if (itk::Math::Absolute(c) - 1. == itk::NumericTraits<ScalarType>::ZeroValue())
+  if (std::abs(c) - 1. == itk::NumericTraits<ScalarType>::ZeroValue())
   {
     return r;
   }

--- a/src/rtkQuadricShape.cxx
+++ b/src/rtkQuadricShape.cxx
@@ -117,7 +117,7 @@ QuadricShape ::IsIntersectedByRay(const PointType &  rayOrigin,
     // The epsilon value allows detection of very close intersections, i.e., a
     // ray tangent to the quadric
     static constexpr ScalarType eps = 1e5 * itk::NumericTraits<ScalarType>::epsilon();
-    if (itk::Math::Absolute(discriminant) <= eps)
+    if (std::abs(discriminant) <= eps)
     {
       infDist = -Bq / (2 * Aq);
       supDist = infDist;

--- a/src/rtkThreeDCircularProjectionGeometry.cxx
+++ b/src/rtkThreeDCircularProjectionGeometry.cxx
@@ -165,7 +165,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const PointType &  sourcePo
   const PointType &  S = sourcePosition;          // source pos
   const PointType &  R = detectorPosition;        // detector pos
 
-  if (itk::Math::Absolute(r * c) > 1e-6) // non-orthogonal row/column vectors
+  if (std::abs(r * c) > 1e-6) // non-orthogonal row/column vectors
     return false;
 
   // Euler angles (ZXY convention) from detector orientation in IEC-based WCS:
@@ -222,7 +222,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const PointType &  sourcePo
   double SID = n[0] * S[0] + n[1] * S[1] + n[2] * S[2];
   // SDD: distance from source to detector along detector normal
   double SDD = n[0] * (S[0] - R[0]) + n[1] * (S[1] - R[1]) + n[2] * (S[2] - R[2]);
-  if (itk::Math::Absolute(SDD) < 1.0E-06)
+  if (std::abs(SDD) < 1.0E-06)
   {
     itkDebugMacro(<< "SourceDetectorDistance is less than 1.0E-06. For parallel geometry SDD is set to 0.0");
     SDD = 0.0;
@@ -269,7 +269,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const HomogeneousProjection
              pMat(0, 2) * pMat(1, 0) * pMat(2, 1) - pMat(0, 0) * pMat(1, 2) * pMat(2, 1) -
              pMat(0, 1) * pMat(1, 0) * pMat(2, 2) - pMat(0, 2) * pMat(1, 1) * pMat(2, 0);
 
-  if (itk::Math::Absolute(d) < std::numeric_limits<double>::epsilon()) // parallel geometry
+  if (std::abs(d) < std::numeric_limits<double>::epsilon()) // parallel geometry
   {
     // setup rotation matrix from three rotated unit vectors
     // v1, v2 - standard unit vectors, n - normal (cross product) [v1,v2]
@@ -312,7 +312,7 @@ rtk::ThreeDCircularProjectionGeometry::AddProjection(const HomogeneousProjection
     return true;
   }
 
-  d = -1. * d / itk::Math::Absolute(d);
+  d = -1. * d / std::abs(d);
 
   // Extract intrinsic parameters u0, v0 and f (f is chosen to be positive at that point)
   // The extraction of u0 and v0 is independant of KR-decomp.
@@ -658,7 +658,7 @@ rtk::ThreeDCircularProjectionGeometry::ToUntiltedCoordinateAtIsocenter(const uns
 
   // the following relation refers to a note by R. Clackdoyle, title
   // "Samping a tilted detector"
-  return l * itk::Math::Absolute(sid) / (sidu - l * cosa);
+  return l * std::abs(sid) / (sidu - l * cosa);
 }
 
 bool
@@ -683,7 +683,7 @@ rtk::ThreeDCircularProjectionGeometry::VerifyAngles(const double          outOfP
 
   for (int i = 0; i < 3; i++) // check whether matrices match
     for (int j = 0; j < 3; j++)
-      if (itk::Math::Absolute(rm[i][j] - m[i][j]) > m_VerifyAnglesTolerance)
+      if (std::abs(rm[i][j] - m[i][j]) > m_VerifyAnglesTolerance)
         return false;
 
   return true;
@@ -697,7 +697,7 @@ rtk::ThreeDCircularProjectionGeometry::FixAngles(double &              outOfPlan
 {
   const Matrix3x3Type & rm = referenceMatrix; // shortcut
 
-  if (itk::Math::Absolute(itk::Math::Absolute(rm[2][1]) - 1.) > m_FixAnglesTolerance)
+  if (std::abs(std::abs(rm[2][1]) - 1.) > m_FixAnglesTolerance)
   {
     double oa = NAN, ga = NAN, ia = NAN;
 

--- a/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
+++ b/src/rtkThreeDCircularProjectionGeometryXMLFileReader.cxx
@@ -153,7 +153,7 @@ ThreeDCircularProjectionGeometryXMLFileReader::EndElement(const char * name)
       {
         // Tolerance can not be vcl_numeric_limits<double>::epsilon(), too strict
         // 0.001 is a random choice to catch "large" inconsistencies
-        if (itk::Math::Absolute(m_Matrix[i][j] - m_OutputObject->GetMatrices().back()[i][j]) > 0.001)
+        if (std::abs(m_Matrix[i][j] - m_OutputObject->GetMatrices().back()[i][j]) > 0.001)
         {
           itkGenericExceptionMacro(<< "Matrix and parameters are not consistent." << std::endl
                                    << "Read matrix from geometry file: " << std::endl

--- a/test/rtkTest.h
+++ b/test/rtkTest.h
@@ -57,7 +57,7 @@ CheckImageQuality(typename TImage::Pointer recon,
   {
     typename TImage::PixelType TestVal = itTest.Get();
     typename TImage::PixelType RefVal = itRef.Get();
-    TestError += itk::Math::Absolute(RefVal - TestVal);
+    TestError += std::abs(RefVal - TestVal);
     EnerError += std::pow(ErrorType(RefVal - TestVal), 2.);
     ++itTest;
     ++itRef;
@@ -302,7 +302,7 @@ CheckGeometries(const rtk::ThreeDCircularProjectionGeometry * g1, const rtk::Thr
     std::cerr << "Unequal number of projections in the two geometries" << std::endl;
     exit(EXIT_FAILURE);
   }
-  if (e < itk::Math::Absolute(g1->GetRadiusCylindricalDetector() - g2->GetRadiusCylindricalDetector()))
+  if (e < std::abs(g1->GetRadiusCylindricalDetector() - g2->GetRadiusCylindricalDetector()))
   {
     std::cerr << "Geometries don't have the same cylindrical detector radius" << std::endl;
     exit(EXIT_FAILURE);
@@ -312,21 +312,21 @@ CheckGeometries(const rtk::ThreeDCircularProjectionGeometry * g1, const rtk::Thr
   {
     // std::cout << g1->GetGantryAngles()[i] << " " << g2->GetGantryAngles()[i] << std::endl;
     if (e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              itk::Math::Absolute(g1->GetGantryAngles()[i] - g2->GetGantryAngles()[i])) ||
+              std::abs(g1->GetGantryAngles()[i] - g2->GetGantryAngles()[i])) ||
         e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              itk::Math::Absolute(g1->GetOutOfPlaneAngles()[i] - g2->GetOutOfPlaneAngles()[i])) ||
+              std::abs(g1->GetOutOfPlaneAngles()[i] - g2->GetOutOfPlaneAngles()[i])) ||
         e < rtk::ThreeDCircularProjectionGeometry::ConvertAngleBetween0And2PIRadians(
-              itk::Math::Absolute(g1->GetInPlaneAngles()[i] - g2->GetInPlaneAngles()[i])) ||
-        e < itk::Math::Absolute(g1->GetSourceToIsocenterDistances()[i] - g2->GetSourceToIsocenterDistances()[i]) ||
-        e < itk::Math::Absolute(g1->GetSourceOffsetsX()[i] - g2->GetSourceOffsetsX()[i]) ||
-        e < itk::Math::Absolute(g1->GetSourceOffsetsY()[i] - g2->GetSourceOffsetsY()[i]) ||
-        e < itk::Math::Absolute(g1->GetSourceToDetectorDistances()[i] - g2->GetSourceToDetectorDistances()[i]) ||
-        e < itk::Math::Absolute(g1->GetProjectionOffsetsX()[i] - g2->GetProjectionOffsetsX()[i]) ||
-        e < itk::Math::Absolute(g1->GetProjectionOffsetsY()[i] - g2->GetProjectionOffsetsY()[i]) ||
-        e < itk::Math::Absolute(g1->GetCollimationUInf()[i] - g2->GetCollimationUInf()[i]) ||
-        e < itk::Math::Absolute(g1->GetCollimationVInf()[i] - g2->GetCollimationVInf()[i]) ||
-        e < itk::Math::Absolute(g1->GetCollimationUSup()[i] - g2->GetCollimationUSup()[i]) ||
-        e < itk::Math::Absolute(g1->GetCollimationVSup()[i] - g2->GetCollimationVSup()[i]))
+              std::abs(g1->GetInPlaneAngles()[i] - g2->GetInPlaneAngles()[i])) ||
+        e < std::abs(g1->GetSourceToIsocenterDistances()[i] - g2->GetSourceToIsocenterDistances()[i]) ||
+        e < std::abs(g1->GetSourceOffsetsX()[i] - g2->GetSourceOffsetsX()[i]) ||
+        e < std::abs(g1->GetSourceOffsetsY()[i] - g2->GetSourceOffsetsY()[i]) ||
+        e < std::abs(g1->GetSourceToDetectorDistances()[i] - g2->GetSourceToDetectorDistances()[i]) ||
+        e < std::abs(g1->GetProjectionOffsetsX()[i] - g2->GetProjectionOffsetsX()[i]) ||
+        e < std::abs(g1->GetProjectionOffsetsY()[i] - g2->GetProjectionOffsetsY()[i]) ||
+        e < std::abs(g1->GetCollimationUInf()[i] - g2->GetCollimationUInf()[i]) ||
+        e < std::abs(g1->GetCollimationVInf()[i] - g2->GetCollimationVInf()[i]) ||
+        e < std::abs(g1->GetCollimationUSup()[i] - g2->GetCollimationUSup()[i]) ||
+        e < std::abs(g1->GetCollimationVSup()[i] - g2->GetCollimationVSup()[i]))
     {
       std::cerr << "Geometry of projection #" << i << " is unvalid." << std::endl;
       exit(EXIT_FAILURE);
@@ -404,7 +404,7 @@ CheckScalarProducts(typename TImage1::Pointer im1A,
 
 
   // Checking results
-  if (!(itk::Math::Absolute(ratio - 1) < 0.001))
+  if (!(std::abs(ratio - 1) < 0.001))
   {
     std::cerr << "Test Failed, ratio not valid! " << ratio << " instead of 1 +/- 0.001" << std::endl;
     exit(EXIT_FAILURE);
@@ -484,7 +484,7 @@ CheckVectorScalarProducts(typename TImage1::Pointer im1A,
 
 
   // Checking results
-  if (!(itk::Math::Absolute(ratio - 1) < 0.001))
+  if (!(std::abs(ratio - 1) < 0.001))
   {
     std::cerr << "Test Failed, ratio not valid! " << ratio << " instead of 1 +/- 0.001" << std::endl;
     exit(EXIT_FAILURE);

--- a/test/rtkTestReg23ProjectionGeometry.cxx
+++ b/test/rtkTestReg23ProjectionGeometry.cxx
@@ -292,8 +292,8 @@ main(int argc, char * argv[])
     {
       for (std::size_t i = 0; i < referenceMarkerProjections.size(); ++i)
       {
-        if (itk::Math::Absolute(referenceMarkerProjections[i][0] - rtkMarkerProjections[i][0]) > EPSILON ||
-            itk::Math::Absolute(referenceMarkerProjections[i][1] - rtkMarkerProjections[i][1]) > EPSILON)
+        if (std::abs(referenceMarkerProjections[i][0] - rtkMarkerProjections[i][0]) > EPSILON ||
+            std::abs(referenceMarkerProjections[i][1] - rtkMarkerProjections[i][1]) > EPSILON)
         {
           VERBOSE(<< "\nAngle-combination out-of-plane=" << anglesList[i][0] << ", gantry=" << anglesList[i][1]
                   << ", in-plane=" << anglesList[i][2] << " failed:\n")

--- a/test/rtkadmmwaveletstest.cxx
+++ b/test/rtkadmmwaveletstest.cxx
@@ -34,7 +34,7 @@ CheckImageQuality(typename TImage::Pointer recon, typename TImage::Pointer ref)
   {
     typename TImage::PixelType TestVal = itTest.Get();
     typename TImage::PixelType RefVal = itRef.Get();
-    TestError += itk::Math::Absolute(RefVal - TestVal);
+    TestError += std::abs(RefVal - TestVal);
     EnerError += std::pow(ErrorType(RefVal - TestVal), 2.);
     ++itTest;
     ++itRef;

--- a/test/rtkamsterdamshroudtest.cxx
+++ b/test/rtkamsterdamshroudtest.cxx
@@ -225,7 +225,7 @@ main(int argc, char * argv[])
   unsigned int                                  i = 0;
   itk::ImageRegionConstIterator<reg1DImageType> it(reg1DSignal, reg1DSignal->GetLargestPossibleRegion());
   for (it.GoToBegin(); !it.IsAtEnd(); ++it, i++)
-    sum += itk::Math::Absolute(reg1D[i] - it.Get());
+    sum += std::abs(reg1D[i] - it.Get());
 
   if (sum <= zeroValue)
     std::cout << "Test PASSED! " << std::endl;
@@ -261,7 +261,7 @@ main(int argc, char * argv[])
   i = 0;
   itk::ImageRegionConstIterator<reg1DImageType> itDP(DPSignal, DPSignal->GetLargestPossibleRegion());
   for (itDP.GoToBegin(); !itDP.IsAtEnd(); ++itDP, i++)
-    sum += itk::Math::Absolute(DP[i] - itDP.Get());
+    sum += std::abs(DP[i] - itDP.Get());
 
   if (sum <= zeroValue)
     std::cout << "Test PASSED! " << std::endl;
@@ -299,7 +299,7 @@ main(int argc, char * argv[])
                                0.58f, 0.63f, 0.68f, 0.72f };
   itk::ImageRegionConstIterator<reg1DImageType> itPhaseLocal(phase, phase->GetLargestPossibleRegion());
   for (sum = 0, i = 0; !itPhaseLocal.IsAtEnd(); ++itPhaseLocal, i++)
-    sum += itk::Math::Absolute(refLocalPhase[i] - itPhaseLocal.Get());
+    sum += std::abs(refLocalPhase[i] - itPhaseLocal.Get());
   std::cout << "LOCAL_PHASE... ";
   if (sum <= 0.27)
     std::cout << "Test PASSED! " << std::endl;
@@ -324,7 +324,7 @@ main(int argc, char * argv[])
 
   itk::ImageRegionConstIterator<reg1DImageType> itPhaseMax(phase, phase->GetLargestPossibleRegion());
   for (sum = 0, i = 0; !itPhaseMax.IsAtEnd(); ++itPhaseMax, i++)
-    sum += itk::Math::Absolute(refMaxPhase[i] - itPhaseMax.Get());
+    sum += std::abs(refMaxPhase[i] - itPhaseMax.Get());
   std::cout << "LINEAR_BETWEEN_MAXIMA... ";
   if (sum <= 0.081)
     std::cout << "Test PASSED! " << std::endl;
@@ -349,7 +349,7 @@ main(int argc, char * argv[])
 
   itk::ImageRegionConstIterator<reg1DImageType> itPhaseMin(phase, phase->GetLargestPossibleRegion());
   for (sum = 0, i = 0; !itPhaseMin.IsAtEnd(); ++itPhaseMin, i++)
-    sum += itk::Math::Absolute(refMinPhase[i] - itPhaseMin.Get());
+    sum += std::abs(refMinPhase[i] - itPhaseMin.Get());
   std::cout << "LINEAR_BETWEEN_MINIMA... ";
   if (sum <= 0.076)
     std::cout << "Test PASSED! " << std::endl;

--- a/test/rtkconjugategradienttest.cxx
+++ b/test/rtkconjugategradienttest.cxx
@@ -45,7 +45,7 @@ CheckImageQuality(typename TImage1::Pointer recon, typename TImage2::Pointer ref
 
     if (TestVal != RefVal)
     {
-      TestError += itk::Math::Absolute(RefVal - TestVal);
+      TestError += std::abs(RefVal - TestVal);
       EnerError += std::pow(ErrorType(RefVal - TestVal), 2.);
     }
     ++itTest;

--- a/test/rtkcroptest.cxx
+++ b/test/rtkcroptest.cxx
@@ -35,7 +35,7 @@ main(int, char **)
   ImageType::IndexType index;
   index.Fill(2);
 
-  if (itk::Math::Absolute(crop->GetOutput()->GetPixel(index) - 12.3) > 0.0001)
+  if (std::abs(crop->GetOutput()->GetPixel(index) - 12.3) > 0.0001)
   {
     std::cout << "Output should be 12.3. Value Computed = " << crop->GetOutput()->GetPixel(index) << std::endl;
     return EXIT_FAILURE;

--- a/test/rtkfourdconjugategradienttest.cxx
+++ b/test/rtkfourdconjugategradienttest.cxx
@@ -139,7 +139,7 @@ main(int, char **)
     // Ellipse 2
     auto e2 = REIType::New();
     semiprincipalaxis.Fill(8.);
-    center[0] = 4 * (itk::Math::Absolute((4 + noProj) % 8 - 4.) - 2.);
+    center[0] = 4 * (std::abs((4 + noProj) % 8 - 4.) - 2.);
     center[1] = 0.;
     center[2] = 0.;
     e2->SetInput(e1->GetOutput());
@@ -198,7 +198,7 @@ main(int, char **)
     axis2.Fill(8.);
     de2->SetAxis(axis2);
     DEType::VectorType center2;
-    center2[0] = 4 * (itk::Math::Absolute((4 + n) % 8 - 4.) - 2.);
+    center2[0] = 4 * (std::abs((4 + n) % 8 - 4.) - 2.);
     center2[1] = 0.;
     center2[2] = 0.;
     de2->SetCenter(center2);

--- a/test/rtkfourdroostertest.cxx
+++ b/test/rtkfourdroostertest.cxx
@@ -142,7 +142,7 @@ main(int, char **)
     // Ellipse 2
     auto e2 = REIType::New();
     semiprincipalaxis.Fill(8.);
-    center[0] = 4 * (itk::Math::Absolute((4 + noProj) % 8 - 4.) - 2.);
+    center[0] = 4 * (std::abs((4 + noProj) % 8 - 4.) - 2.);
     center[1] = 0.;
     center[2] = 0.;
     e2->SetInput(e1->GetOutput());
@@ -253,7 +253,7 @@ main(int, char **)
     axis2.Fill(8.);
     de2->SetAxis(axis2);
     DEType::VectorType center2;
-    center2[0] = 4 * (itk::Math::Absolute((4 + n) % 8 - 4.) - 2.);
+    center2[0] = 4 * (std::abs((4 + n) % 8 - 4.) - 2.);
     center2[1] = 0.;
     center2[2] = 0.;
     de2->SetCenter(center2);

--- a/test/rtkfourdsarttest.cxx
+++ b/test/rtkfourdsarttest.cxx
@@ -186,7 +186,7 @@ main(int, char **)
     // Ellipse 2
     auto e2 = REIType::New();
     semiprincipalaxis.Fill(8.);
-    center[0] = 4 * (itk::Math::Absolute((4 + noProj) % 8 - 4.) - 2.);
+    center[0] = 4 * (std::abs((4 + noProj) % 8 - 4.) - 2.);
     center[1] = 0.;
     center[2] = 0.;
     e2->SetInput(e1->GetOutput());
@@ -245,7 +245,7 @@ main(int, char **)
     axis2.Fill(8.);
     de2->SetAxis(axis2);
     DEType::VectorType center2;
-    center2[0] = 4 * (itk::Math::Absolute((4 + n) % 8 - 4.) - 2.);
+    center2[0] = 4 * (std::abs((4 + n) % 8 - 4.) - 2.);
     center2[1] = 0.;
     center2[2] = 0.;
     de2->SetCenter(center2);

--- a/test/rtkgaincorrectiontest.cxx
+++ b/test/rtkgaincorrectiontest.cxx
@@ -242,7 +242,7 @@ main(int, char **)
   float diffValue = 0.f;
   while (!itExp.IsAtEnd())
   {
-    diffValue += itk::Math::Absolute(itExp.Get() - itOut.Get());
+    diffValue += std::abs(itExp.Get() - itOut.Get());
     ++itExp;
     ++itOut;
   }

--- a/test/rtkgeometryfiletest.cxx
+++ b/test/rtkgeometryfiletest.cxx
@@ -30,7 +30,7 @@ WriteReadAndCheck(GeometryType * geometry)
   {                                                                                           \
     double val1 = geoRead->Get##paramName()[i];                                               \
     double val2 = geometry->Get##paramName()[i];                                              \
-    if (itk::Math::Absolute(val1 - val2) > epsilon)                                           \
+    if (std::abs(val1 - val2) > epsilon)                                                      \
     {                                                                                         \
       std::cerr << #paramName " differ [" << val1 << "] read from written file vs. [" << val2 \
                 << "] for the reference, difference=[" << val1 - val2 << "]." << std::endl;   \

--- a/test/rtkgeometryfrommatrixtest.cxx
+++ b/test/rtkgeometryfrommatrixtest.cxx
@@ -23,7 +23,7 @@ main(int, char **)
                     geometry2->AddProjection(geometry1->GetMatrices().back());
 
                     double d = geometry1->GetGantryAngles().back() - geometry2->GetGantryAngles().back();
-                    d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+                    d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
                     if (d > 0.01)
                     {
                       std::cerr << "ERROR: GantryAngles 1 is " << geometry1->GetGantryAngles().back()
@@ -32,7 +32,7 @@ main(int, char **)
                     }
 
                     d = geometry1->GetInPlaneAngles().back() - geometry2->GetInPlaneAngles().back();
-                    d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+                    d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
                     if (d > 0.01)
                     {
                       std::cerr << "ERROR: InPlaneAngles 1 is " << geometry1->GetInPlaneAngles().back()
@@ -41,7 +41,7 @@ main(int, char **)
                     }
 
                     d = geometry1->GetOutOfPlaneAngles().back() - geometry2->GetOutOfPlaneAngles().back();
-                    d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+                    d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
                     if (d > 0.01)
                     {
                       std::cerr << "ERROR: OutOfPlaneAngle 1 is " << geometry1->GetOutOfPlaneAngles().back()
@@ -49,24 +49,24 @@ main(int, char **)
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetProjectionOffsetsY().back() -
-                                            geometry2->GetProjectionOffsetsY().back()) > 0.01)
+                    if (std::abs(geometry1->GetProjectionOffsetsY().back() -
+                                 geometry2->GetProjectionOffsetsY().back()) > 0.01)
                     {
                       std::cerr << "ERROR: ProjectionOffsetsY 1 is " << geometry1->GetProjectionOffsetsY().back()
                                 << " and ProjectionOffsetsY 2 is " << geometry2->GetProjectionOffsetsY().back();
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetProjectionOffsetsX().back() -
-                                            geometry2->GetProjectionOffsetsX().back()) > 0.01)
+                    if (std::abs(geometry1->GetProjectionOffsetsX().back() -
+                                 geometry2->GetProjectionOffsetsX().back()) > 0.01)
                     {
                       std::cerr << "ERROR: ProjectionOffsetsX 1 is " << geometry1->GetProjectionOffsetsX().back()
                                 << " and ProjectionOffsetsX 2 is " << geometry2->GetProjectionOffsetsX().back();
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetSourceToIsocenterDistances().back() -
-                                            geometry2->GetSourceToIsocenterDistances().back()) > 0.01)
+                    if (std::abs(geometry1->GetSourceToIsocenterDistances().back() -
+                                 geometry2->GetSourceToIsocenterDistances().back()) > 0.01)
                     {
                       std::cerr << "ERROR: GetSourceToIsocenterDistances 1 is "
                                 << geometry1->GetSourceToIsocenterDistances().back()
@@ -75,8 +75,8 @@ main(int, char **)
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetSourceToDetectorDistances().back() -
-                                            geometry2->GetSourceToDetectorDistances().back()) > 0.01)
+                    if (std::abs(geometry1->GetSourceToDetectorDistances().back() -
+                                 geometry2->GetSourceToDetectorDistances().back()) > 0.01)
                     {
                       std::cerr << "ERROR: GetSourceToDetectorDistances 1 is "
                                 << geometry1->GetSourceToDetectorDistances().back()
@@ -85,16 +85,14 @@ main(int, char **)
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetSourceOffsetsY().back() -
-                                            geometry2->GetSourceOffsetsY().back()) > 0.01)
+                    if (std::abs(geometry1->GetSourceOffsetsY().back() - geometry2->GetSourceOffsetsY().back()) > 0.01)
                     {
                       std::cerr << "ERROR: SourceOffsetsY 1 is " << geometry1->GetSourceOffsetsY().back()
                                 << " and SourceOffsetsY 2 is " << geometry2->GetSourceOffsetsY().back();
                       return EXIT_FAILURE;
                     }
 
-                    if (itk::Math::Absolute(geometry1->GetSourceOffsetsX().back() -
-                                            geometry2->GetSourceOffsetsX().back()) > 0.01)
+                    if (std::abs(geometry1->GetSourceOffsetsX().back() - geometry2->GetSourceOffsetsX().back()) > 0.01)
                     {
                       std::cerr << "ERROR: SourceOffsetsX 1 is " << geometry1->GetSourceOffsetsX().back()
                                 << " and SourceOffsetsX 2 is " << geometry2->GetSourceOffsetsX().back();

--- a/test/rtkgradienttest.cxx
+++ b/test/rtkgradienttest.cxx
@@ -52,8 +52,8 @@ CheckGradient(typename TImage::Pointer im, typename TGradient::Pointer grad, con
   {
     for (std::vector<int>::size_type k = 0; k < dimsToProcess.size(); k++)
     {
-      AbsDiff = itk::Math::Absolute(iit.GetPixel(c + strides[dimsToProcess[k]]) - iit.GetPixel(c) -
-                                    itGrad.Get()[k] * grad->GetSpacing()[k]);
+      AbsDiff = std::abs(iit.GetPixel(c + strides[dimsToProcess[k]]) - iit.GetPixel(c) -
+                         itGrad.Get()[k] * grad->GetSpacing()[k]);
 
       // Checking results
       if (AbsDiff > epsilon)

--- a/test/rtkimporttest.cxx
+++ b/test/rtkimporttest.cxx
@@ -43,7 +43,7 @@ CheckError(typename TImage::Pointer     recon,
   while (!itTest.IsAtEnd())
   {
     typename TImage::PixelType TestVal = itTest.Get();
-    TestError += itk::Math::Absolute(ErrorType(ref[k] - TestVal));
+    TestError += std::abs(ErrorType(ref[k] - TestVal));
     EnerError += std::pow(ErrorType(ref[k] - TestVal), 2.);
     ++itTest;
     ++k;

--- a/test/rtkmotioncompensatedfdktest.cxx
+++ b/test/rtkmotioncompensatedfdktest.cxx
@@ -111,7 +111,7 @@ main(int, char **)
     e2->SetGeometry(oneProjGeometry);
     e2->SetDensity(-1.);
     e2->SetAxis(itk::MakeVector(8., 8., 8.));
-    e2->SetCenter(itk::MakeVector(4 * (itk::Math::Absolute((4 + noProj) % 8 - 4.) - 2.), 0., 0.));
+    e2->SetCenter(itk::MakeVector(4 * (std::abs((4 + noProj) % 8 - 4.) - 2.), 0., 0.));
     e2->SetAngle(0.);
     e2->Update();
 

--- a/test/rtkparallelgeometryfrommatrixtest.cxx
+++ b/test/rtkparallelgeometryfrommatrixtest.cxx
@@ -27,7 +27,7 @@ main(int, char **)
             double g1 = geometry1->GetGantryAngles().back();
             double g2 = geometry2->GetGantryAngles().back();
             double d = g1 - g2;
-            d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
             if (d > 0.01)
             {
               std::cerr << "ERROR: GantryAngles 1 is " << g1 << " and GantryAngles 2 is " << g2;
@@ -37,7 +37,7 @@ main(int, char **)
             double ia1 = geometry1->GetInPlaneAngles().back();
             double ia2 = geometry2->GetInPlaneAngles().back();
             d = ia1 - ia2;
-            d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
             if (d > 0.01)
             {
               std::cerr << "ERROR: InPlaneAngles 1 is " << ia1 << " and InPlaneAngles 2 is " << ia2;
@@ -47,7 +47,7 @@ main(int, char **)
             double oa1 = geometry1->GetOutOfPlaneAngles().back();
             double oa2 = geometry2->GetOutOfPlaneAngles().back();
             d = oa1 - oa2;
-            d = itk::Math::Absolute(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
+            d = std::abs(geometry1->ConvertAngleBetweenMinusAndPlusPIRadians(d));
             if (d > 0.01)
             {
               std::cerr << "ERROR: OutOfPlaneAngle 1 is " << oa1 << " and OutOfPlaneAngle 2 is " << oa2;
@@ -56,7 +56,7 @@ main(int, char **)
 
             double py1 = geometry1->GetProjectionOffsetsY().back();
             double py2 = geometry2->GetProjectionOffsetsY().back();
-            d = itk::Math::Absolute(py1 - py2);
+            d = std::abs(py1 - py2);
             if (d > 0.01)
             {
               std::cerr << "ERROR: ProjectionOffsetsY 1 is " << py1 << " and ProjectionOffsetsY 2 is " << py2;
@@ -65,7 +65,7 @@ main(int, char **)
 
             double px1 = geometry1->GetProjectionOffsetsX().back();
             double px2 = geometry2->GetProjectionOffsetsX().back();
-            d = itk::Math::Absolute(px1 - px2);
+            d = std::abs(px1 - px2);
             if (d > 0.01)
             {
               std::cerr << "ERROR: ProjectionOffsetsX 1 is " << px1 << " and ProjectionOffsetsX 2 is " << px2;
@@ -74,7 +74,7 @@ main(int, char **)
 
             double sid1 = geometry1->GetSourceToIsocenterDistances().back();
             double sid2 = geometry2->GetSourceToIsocenterDistances().back();
-            d = itk::Math::Absolute(sid1 - sid2);
+            d = std::abs(sid1 - sid2);
             if (d > 0.01)
             {
               std::cerr << "ERROR: GetSourceToIsocenterDistances 1 is " << sid1
@@ -84,7 +84,7 @@ main(int, char **)
 
             double sdd1 = geometry1->GetSourceToDetectorDistances().back();
             double sdd2 = geometry2->GetSourceToDetectorDistances().back();
-            d = itk::Math::Absolute(sdd1 - sdd2);
+            d = std::abs(sdd1 - sdd2);
             if (d > 0.01)
             {
               std::cerr << "ERROR: GetSourceToDetectorDistances 1 is " << sdd1

--- a/test/rtkrampfiltertest2.cxx
+++ b/test/rtkrampfiltertest2.cxx
@@ -53,7 +53,7 @@ main(int, char **)
   // Check the results
   auto  index = itk::MakeIndex(3, 21, 26);
   float value = 0.132652;
-  if (itk::Math::Absolute(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (std::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #0 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;
@@ -64,7 +64,7 @@ main(int, char **)
   rampFilter->SetHannCutFrequency(0.8);
   rampFilter->Update();
   value = 0.149724;
-  if (itk::Math::Absolute(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (std::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #1 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;
@@ -75,7 +75,7 @@ main(int, char **)
   rampFilter->SetHannCutFrequencyY(0.1);
   rampFilter->Update();
   value = 0.150181;
-  if (itk::Math::Absolute(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
+  if (std::abs(rampFilter->GetOutput()->GetPixel(index) - value) > 0.000001)
   {
     std::cout << "Output value #2 should be " << value << " found " << rampFilter->GetOutput()->GetPixel(index)
               << " instead." << std::endl;

--- a/test/rtkscatterglarefiltertest.cxx
+++ b/test/rtkscatterglarefiltertest.cxx
@@ -132,7 +132,7 @@ main(int, char **)
     ++itO;
   }
 
-  if (!((itk::Math::Absolute(spikeValueOut - spikeValue) < 1e-2) && (itk::Math::Absolute(sumBng) < 1e-2)))
+  if (!((std::abs(spikeValueOut - spikeValue) < 1e-2) && (std::abs(sumBng) < 1e-2)))
   {
     std::cerr << "Test Failed! " << std::endl;
     exit(EXIT_FAILURE);

--- a/test/rtkselectoneprojpercycletest.cxx
+++ b/test/rtkselectoneprojpercycletest.cxx
@@ -90,7 +90,7 @@ main(int, char **)
     // Ellipse 2
     auto e2 = REIType::New();
     semiprincipalaxis.Fill(8.);
-    center[0] = 4 * (itk::Math::Absolute((4 + noProj) % 8 - 4.) - 2.);
+    center[0] = 4 * (std::abs((4 + noProj) % 8 - 4.) - 2.);
     center[1] = 0.;
     center[2] = 0.;
     e2->SetInput(e1->GetOutput());

--- a/test/rtkwaveletstest.cxx
+++ b/test/rtkwaveletstest.cxx
@@ -29,7 +29,7 @@ CheckImageQuality(typename TImage::Pointer recon, typename TImage::Pointer ref)
   {
     typename TImage::PixelType TestVal = itTest.Get();
     typename TImage::PixelType RefVal = itRef.Get();
-    TestError += itk::Math::Absolute(RefVal - TestVal);
+    TestError += std::abs(RefVal - TestVal);
     EnerError += std::pow(ErrorType(RefVal - TestVal), 2.);
     ++itTest;
     ++itRef;


### PR DESCRIPTION
InsightSoftwareConsortium/ITK#5802 and #904 have triggered new warnings such as
```
[CTest: warning matched] /home/srit/src/rtk/dashboard_tests/RTK/include/rtkJosephBackProjectionImageFilter.hxx:277:28: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
  277 |         for (int i{ 0 }; i < itk::Math::Absolute(fs - ns) - 1; ++i)
```
The new behavior is intentional but returning an unsigned is problematic in this case as we subtract 1 from it. So we now use `std::abs` throughout the code