### PR TITLE
ENH: Fix CUDA 2D FFT convolution for multi-projection inputs

### DIFF
--- a/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
+++ b/include/rtkCudaFFTProjectionsConvolutionImageFilter.hxx
@@ -91,85 +91,138 @@ template <class TParentImageFilter>
 void
 CudaFFTProjectionsConvolutionImageFilter<TParentImageFilter>::GPUGenerateData()
 {
-  // Pad image region
-  FFTInputImagePointer paddedImage = PadInputImageRegion(this->GetInput()->GetRequestedRegion());
+  auto convolveRegion = [this](const RegionType & requestedRegion) {
+    FFTInputImagePointer paddedImage = PadInputImageRegion(requestedRegion);
 
-  int3 inputDimension;
-  inputDimension.x = paddedImage->GetBufferedRegion().GetSize()[0];
-  inputDimension.y = paddedImage->GetBufferedRegion().GetSize()[1];
-  inputDimension.z = paddedImage->GetBufferedRegion().GetSize()[2];
-  if (inputDimension.y == 1 && inputDimension.z > 1) // Troubles cuda 3.2 and 4.0
-    std::swap(inputDimension.y, inputDimension.z);
+    int3 inputDimension;
+    inputDimension.x = paddedImage->GetBufferedRegion().GetSize()[0];
+    inputDimension.y = paddedImage->GetBufferedRegion().GetSize()[1];
+    inputDimension.z = paddedImage->GetBufferedRegion().GetSize()[2];
+    if (inputDimension.y == 1 && inputDimension.z > 1) // Troubles cuda 3.2 and 4.0
+      std::swap(inputDimension.y, inputDimension.z);
 
-  // Get FFT ramp kernel. Must be itk::Image because GetFFTProjectionsConvolutionKernel is not
-  // compatible with itk::CudaImage + ITK 3.20.
-  typename Superclass::FFTOutputImageType::SizeType s = paddedImage->GetLargestPossibleRegion().GetSize();
-  this->UpdateFFTProjectionsConvolutionKernel(s);
-  if (this->m_KernelFFTCUDA.GetPointer() == nullptr ||
-      this->m_KernelFFTCUDA->GetTimeStamp() < this->m_KernelFFT->GetTimeStamp())
-  {
-
-    // Create the itk::CudaImage holding the kernel
-    typename Superclass::FFTOutputImageType::RegionType kreg = this->m_KernelFFT->GetLargestPossibleRegion();
-
-    this->m_KernelFFTCUDA = CudaFFTOutputImageType::New();
-    this->m_KernelFFTCUDA->SetRegions(kreg);
-    this->m_KernelFFTCUDA->Allocate();
-
-    // CUFFT scales by the number of element, correct for it in kernel.
-    // Also transfer the kernel from the itk::Image to the itk::CudaImage.
-    itk::ImageRegionIterator<typename TParentImageFilter::FFTOutputImageType> itKI(this->m_KernelFFT, kreg);
-    itk::ImageRegionIterator<CudaFFTOutputImageType>                          itKO(this->m_KernelFFTCUDA, kreg);
-    typename TParentImageFilter::FFTPrecisionType                             invNPixels;
-    invNPixels = 1 / double(paddedImage->GetBufferedRegion().GetNumberOfPixels());
-    while (!itKO.IsAtEnd())
+    // Get FFT ramp kernel. Must be itk::Image because GetFFTProjectionsConvolutionKernel is not
+    // compatible with itk::CudaImage + ITK 3.20.
+    typename Superclass::FFTOutputImageType::SizeType s = paddedImage->GetLargestPossibleRegion().GetSize();
+    this->UpdateFFTProjectionsConvolutionKernel(s);
+    if (this->m_KernelFFTCUDA.GetPointer() == nullptr ||
+        this->m_KernelFFTCUDA->GetTimeStamp() < this->m_KernelFFT->GetTimeStamp())
     {
-      itKO.Set(itKI.Get() * invNPixels);
-      ++itKI;
-      ++itKO;
+
+      // Create the itk::CudaImage holding the kernel
+      typename Superclass::FFTOutputImageType::RegionType kreg = this->m_KernelFFT->GetLargestPossibleRegion();
+
+      this->m_KernelFFTCUDA = CudaFFTOutputImageType::New();
+      this->m_KernelFFTCUDA->SetRegions(kreg);
+      this->m_KernelFFTCUDA->Allocate();
+
+      // CUFFT scales by the number of element, correct for it in kernel.
+      // Also transfer the kernel from the itk::Image to the itk::CudaImage.
+      itk::ImageRegionIterator<typename TParentImageFilter::FFTOutputImageType> itKI(this->m_KernelFFT, kreg);
+      itk::ImageRegionIterator<CudaFFTOutputImageType>                          itKO(this->m_KernelFFTCUDA, kreg);
+      typename TParentImageFilter::FFTPrecisionType                             invNPixels;
+      invNPixels = 1 / double(paddedImage->GetBufferedRegion().GetNumberOfPixels());
+      while (!itKO.IsAtEnd())
+      {
+        itKO.Set(itKI.Get() * invNPixels);
+        ++itKI;
+        ++itKO;
+      }
     }
+
+    auto * cuPadImgP = dynamic_cast<CudaImageType *>(paddedImage.GetPointer());
+
+    int2 kernelDimension;
+    kernelDimension.x = this->m_KernelFFT->GetBufferedRegion().GetSize()[0];
+    kernelDimension.y = this->m_KernelFFT->GetBufferedRegion().GetSize()[1];
+    CUDA_fft_convolution(inputDimension,
+                         kernelDimension,
+#  ifdef CudaCommon_VERSION_MAJOR
+                         static_cast<float *>(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
+                         (float2 *)(this->m_KernelFFTCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
+#  else
+                         *(float **)(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
+                         *(float2 **)(this->m_KernelFFTCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
+#  endif
+
+    auto                                           cf = CudaCropImageFilter::New();
+    typename Superclass::OutputImageType::SizeType upCropSize, lowCropSize;
+    for (unsigned int i = 0; i < CudaImageType::ImageDimension; i++)
+    {
+      lowCropSize[i] = requestedRegion.GetIndex()[i] - paddedImage->GetLargestPossibleRegion().GetIndex()[i];
+      upCropSize[i] =
+        paddedImage->GetLargestPossibleRegion().GetSize()[i] - requestedRegion.GetSize()[i] - lowCropSize[i];
+    }
+    cf->SetUpperBoundaryCropSize(upCropSize);
+    cf->SetLowerBoundaryCropSize(lowCropSize);
+    cf->SetInput(cuPadImgP);
+    cf->Update();
+    auto croppedOutput = CudaImageType::New();
+    croppedOutput->Graft(cf->GetOutput());
+    return croppedOutput;
+  };
+
+  const RegionType requestedRegion = this->GetOutput()->GetRequestedRegion();
+  if (this->m_KernelDimension == 2 && requestedRegion.GetSize()[2] > 1)
+  {
+    auto assembledOutput = CudaImageType::New();
+    assembledOutput->SetRegions(this->GetOutput()->GetBufferedRegion());
+    assembledOutput->Allocate();
+    assembledOutput->CopyInformation(this->GetOutput());
+
+#  ifdef CudaCommon_VERSION_MAJOR
+    auto * outputBuffer = static_cast<float *>(assembledOutput->GetCudaDataManager()->GetGPUBufferPointer());
+#  else
+    float * outputBuffer = *(float **)(assembledOutput->GetCudaDataManager()->GetGPUBufferPointer());
+#  endif
+
+    const size_t pixelsPerProjection = requestedRegion.GetSize()[0] * requestedRegion.GetSize()[1];
+    for (typename RegionType::SizeType::SizeValueType projection = 0; projection < requestedRegion.GetSize()[2];
+         ++projection)
+    {
+      RegionType projectionRegion = requestedRegion;
+      projectionRegion.SetSize(2, 1);
+      projectionRegion.SetIndex(2, requestedRegion.GetIndex(2) + projection);
+
+      auto croppedProjection = convolveRegion(projectionRegion);
+
+#  ifdef CudaCommon_VERSION_MAJOR
+      auto * projectionBuffer = static_cast<float *>(croppedProjection->GetCudaDataManager()->GetGPUBufferPointer());
+#  else
+      float * projectionBuffer = *(float **)(croppedProjection->GetCudaDataManager()->GetGPUBufferPointer());
+#  endif
+
+      cudaError_t err = cudaMemcpy(outputBuffer + projection * pixelsPerProjection,
+                                   projectionBuffer,
+                                   pixelsPerProjection * sizeof(float),
+                                   cudaMemcpyDeviceToDevice);
+      if (err != cudaSuccess)
+      {
+        itkGenericExceptionMacro(<< "CUDA ERROR: " << cudaGetErrorString(err) << std::endl);
+      }
+    }
+
+    itk::ProgressReporter progress(this, 0, 1);
+    progress.CompletedPixel();
+
+    assembledOutput->SetBufferedRegion(this->GetOutput()->GetBufferedRegion());
+    assembledOutput->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
+    this->GraftOutput(assembledOutput);
+    return;
   }
 
-  auto * cuPadImgP = dynamic_cast<CudaImageType *>(paddedImage.GetPointer());
-
-  int2 kernelDimension;
-  kernelDimension.x = this->m_KernelFFT->GetBufferedRegion().GetSize()[0];
-  kernelDimension.y = this->m_KernelFFT->GetBufferedRegion().GetSize()[1];
-  CUDA_fft_convolution(inputDimension,
-                       kernelDimension,
-#  ifdef CudaCommon_VERSION_MAJOR
-                       static_cast<float *>(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
-                       (float2 *)(this->m_KernelFFTCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
-#  else
-                       *(float **)(cuPadImgP->GetCudaDataManager()->GetGPUBufferPointer()),
-                       *(float2 **)(this->m_KernelFFTCUDA->GetCudaDataManager()->GetGPUBufferPointer()));
-#  endif
+  auto croppedOutput = convolveRegion(requestedRegion);
 
   /* Impossible to get a pixel-wise progress reporting with CUDA
    * so this filter only reports 0 and 100% completion. */
   itk::ProgressReporter progress(this, 0, 1);
   progress.CompletedPixel();
 
-  // CUDA Cropping and Graft Output
-  auto                                           cf = CudaCropImageFilter::New();
-  typename Superclass::OutputImageType::SizeType upCropSize, lowCropSize;
-  for (unsigned int i = 0; i < CudaImageType::ImageDimension; i++)
-  {
-    lowCropSize[i] =
-      this->GetOutput()->GetRequestedRegion().GetIndex()[i] - paddedImage->GetLargestPossibleRegion().GetIndex()[i];
-    upCropSize[i] = paddedImage->GetLargestPossibleRegion().GetSize()[i] -
-                    this->GetOutput()->GetRequestedRegion().GetSize()[i] - lowCropSize[i];
-  }
-  cf->SetUpperBoundaryCropSize(upCropSize);
-  cf->SetLowerBoundaryCropSize(lowCropSize);
-  cf->SetInput(cuPadImgP);
-  cf->Update();
-
   // We only want to graft the data. To do so, we copy the rest before grafting.
-  cf->GetOutput()->CopyInformation(this->GetOutput());
-  cf->GetOutput()->SetBufferedRegion(this->GetOutput()->GetBufferedRegion());
-  cf->GetOutput()->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
-  this->GraftOutput(cf->GetOutput());
+  croppedOutput->CopyInformation(this->GetOutput());
+  croppedOutput->SetBufferedRegion(this->GetOutput()->GetBufferedRegion());
+  croppedOutput->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
+  this->GraftOutput(croppedOutput);
 }
 
 } // namespace rtk


### PR DESCRIPTION
Process multi-projection 2D-kernel convolutions slice-by-slice in CudaFFTProjectionsConvolutionImageFilter instead of building one large stack-wide FFT problem.

This avoids the oversized padded convolution volume seen with CudaScatterGlareCorrectionImageFilter on large projection stacks

Fix #557 