### PR TITLE
COMP :  Update to the new cuCtxCreate() for cuda 13

### DIFF
--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python3-minor-version: ${{ github.event_name == 'pull_request' && fromJSON('["11"]') || fromJSON('["9","10","11"]') }}
         manylinux-platform: ${{ github.event_name == 'pull_request' && fromJSON('["_2_28-x64"]') || fromJSON('["_2_28-x64","2014-x64"]') }}
-        cuda-version: ${{ github.event_name == 'pull_request' && fromJSON('["128"]') || fromJSON('["118","128","130"]') }}
+        cuda-version: ${{ github.event_name == 'pull_request' && fromJSON('["118","130"]') || fromJSON('["118","128","130"]') }}
 
     steps:
     - uses: actions/checkout@v4
@@ -244,7 +244,7 @@ jobs:
     - name: Test python wheel
       run: |
         # Find the CUDA 128 wheel for Python 3.11 dynamically
-        wheel=$(find wheels -name "*cuda128*cp311*manylinux_2_28_x86_64.whl" -type f | head -1)
+        wheel=$(find wheels -name "*cuda130*cp311*manylinux_2_28_x86_64.whl" -type f | head -1)
         pip uninstall -y $(pip freeze | sed -E 's/(==.*|[[:space:]]+@.*)$//' | grep -E '^itk-') || true
         echo "Installing wheel: $wheel"
         pip install $wheel

--- a/src/rtkCudaUtilities.cu
+++ b/src/rtkCudaUtilities.cu
@@ -57,7 +57,12 @@ GetFreeGPUGlobalMemory(int device)
 
   // create cuda context
   CUcontext cudaContext;
+#if CUDA_VERSION >= 13000
+  CUctxCreateParams ctxCreateParams = {};
+  result = cuCtxCreate(&cudaContext, &ctxCreateParams, CU_CTX_SCHED_AUTO, device);
+#else
   result = cuCtxCreate(&cudaContext, CU_CTX_SCHED_AUTO, device);
+#endif
   if (result != CUDA_SUCCESS)
   {
     itkGenericExceptionMacro(<< "Could not create context on this CUDA device");


### PR DESCRIPTION
CUDA 13.0 has replaced the older cuCtxCreate() function with a new version, so th  CUDA 13 cuCtxCreate signature is used with CUctxCreateParams in GetFreeGPUGlobalMemory, while keeping a fallback for older CUDA versions via CUDA_VERSION guards.