### PR TITLE
Make application argument names consistent

### DIFF
--- a/CodeContribution.md
+++ b/CodeContribution.md
@@ -4,6 +4,8 @@
 
 RTK is based on ITK and aims at following its coding conventions. Any developer should follow these conventions when submitting new code or contributions to the existing one. We strongly recommend you to read thoroughly [ITK's style guide](http://www.itk.org/Wiki/ITK/Coding_Style_Guide).
 
+All (new) command-line options in applications must use hyphen-separated lowercase names (for example, `output-file`), following the [glibc convention](https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_node/libc_511.html). This rule applies to both C++ and Python applications. Some existing options not following this style are kept for backward compatibility.
+
 ## Testing
 
 This section describes how to add/edit datasets for testing purposes for RTK. Datasets are not stored in the GIT repository for efficiency and also to avoid having large history due to binary files. Instead the files are stored on a [Girder](http://data.kitware.com) instance. Here's the recipe to add new datasets:
@@ -20,6 +22,8 @@ RTK_ADD_TEST(NAME rtkimagxtest
     DATA{Data/Input/ImagX/raw.xml,raw.raw}
     DATA{Data/Baseline/ImagX/attenuation.mha})
 ```
+
+
 ## Dashboard
 
 *   The RTK dashboard is available at [RTK Dashboard](http://my.cdash.org/index.php?project=RTK)

--- a/applications/rtkiterations_group.py
+++ b/applications/rtkiterations_group.py
@@ -10,12 +10,12 @@ __all__ = [
 def add_rtkiterations_group(parser):
     rtkiterations_group = parser.add_argument_group("Iteration reporting")
     rtkiterations_group.add_argument(
-        "--outputevery",
+        "--output-every",
         help="Output intermediate reconstruction after some iterations",
         type=int,
     )
     rtkiterations_group.add_argument(
-        "--iterationfilename",
+        "--iteration-file-name",
         help="File name to output intermediate iterations with {i} as a placeholder for iteration number",
     )
 
@@ -37,22 +37,22 @@ class VerboseEndCommand:
 
 # Mimicks OutputIterationCommand
 class OutputIterationCommand:
-    def __init__(self, reconstruction_filter, outputevery, iterationfilename):
+    def __init__(self, reconstruction_filter, output_every, iteration_file_name):
         self.count = 0
         self.reconstruction_filter = reconstruction_filter
-        self.outputevery = outputevery
-        self.iterationfilename = iterationfilename
+        self.output_every = output_every
+        self.iteration_file_name = iteration_file_name
 
     def callback(self):
         self.count = self.count + 1
-        if self.count % self.outputevery == 0:
+        if self.count % self.output_every == 0:
             output = self.reconstruction_filter.GetOutput()
             OutputImageType = type(output)
             if hasattr(output, "GetCudaDataManager"):
                 OutputImageType = OutputImageType.__bases__[0]
             writer = itk.ImageFileWriter[OutputImageType].New()
             writer.SetInput(output)
-            writer.SetFileName(self.iterationfilename.format(i=self.count))
+            writer.SetFileName(self.iteration_file_name.format(i=self.count))
             writer.Update()
 
 
@@ -63,8 +63,8 @@ def SetIterationsReportFromArgParse(args_info, filt):
         filt.AddObserver(itk.IterationEvent(), cmd.callback)
         cmd = VerboseEndCommand()
         filt.AddObserver(itk.EndEvent(), cmd.callback)
-    if args_info.outputevery is not None:
+    if args_info.output_every is not None:
         cmd = OutputIterationCommand(
-            filt, args_info.outputevery, args_info.iterationfilename
+            filt, args_info.output_every, args_info.iteration_file_name
         )
         filt.AddObserver(itk.IterationEvent(), cmd.callback)

--- a/applications/rtkshowgeometry/rtkshowgeometry.py
+++ b/applications/rtkshowgeometry/rtkshowgeometry.py
@@ -12,10 +12,10 @@ def build_parser():
 
     parser.add_argument("--geometry", "-g", help="Geometry file name", required=True)
     parser.add_argument(
-        "--show_trajectory", "-t", help="Show source trajectory", action="store_true"
+        "--show-trajectory", "-t", help="Show source trajectory", action="store_true"
     )
     parser.add_argument("--input", "-i", help="Input volume")
-    parser.add_argument("--hide_volume", help="hide input volume", action="store_true")
+    parser.add_argument("--hide-volume", help="hide input volume", action="store_true")
 
     rtk.add_rtkinputprojections_group(parser)
 

--- a/documentation/docs/rtk_3_migration_guide.md
+++ b/documentation/docs/rtk_3_migration_guide.md
@@ -1,5 +1,13 @@
 # RTK v3 migration guide
 
+## Python application options use hyphens
+
+Multi-word options in Python applications now use hyphens to match the C++
+applications and the GNU coding standards:
+`--outputevery` →`--output-every`,
+`--iterationfilename` → `--iteration-file-name`,
+`--hide_volume` → `--hide-volume`.
+
 ## Use `--size` instead of `--dimension`
 
 As of RTK 3.0, the `--dimension` argument in applications is deprecated and


### PR DESCRIPTION
Close #923 

I preferred harmonize all application argument names by using hyphens according to gnu convention