### PR TITLE
COMP: Remove uninialized variable warning in wavelet filters

### DIFF
--- a/include/rtkDeconstructImageFilter.hxx
+++ b/include/rtkDeconstructImageFilter.hxx
@@ -95,7 +95,7 @@ DeconstructImageFilter<TImage>::GeneratePassVectors()
   m_PassVectors.clear();
   for (unsigned int vectIndex = 0; vectIndex < n; vectIndex++)
   {
-    typename ConvolutionFilterType::PassVector temp;
+    typename ConvolutionFilterType::PassVector temp{};
     m_PassVectors.push_back(temp);
   }
 

--- a/include/rtkReconstructImageFilter.hxx
+++ b/include/rtkReconstructImageFilter.hxx
@@ -73,7 +73,7 @@ ReconstructImageFilter<TImage>::GeneratePassVectors()
   m_PassVectors.clear();
   for (unsigned int vectIndex = 0; vectIndex < n; vectIndex++)
   {
-    typename ConvolutionFilterType::PassVector temp;
+    typename ConvolutionFilterType::PassVector temp{};
     m_PassVectors.push_back(temp);
   }
 


### PR DESCRIPTION
GCC warnings were, e.g.,
```
/usr/include/c++/13/bits/stl_vector.h:1292:28: warning: ‘temp’ may be used uninitialized [-Wmaybe-uninitialized]
```