### PR TITLE
Fix pytest command in documentation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -61,7 +61,7 @@ This installs:
 
 After installing, run the tests with:
 ```
-pytest test/
+pytest test/*.py
 ```
 
 ### Documentation


### PR DESCRIPTION
The command currently given in the documentation is wrong and does not run any test.