### PR TITLE
COMP: Fix Doxygen warnings due to wrong references

### DIFF
--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.h
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.h
@@ -231,7 +231,7 @@ protected:
   typename BackProjectionImageFilter<TOutputImage, TOutputImage>::Pointer    m_BackProjectionFilter;
   typename BackProjectionImageFilter<TOutputImage, TOutputImage>::Pointer    m_BackProjectionFilterForB;
   typename DisplacedDetectorFilterType::Pointer                              m_DisplacedDetectorFilter;
-  typename ConstantImageSourceType::Pointer                                  m_ConstantVolumeSource;
+  typename ConstantImageSourceType::Pointer                                  m_ConstantImageSource;
   typename MultiplyWithWeightsFilterType::Pointer                            m_MultiplyWithWeightsFilter;
 
   /** The inputs of this filter have the same type (float, 3) but not the same meaning

--- a/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
+++ b/include/rtkConjugateGradientConeBeamReconstructionFilter.hxx
@@ -42,7 +42,7 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 
   // Create the filters
   m_DisplacedDetectorFilter = DisplacedDetectorFilterType::New();
-  m_ConstantVolumeSource = ConstantImageSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
   m_CGOperator = CGOperatorFilterType::New();
   m_MultiplyVolumeFilter = MultiplyFilterType::New();
   m_MultiplyProjectionsFilter = MultiplyFilterType::New();
@@ -50,7 +50,7 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
   m_MultiplyWithWeightsFilter = MultiplyWithWeightsFilterType::New();
 
   // Set permanent parameters
-  m_ConstantVolumeSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
+  m_ConstantImageSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
   m_DisplacedDetectorFilter->SetPadOnTruncatedSide(false);
 }
 
@@ -215,7 +215,7 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
   m_CGOperator->SetBackProjectionFilter(m_BackProjectionFilter);
 
   // Set runtime connections
-  m_ConstantVolumeSource->SetInformationFromImage(this->GetInputVolume());
+  m_ConstantImageSource->SetInformationFromImage(this->GetInputVolume());
   m_CGOperator->SetInputProjectionStack(this->GetInputProjectionStack());
   m_CGOperator->SetSupportMask(this->GetSupportMask());
   m_ConjugateGradientFilter->SetX(this->GetInputVolume());
@@ -233,7 +233,7 @@ ConjugateGradientConeBeamReconstructionFilter<TOutputImage, TSingleComponentImag
 
   // Links with the m_BackProjectionFilter should be set here and not
   // in the constructor, as m_BackProjectionFilter is set at runtime
-  m_BackProjectionFilterForB->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionFilterForB->SetInput(0, m_ConstantImageSource->GetOutput());
   m_ConjugateGradientFilter->SetB(m_BackProjectionFilterForB->GetOutput());
 
   // Multiply the projections by the weights map

--- a/include/rtkDePierroRegularizationImageFilter.h
+++ b/include/rtkDePierroRegularizationImageFilter.h
@@ -95,8 +95,8 @@ public:
   /** Typedefs of each subfilter of this composite filter */
   using MultiplyImageFilterType = itk::MultiplyImageFilter<InputImageType, InputImageType>;
   using MultpiplyImageFilterPointerType = typename MultiplyImageFilterType::Pointer;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<InputImageType>;
-  using ConstantVolumeSourcePointerType = typename ConstantVolumeSourceType::Pointer;
+  using ConstantImageSourceType = rtk::ConstantImageSource<InputImageType>;
+  using ConstantImageSourcePointerType = typename ConstantImageSourceType::Pointer;
   using SubtractImageFilterType = itk::SubtractImageFilter<InputImageType, InputImageType>;
   using SubtractImageFilterPointerType = typename SubtractImageFilterType::Pointer;
   using ImageKernelOperatorType = itk::ImageKernelOperator<InputPixelType, InputImageDimension>;
@@ -133,8 +133,8 @@ protected:
 
   MultpiplyImageFilterPointerType m_MultiplyConstant1ImageFilter;
   MultpiplyImageFilterPointerType m_MultiplyConstant2ImageFilter;
-  ConstantVolumeSourcePointerType m_KernelImage;
-  ConstantVolumeSourcePointerType m_DefaultNormalizationVolume;
+  ConstantImageSourcePointerType  m_KernelImage;
+  ConstantImageSourcePointerType  m_DefaultNormalizationVolume;
   SubtractImageFilterPointerType  m_SubtractImageFilter;
   BoundaryCondition               m_BoundsCondition;
   ImageKernelOperatorType         m_KernelOperator;

--- a/include/rtkDePierroRegularizationImageFilter.hxx
+++ b/include/rtkDePierroRegularizationImageFilter.hxx
@@ -30,8 +30,8 @@ DePierroRegularizationImageFilter<TInputImage, TOutputImage>::DePierroRegulariza
   // Create each filter of the composite filter
   m_MultiplyConstant1ImageFilter = MultiplyImageFilterType::New();
   m_MultiplyConstant2ImageFilter = MultiplyImageFilterType::New();
-  m_KernelImage = ConstantVolumeSourceType::New();
-  m_DefaultNormalizationVolume = ConstantVolumeSourceType::New();
+  m_KernelImage = ConstantImageSourceType::New();
+  m_DefaultNormalizationVolume = ConstantImageSourceType::New();
   m_SubtractImageFilter = SubtractImageFilterType::New();
   m_ConvolutionFilter = NOIFType::New();
   m_CustomBinaryFilter = CustomBinaryFilterType::New();
@@ -49,9 +49,9 @@ DePierroRegularizationImageFilter<TInputImage, TOutputImage>::DePierroRegulariza
   m_CustomBinaryFilter->SetInput2(m_MultiplyConstant2ImageFilter->GetOutput());
 
   // Set the kernel image
-  typename ConstantVolumeSourceType::PointType   origin;
-  typename ConstantVolumeSourceType::SizeType    size;
-  typename ConstantVolumeSourceType::SpacingType spacing;
+  typename ConstantImageSourceType::PointType   origin;
+  typename ConstantImageSourceType::SizeType    size;
+  typename ConstantImageSourceType::SpacingType spacing;
   origin.Fill(-1);
   size.Fill(3);
   spacing.Fill(1);

--- a/include/rtkFourDReconstructionConjugateGradientOperator.h
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.h
@@ -163,7 +163,7 @@ public:
   using ForwardProjectionFilterType = ForwardProjectionImageFilter<ProjectionStackType, ProjectionStackType>;
   using InterpolationFilterType = InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>;
   using SplatFilterType = SplatWithKnownWeightsImageFilter<VolumeSeriesType, VolumeType>;
-  using ConstantVolumeSourceType = ConstantImageSource<VolumeType>;
+  using ConstantImageSourceType = ConstantImageSource<VolumeType>;
   using ConstantProjectionStackSourceType = ConstantImageSource<ProjectionStackType>;
   using ConstantVolumeSeriesSourceType = ConstantImageSource<VolumeSeriesType>;
 
@@ -183,7 +183,7 @@ public:
     conditional_t<std::is_same_v<ProjectionStackType, CPUProjectionStackType>, SplatFilterType, CudaSplatImageFilter>;
   using CudaConstantVolumeSourceType =
     typename std::conditional_t<std::is_same_v<ProjectionStackType, CPUProjectionStackType>,
-                                ConstantVolumeSourceType,
+                                ConstantImageSourceType,
                                 CudaConstantVolumeSource>;
   using CudaConstantVolumeSeriesSourceType =
     typename std::conditional_t<std::is_same_v<ProjectionStackType, CPUProjectionStackType>,
@@ -193,7 +193,7 @@ public:
   using DisplacedDetectorFilterType = DisplacedDetectorImageFilter<ProjectionStackType>;
   using CudaInterpolateImageFilterType = InterpolationFilterType;
   using CudaSplatImageFilterType = SplatFilterType;
-  using CudaConstantVolumeSourceType = ConstantVolumeSourceType;
+  using CudaConstantVolumeSourceType = ConstantImageSourceType;
   using CudaConstantVolumeSeriesSourceType = ConstantVolumeSeriesSourceType;
 #endif
 
@@ -257,8 +257,8 @@ protected:
   typename ForwardProjectionFilterType::Pointer       m_ForwardProjectionFilter;
   typename InterpolationFilterType::Pointer           m_InterpolationFilter;
   typename SplatFilterType::Pointer                   m_SplatFilter;
-  typename ConstantVolumeSourceType::Pointer          m_ConstantVolumeSource1;
-  typename ConstantVolumeSourceType::Pointer          m_ConstantVolumeSource2;
+  typename ConstantImageSourceType::Pointer           m_ConstantImageSource1;
+  typename ConstantImageSourceType::Pointer           m_ConstantImageSource2;
   typename ConstantProjectionStackSourceType::Pointer m_ConstantProjectionStackSource;
   typename ConstantVolumeSeriesSourceType::Pointer    m_ConstantVolumeSeriesSource;
   typename DisplacedDetectorFilterType::Pointer       m_DisplacedDetectorFilter;

--- a/include/rtkFourDReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkFourDReconstructionConjugateGradientOperator.hxx
@@ -107,30 +107,30 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
   unsigned int Dimension = 3;
 
   // Configure the constant volume sources
-  typename VolumeType::SizeType      ConstantVolumeSourceSize{};
-  typename VolumeType::SpacingType   ConstantVolumeSourceSpacing{};
-  typename VolumeType::PointType     ConstantVolumeSourceOrigin{};
-  typename VolumeType::DirectionType ConstantVolumeSourceDirection;
+  typename VolumeType::SizeType      ConstantImageSourceSize{};
+  typename VolumeType::SpacingType   ConstantImageSourceSpacing{};
+  typename VolumeType::PointType     ConstantImageSourceOrigin{};
+  typename VolumeType::DirectionType ConstantImageSourceDirection;
 
   for (unsigned int i = 0; i < Dimension; i++)
   {
-    ConstantVolumeSourceSize[i] = GetInputVolumeSeries()->GetLargestPossibleRegion().GetSize()[i];
-    ConstantVolumeSourceSpacing[i] = GetInputVolumeSeries()->GetSpacing()[i];
-    ConstantVolumeSourceOrigin[i] = GetInputVolumeSeries()->GetOrigin()[i];
+    ConstantImageSourceSize[i] = GetInputVolumeSeries()->GetLargestPossibleRegion().GetSize()[i];
+    ConstantImageSourceSpacing[i] = GetInputVolumeSeries()->GetSpacing()[i];
+    ConstantImageSourceOrigin[i] = GetInputVolumeSeries()->GetOrigin()[i];
   }
-  ConstantVolumeSourceDirection.SetIdentity();
+  ConstantImageSourceDirection.SetIdentity();
 
-  m_ConstantVolumeSource1->SetOrigin(ConstantVolumeSourceOrigin);
-  m_ConstantVolumeSource1->SetSpacing(ConstantVolumeSourceSpacing);
-  m_ConstantVolumeSource1->SetDirection(ConstantVolumeSourceDirection);
-  m_ConstantVolumeSource1->SetSize(ConstantVolumeSourceSize);
-  m_ConstantVolumeSource1->SetConstant(0.);
+  m_ConstantImageSource1->SetOrigin(ConstantImageSourceOrigin);
+  m_ConstantImageSource1->SetSpacing(ConstantImageSourceSpacing);
+  m_ConstantImageSource1->SetDirection(ConstantImageSourceDirection);
+  m_ConstantImageSource1->SetSize(ConstantImageSourceSize);
+  m_ConstantImageSource1->SetConstant(0.);
 
-  m_ConstantVolumeSource2->SetOrigin(ConstantVolumeSourceOrigin);
-  m_ConstantVolumeSource2->SetSpacing(ConstantVolumeSourceSpacing);
-  m_ConstantVolumeSource2->SetDirection(ConstantVolumeSourceDirection);
-  m_ConstantVolumeSource2->SetSize(ConstantVolumeSourceSize);
-  m_ConstantVolumeSource2->SetConstant(0.);
+  m_ConstantImageSource2->SetOrigin(ConstantImageSourceOrigin);
+  m_ConstantImageSource2->SetSpacing(ConstantImageSourceSpacing);
+  m_ConstantImageSource2->SetDirection(ConstantImageSourceDirection);
+  m_ConstantImageSource2->SetSize(ConstantImageSourceSize);
+  m_ConstantImageSource2->SetConstant(0.);
 
   // Configure the constant projection stack source
   m_ConstantProjectionStackSource->SetInformationFromImage(this->GetInputProjectionStack());
@@ -186,16 +186,16 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
   }
 
   // Create the constant sources (first on CPU, and overwrite with the GPU version if CUDA requested)
-  m_ConstantVolumeSource1 = ConstantVolumeSourceType::New();
-  m_ConstantVolumeSource2 = ConstantVolumeSourceType::New();
+  m_ConstantImageSource1 = ConstantImageSourceType::New();
+  m_ConstantImageSource2 = ConstantImageSourceType::New();
   m_ConstantProjectionStackSource = ConstantProjectionStackSourceType::New();
   m_ConstantVolumeSeriesSource = ConstantVolumeSeriesSourceType::New();
   if (m_UseCudaSources)
   {
     if (std::is_same_v<ProjectionStackType, CPUProjectionStackType>)
       itkGenericExceptionMacro(<< "UseCudaSources option only available with itk::CudaImage.");
-    m_ConstantVolumeSource1 = CudaConstantVolumeSourceType::New();
-    m_ConstantVolumeSource2 = CudaConstantVolumeSourceType::New();
+    m_ConstantImageSource1 = CudaConstantVolumeSourceType::New();
+    m_ConstantImageSource2 = CudaConstantVolumeSourceType::New();
     m_ConstantProjectionStackSource = CudaConstantVolumeSourceType::New();
     m_ConstantVolumeSeriesSource = CudaConstantVolumeSeriesSourceType::New();
   }
@@ -204,7 +204,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
   this->InitializeConstantSources();
 
   // Set runtime connections
-  m_InterpolationFilter->SetInputVolume(m_ConstantVolumeSource1->GetOutput());
+  m_InterpolationFilter->SetInputVolume(m_ConstantImageSource1->GetOutput());
   m_InterpolationFilter->SetInputVolumeSeries(this->GetInputVolumeSeries());
 
   m_ForwardProjectionFilter->SetInput(0, m_ConstantProjectionStackSource->GetOutput());
@@ -212,7 +212,7 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
 
   m_DisplacedDetectorFilter->SetInput(m_ForwardProjectionFilter->GetOutput());
 
-  m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource2->GetOutput());
+  m_BackProjectionFilter->SetInput(0, m_ConstantImageSource2->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_DisplacedDetectorFilter->GetOutput());
   m_BackProjectionFilter->SetInPlace(false);
 
@@ -318,8 +318,8 @@ FourDReconstructionConjugateGradientOperator<VolumeSeriesType, ProjectionStackTy
 
   // Release the data in internal filters
   pimg->ReleaseData();
-  m_ConstantVolumeSource1->GetOutput()->ReleaseData();
-  m_ConstantVolumeSource2->GetOutput()->ReleaseData();
+  m_ConstantImageSource1->GetOutput()->ReleaseData();
+  m_ConstantImageSource2->GetOutput()->ReleaseData();
   m_ConstantVolumeSeriesSource->GetOutput()->ReleaseData();
   m_ConstantProjectionStackSource->GetOutput()->ReleaseData();
   m_DisplacedDetectorFilter->GetOutput()->ReleaseData();

--- a/include/rtkFourDToProjectionStackImageFilter.h
+++ b/include/rtkFourDToProjectionStackImageFilter.h
@@ -131,7 +131,7 @@ public:
   using ForwardProjectionFilterType = rtk::ForwardProjectionImageFilter<ProjectionStackType, ProjectionStackType>;
   using PasteFilterType = itk::PasteImageFilter<ProjectionStackType, ProjectionStackType>;
   using InterpolatorFilterType = rtk::InterpolatorWithKnownWeightsImageFilter<VolumeType, VolumeSeriesType>;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<VolumeType>;
+  using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
   using ConstantProjectionStackSourceType = rtk::ConstantImageSource<ProjectionStackType>;
   using GeometryType = rtk::ThreeDCircularProjectionGeometry;
 
@@ -148,7 +148,7 @@ public:
 
   /** Initializes the empty volume source, set it and update it */
   void
-  InitializeConstantVolumeSource();
+  InitializeConstantImageSource();
 
   /** Store the phase signal in a member variable */
   virtual void
@@ -176,7 +176,7 @@ protected:
   /** Member pointers to the filters used internally (for convenience)*/
   typename PasteFilterType::Pointer                   m_PasteFilter;
   typename InterpolatorFilterType::Pointer            m_InterpolationFilter;
-  typename ConstantVolumeSourceType::Pointer          m_ConstantVolumeSource;
+  typename ConstantImageSourceType::Pointer           m_ConstantImageSource;
   typename ConstantProjectionStackSourceType::Pointer m_ConstantProjectionStackSource;
   typename ForwardProjectionFilterType::Pointer       m_ForwardProjectionFilter;
 

--- a/include/rtkFourDToProjectionStackImageFilter.hxx
+++ b/include/rtkFourDToProjectionStackImageFilter.hxx
@@ -31,7 +31,7 @@ FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::FourDT
   // Create the filters that can be created (all but the forward projection filter)
   m_PasteFilter = PasteFilterType::New();
   m_InterpolationFilter = InterpolatorFilterType::New();
-  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
   m_ConstantProjectionStackSource = ConstantProjectionStackSourceType::New();
 
   // Set parameters
@@ -96,7 +96,7 @@ FourDToProjectionStackImageFilter<VolumeSeriesType, ProjectionStackType>::SetSig
 
 template <typename ProjectionStackType, typename VolumeSeriesType>
 void
-FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::InitializeConstantVolumeSource()
+FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::InitializeConstantImageSource()
 {
   // Set the volume source
   int VolumeDimension = VolumeType::ImageDimension;
@@ -116,19 +116,19 @@ FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::Initia
   typename VolumeType::DirectionType constantVolumeSourceDirection;
   constantVolumeSourceDirection.SetIdentity();
 
-  m_ConstantVolumeSource->SetOrigin(constantVolumeSourceOrigin);
-  m_ConstantVolumeSource->SetSpacing(constantVolumeSourceSpacing);
-  m_ConstantVolumeSource->SetDirection(constantVolumeSourceDirection);
-  m_ConstantVolumeSource->SetSize(constantVolumeSourceSize);
-  m_ConstantVolumeSource->SetConstant(0.);
-  m_ConstantVolumeSource->Update();
+  m_ConstantImageSource->SetOrigin(constantVolumeSourceOrigin);
+  m_ConstantImageSource->SetSpacing(constantVolumeSourceSpacing);
+  m_ConstantImageSource->SetDirection(constantVolumeSourceDirection);
+  m_ConstantImageSource->SetSize(constantVolumeSourceSize);
+  m_ConstantImageSource->SetConstant(0.);
+  m_ConstantImageSource->Update();
 }
 
 template <typename ProjectionStackType, typename VolumeSeriesType>
 void
 FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::GenerateOutputInformation()
 {
-  this->InitializeConstantVolumeSource();
+  this->InitializeConstantImageSource();
 
   int ProjectionStackDimension = ProjectionStackType::ImageDimension;
   m_PasteRegion = this->GetInputProjectionStack()->GetLargestPossibleRegion();
@@ -141,7 +141,7 @@ FourDToProjectionStackImageFilter<ProjectionStackType, VolumeSeriesType>::Genera
 
   // Connect the filters
   m_InterpolationFilter->SetInputVolumeSeries(this->GetInputVolumeSeries());
-  m_InterpolationFilter->SetInputVolume(m_ConstantVolumeSource->GetOutput());
+  m_InterpolationFilter->SetInputVolume(m_ConstantImageSource->GetOutput());
   m_PasteFilter->SetDestinationImage(this->GetInputProjectionStack());
 
   // Connections with the Forward projection filter can only be set at runtime

--- a/include/rtkOSEMConeBeamReconstructionFilter.h
+++ b/include/rtkOSEMConeBeamReconstructionFilter.h
@@ -138,7 +138,7 @@ public:
   using BackProjectionFilterType = rtk::BackProjectionImageFilter<VolumeType, ProjectionType>;
   using DivideProjectionFilterType = itk::DivideOrZeroOutImageFilter<ProjectionType, ProjectionType, ProjectionType>;
   using DivideVolumeFilterType = itk::DivideOrZeroOutImageFilter<VolumeType, VolumeType, VolumeType>;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<VolumeType>;
+  using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
   using ConstantProjectionSourceType = rtk::ConstantImageSource<ProjectionType>;
   using DePierroRegularizationFilterType = rtk::DePierroRegularizationImageFilter<VolumeType, VolumeType>;
 
@@ -208,7 +208,7 @@ protected:
   typename DivideVolumeFilterType::Pointer           m_DivideVolumeFilter;
   typename ConstantProjectionSourceType::Pointer     m_ZeroConstantProjectionStackSource;
   typename ConstantProjectionSourceType::Pointer     m_OneConstantProjectionStackSource;
-  typename ConstantVolumeSourceType::Pointer         m_ConstantVolumeSource;
+  typename ConstantImageSourceType::Pointer          m_ConstantImageSource;
   typename DePierroRegularizationFilterType::Pointer m_DePierroRegularizationFilter;
 
 private:

--- a/include/rtkOSEMConeBeamReconstructionFilter.hxx
+++ b/include/rtkOSEMConeBeamReconstructionFilter.hxx
@@ -38,7 +38,7 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::OSEMConeBeamRe
   // Create each filter of the composite filter
   m_ExtractFilter = ExtractFilterType::New();
   m_MultiplyFilter = MultiplyFilterType::New();
-  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
   m_ZeroConstantProjectionStackSource = ConstantProjectionSourceType::New();
   m_DivideProjectionFilter = DivideProjectionFilterType::New();
   m_DePierroRegularizationFilter = DePierroRegularizationFilterType::New();
@@ -104,8 +104,8 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
 
   // Links with the forward and back projection filters should be set here
   // and not in the constructor, as these filters are set at runtime
-  m_ConstantVolumeSource->SetInformationFromImage(const_cast<TVolumeImage *>(this->GetInput(0)));
-  m_ConstantVolumeSource->SetConstant(0);
+  m_ConstantImageSource->SetInformationFromImage(const_cast<TVolumeImage *>(this->GetInput(0)));
+  m_ConstantImageSource->SetConstant(0);
 
   m_OneConstantProjectionStackSource->SetInformationFromImage(
     const_cast<TProjectionImage *>(m_ExtractFilter->GetOutput()));
@@ -115,11 +115,11 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
     const_cast<TProjectionImage *>(m_ExtractFilter->GetOutput()));
   m_ZeroConstantProjectionStackSource->SetConstant(0);
 
-  m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_DivideProjectionFilter->GetOutput());
   m_BackProjectionFilter->SetTranspose(false);
 
-  m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionNormalizationFilter->SetInput(1, m_OneConstantProjectionStackSource->GetOutput());
   m_BackProjectionNormalizationFilter->SetTranspose(false);
 
@@ -246,8 +246,8 @@ OSEMConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
         m_ForwardProjectionFilter->SetInput(1, pimg);
         m_DePierroRegularizationFilter->SetInput(0, pimg);
         m_MultiplyFilter->SetInput2(pimg);
-        m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
-        m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+        m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
+        m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantImageSource->GetOutput());
 
         currentSubset++;
         projectionsProcessedInSubset = 0;

--- a/include/rtkProjectionStackToFourDImageFilter.h
+++ b/include/rtkProjectionStackToFourDImageFilter.h
@@ -136,7 +136,7 @@ public:
 
   using BackProjectionFilterType = rtk::BackProjectionImageFilter<VolumeType, VolumeType>;
   using ExtractFilterType = itk::ExtractImageFilter<ProjectionStackType, ProjectionStackType>;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<VolumeType>;
+  using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
   using ConstantVolumeSeriesSourceType = rtk::ConstantImageSource<VolumeSeriesType>;
   using SplatFilterType = rtk::SplatWithKnownWeightsImageFilter<VolumeSeriesType, VolumeType>;
 
@@ -150,7 +150,7 @@ public:
     conditional_t<std::is_same_v<VolumeSeriesType, CPUVolumeSeriesType>, SplatFilterType, CudaSplatImageFilter>;
   using CudaConstantVolumeSourceType =
     typename std::conditional_t<std::is_same_v<VolumeSeriesType, CPUVolumeSeriesType>,
-                                ConstantVolumeSourceType,
+                                ConstantImageSourceType,
                                 CudaConstantVolumeSource>;
   using CudaConstantVolumeSeriesSourceType =
     typename std::conditional_t<std::is_same_v<VolumeSeriesType, CPUVolumeSeriesType>,
@@ -158,7 +158,7 @@ public:
                                 CudaConstantVolumeSeriesSource>;
 #else
   using CudaSplatImageFilterType = SplatFilterType;
-  using CudaConstantVolumeSourceType = ConstantVolumeSourceType;
+  using CudaConstantVolumeSourceType = ConstantImageSourceType;
   using CudaConstantVolumeSeriesSourceType = ConstantVolumeSeriesSourceType;
 #endif
 
@@ -208,7 +208,7 @@ protected:
   typename SplatFilterType::Pointer                m_SplatFilter;
   typename BackProjectionFilterType::Pointer       m_BackProjectionFilter;
   typename ExtractFilterType::Pointer              m_ExtractFilter;
-  typename ConstantVolumeSourceType::Pointer       m_ConstantVolumeSource;
+  typename ConstantImageSourceType::Pointer        m_ConstantImageSource;
   typename ConstantVolumeSeriesSourceType::Pointer m_ConstantVolumeSeriesSource;
 
   /** Other member variables */

--- a/include/rtkProjectionStackToFourDImageFilter.hxx
+++ b/include/rtkProjectionStackToFourDImageFilter.hxx
@@ -94,24 +94,24 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
   unsigned int Dimension = 3;
 
   // Configure the constant volume sources
-  typename VolumeType::SizeType      ConstantVolumeSourceSize{};
-  typename VolumeType::SpacingType   ConstantVolumeSourceSpacing{};
-  typename VolumeType::PointType     ConstantVolumeSourceOrigin{};
-  typename VolumeType::DirectionType ConstantVolumeSourceDirection;
+  typename VolumeType::SizeType      ConstantImageSourceSize{};
+  typename VolumeType::SpacingType   ConstantImageSourceSpacing{};
+  typename VolumeType::PointType     ConstantImageSourceOrigin{};
+  typename VolumeType::DirectionType ConstantImageSourceDirection;
 
   for (unsigned int i = 0; i < Dimension; i++)
   {
-    ConstantVolumeSourceSize[i] = GetInputVolumeSeries()->GetLargestPossibleRegion().GetSize()[i];
-    ConstantVolumeSourceSpacing[i] = GetInputVolumeSeries()->GetSpacing()[i];
-    ConstantVolumeSourceOrigin[i] = GetInputVolumeSeries()->GetOrigin()[i];
+    ConstantImageSourceSize[i] = GetInputVolumeSeries()->GetLargestPossibleRegion().GetSize()[i];
+    ConstantImageSourceSpacing[i] = GetInputVolumeSeries()->GetSpacing()[i];
+    ConstantImageSourceOrigin[i] = GetInputVolumeSeries()->GetOrigin()[i];
   }
-  ConstantVolumeSourceDirection.SetIdentity();
+  ConstantImageSourceDirection.SetIdentity();
 
-  m_ConstantVolumeSource->SetOrigin(ConstantVolumeSourceOrigin);
-  m_ConstantVolumeSource->SetSpacing(ConstantVolumeSourceSpacing);
-  m_ConstantVolumeSource->SetDirection(ConstantVolumeSourceDirection);
-  m_ConstantVolumeSource->SetSize(ConstantVolumeSourceSize);
-  m_ConstantVolumeSource->SetConstant(0.);
+  m_ConstantImageSource->SetOrigin(ConstantImageSourceOrigin);
+  m_ConstantImageSource->SetSpacing(ConstantImageSourceSpacing);
+  m_ConstantImageSource->SetDirection(ConstantImageSourceDirection);
+  m_ConstantImageSource->SetSize(ConstantImageSourceSize);
+  m_ConstantImageSource->SetConstant(0.);
 
   // Configure the constant volume series source
   m_ConstantVolumeSeriesSource->SetInformationFromImage(this->GetInputVolumeSeries());
@@ -143,20 +143,20 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
   }
 
   // Create the constant sources (first on CPU, and overwrite with the GPU version if CUDA requested)
-  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
   m_ConstantVolumeSeriesSource = ConstantVolumeSeriesSourceType::New();
   if (m_UseCudaSources)
   {
     if (std::is_same_v<VolumeSeriesType, CPUVolumeSeriesType>)
       itkGenericExceptionMacro(<< "UseCudaSources option only available with itk::CudaImage.");
-    m_ConstantVolumeSource = CudaConstantVolumeSourceType::New();
+    m_ConstantImageSource = CudaConstantVolumeSourceType::New();
     m_ConstantVolumeSeriesSource = CudaConstantVolumeSeriesSourceType::New();
   }
 
   // Set runtime connections
   m_ExtractFilter->SetInput(this->GetInputProjectionStack());
 
-  m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_ExtractFilter->GetOutput());
   m_BackProjectionFilter->SetInPlace(false);
 
@@ -271,7 +271,7 @@ ProjectionStackToFourDImageFilter<VolumeSeriesType, ProjectionStackType, TFFTPre
     pimg->ReleaseData();
   m_BackProjectionFilter->GetOutput()->ReleaseData();
   m_ExtractFilter->GetOutput()->ReleaseData();
-  m_ConstantVolumeSource->GetOutput()->ReleaseData();
+  m_ConstantImageSource->GetOutput()->ReleaseData();
 }
 
 } // namespace rtk

--- a/include/rtkReconstructionConjugateGradientOperator.h
+++ b/include/rtkReconstructionConjugateGradientOperator.h
@@ -73,7 +73,7 @@ namespace rtk
  * Output [shape=Mdiamond];
  *
  * node [shape=box];
- * ConstantVolumeSource [label="rtk::ConstantImageSource" URL="\ref rtk::ConstantImageSource"];
+ * ConstantImageSource [label="rtk::ConstantImageSource" URL="\ref rtk::ConstantImageSource"];
  * ConstantProjectionsSource [label="rtk::ConstantImageSource" URL="\ref rtk::ConstantImageSource"];
  * BackProjection [ label="rtk::BackProjectionImageFilter" URL="\ref rtk::BackProjectionImageFilter"];
  * ForwardProjection [ label="rtk::ForwardProjectionImageFilter" URL="\ref rtk::ForwardProjectionImageFilter"];
@@ -91,7 +91,7 @@ namespace rtk
  * Input3 -> MultiplyInput;
  * MultiplyInput -> ForwardProjection;
  * ConstantProjectionsSource -> ForwardProjection;
- * ConstantVolumeSource -> BackProjection;
+ * ConstantImageSource -> BackProjection;
  * ForwardProjection -> Multiply;
  * Input2 -> Multiply;
  * Multiply -> BackProjection;
@@ -220,7 +220,7 @@ protected:
   ForwardProjectionFilterPointer m_ForwardProjectionFilter;
 
   typename ConstantSourceType::Pointer                                  m_ConstantProjectionsSource;
-  typename ConstantSourceType::Pointer                                  m_ConstantVolumeSource;
+  typename ConstantSourceType::Pointer                                  m_ConstantImageSource;
   typename MultiplyFilterType::Pointer                                  m_MultiplyOutputVolumeFilter;
   typename MultiplyFilterType::Pointer                                  m_MultiplyInputVolumeFilter;
   typename MultiplyFilterType::Pointer                                  m_MultiplyLaplacianFilter;

--- a/include/rtkReconstructionConjugateGradientOperator.hxx
+++ b/include/rtkReconstructionConjugateGradientOperator.hxx
@@ -32,11 +32,11 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
   // Create filters
   // #ifdef RTK_USE_CUDA
   //  m_ConstantProjectionsSource = rtk::CudaConstantVolumeSource::New();
-  //  m_ConstantVolumeSource = rtk::CudaConstantVolumeSource::New();
+  //  m_ConstantImageSource = rtk::CudaConstantVolumeSource::New();
   //  m_LaplacianFilter = rtk::CudaLaplacianImageFilter::New();
   // #else
   m_ConstantProjectionsSource = ConstantSourceType::New();
-  m_ConstantVolumeSource = ConstantSourceType::New();
+  m_ConstantImageSource = ConstantSourceType::New();
   // #endif
   m_MultiplyWithWeightsFilter = MultiplyWithWeightsFilterType::New();
   m_MultiplyOutputVolumeFilter = MultiplyFilterType::New();
@@ -44,11 +44,11 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
 
   // Set permanent parameters
   m_ConstantProjectionsSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
-  m_ConstantVolumeSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
+  m_ConstantImageSource->SetConstant(itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue());
 
   // Set memory management options
   m_ConstantProjectionsSource->ReleaseDataFlagOn();
-  m_ConstantVolumeSource->ReleaseDataFlagOn();
+  m_ConstantImageSource->ReleaseDataFlagOn();
   //  m_LaplacianFilter->ReleaseDataFlagOn();
   //  m_MultiplyLaplacianFilter->ReleaseDataFlagOn();
 }
@@ -196,7 +196,7 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
   // Set runtime connections, and connections with
   // forward and back projection filters, which are set
   // at runtime
-  m_ConstantVolumeSource->SetInformationFromImage(this->GetInputVolume());
+  m_ConstantImageSource->SetInformationFromImage(this->GetInputVolume());
   m_ConstantProjectionsSource->SetInformationFromImage(this->GetInputProjectionStack());
 
   m_FloatingInputPointer = const_cast<TOutputImage *>(this->GetInputVolume().GetPointer());
@@ -218,7 +218,7 @@ ReconstructionConjugateGradientOperator<TOutputImage, TSingleComponentImage, TWe
   m_MultiplyWithWeightsFilter->SetInput2(this->GetInputWeights());
 
   // Set the back projection filter's inputs
-  m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_MultiplyWithWeightsFilter->GetOutput());
   m_FloatingOutputPointer = m_BackProjectionFilter->GetOutput();
 

--- a/include/rtkSARTConeBeamReconstructionFilter.h
+++ b/include/rtkSARTConeBeamReconstructionFilter.h
@@ -166,7 +166,7 @@ public:
   using RayBoxIntersectionFilterType = rtk::RayBoxIntersectionImageFilter<ProjectionType, ProjectionType>;
   using DivideProjectionFilterType = itk::DivideOrZeroOutImageFilter<ProjectionType, ProjectionType, ProjectionType>;
   using DivideVolumeFilterType = itk::DivideOrZeroOutImageFilter<VolumeType, VolumeType, VolumeType>;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<VolumeType>;
+  using ConstantImageSourceType = rtk::ConstantImageSource<VolumeType>;
   using ConstantProjectionSourceType = rtk::ConstantImageSource<ProjectionType>;
   using ThresholdFilterType = itk::ThresholdImageFilter<VolumeType>;
   using DisplacedDetectorFilterType = rtk::DisplacedDetectorImageFilter<ProjectionType>;
@@ -260,7 +260,7 @@ protected:
   typename DivideVolumeFilterType::Pointer       m_DivideVolumeFilter;
   typename ConstantProjectionSourceType::Pointer m_ConstantProjectionStackSource;
   typename ConstantProjectionSourceType::Pointer m_OneConstantProjectionStackSource;
-  typename ConstantVolumeSourceType::Pointer     m_ConstantVolumeSource;
+  typename ConstantImageSourceType::Pointer      m_ConstantImageSource;
   typename ThresholdFilterType::Pointer          m_ThresholdFilter;
   typename DisplacedDetectorFilterType::Pointer  m_DisplacedDetectorFilter;
   typename GatingWeightsFilterType::Pointer      m_GatingWeightsFilter;

--- a/include/rtkSARTConeBeamReconstructionFilter.hxx
+++ b/include/rtkSARTConeBeamReconstructionFilter.hxx
@@ -45,7 +45,7 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::SARTConeBeamRe
   m_DisplacedDetectorFilter = DisplacedDetectorFilterType::New();
   m_MultiplyFilter = MultiplyFilterType::New();
   m_GatingWeightsFilter = GatingWeightsFilterType::New();
-  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
 
   // Create the filters required for correct weighting of the difference
   // projection
@@ -148,19 +148,19 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateOutput
 
   // Links with the forward and back projection filters should be set here
   // and not in the constructor, as these filters are set at runtime
-  m_ConstantVolumeSource->SetInformationFromImage(const_cast<TVolumeImage *>(this->GetInput(0)));
-  m_ConstantVolumeSource->SetConstant(0);
-  m_ConstantVolumeSource->UpdateOutputInformation();
+  m_ConstantImageSource->SetInformationFromImage(const_cast<TVolumeImage *>(this->GetInput(0)));
+  m_ConstantImageSource->SetConstant(0);
+  m_ConstantImageSource->UpdateOutputInformation();
 
   m_OneConstantProjectionStackSource->SetInformationFromImage(
     const_cast<TProjectionImage *>(m_ExtractFilter->GetOutput()));
   m_OneConstantProjectionStackSource->SetConstant(1);
 
-  m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionFilter->SetInput(1, m_DisplacedDetectorFilter->GetOutput());
   m_BackProjectionFilter->SetTranspose(false);
 
-  m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+  m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantImageSource->GetOutput());
   m_BackProjectionNormalizationFilter->SetInput(1, m_OneConstantProjectionStackSource->GetOutput());
   m_BackProjectionNormalizationFilter->SetTranspose(false);
 
@@ -328,8 +328,8 @@ SARTConeBeamReconstructionFilter<TVolumeImage, TProjectionImage>::GenerateData()
           m_AddFilter->SetInput2(pimg);
         else
           m_NesterovFilter->SetInput(pimg);
-        m_BackProjectionFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
-        m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantVolumeSource->GetOutput());
+        m_BackProjectionFilter->SetInput(0, m_ConstantImageSource->GetOutput());
+        m_BackProjectionNormalizationFilter->SetInput(0, m_ConstantImageSource->GetOutput());
 
         projectionsProcessedInSubset = 0;
       }

--- a/include/rtkZengBackProjectionImageFilter.h
+++ b/include/rtkZengBackProjectionImageFilter.h
@@ -70,10 +70,10 @@ namespace rtk
  *
  *  Add [ label="itk::AddImageFilter" URL="\ref itk::AddImageFilter"];
  *  Paste [ label="itk::PasteImageFilter" URL="\ref itk::PasteImageFilter"];
- *  Gaussian [ label="itk::DiscreteGaussianFilter" URL="\ref itk::DiscreteGaussianFilter"];
+ *  Gaussian [ label="itk::DiscreteGaussianImageFilter" URL="\ref itk::DiscreteGaussianImageFilter"];
  *  Resample [ label="itk::ResampleImageFilter" URL="\ref itk::ResampleImageFilter"];
  *  Multiply [ label="itk::MultiplyImageFilter" URL="\ref itk::MultiplyImageFilter"];
- *  Constant [ label="itk::ConstantVolumeSource" URL="\ref itk::ConstantVolumeSource"];
+ *  Constant [ label="rtk::ConstantImageSource" URL="\ref rtk::ConstantImageSource"];
  *  Extract [ label="itk::ExtractImageFilter" URL="\ref itk::ExtractImageFilter"];
  *  ChangeInfo [ label="itk::ChangeInformationImageFilter" URL="\ref itk::ChangeInformationImageFilter"];
  *  AttMultiply [ label="itk::MultiplyImageFilter" URL="\ref itk::MultiplyImageFilter"];
@@ -130,8 +130,8 @@ public:
   using AddImageFilterPointerType = typename AddImageFilterType::Pointer;
   using PasteImageFilterType = itk::PasteImageFilter<InputCPUImageType, OuputCPUImageType>;
   using PasteImageFilterPointerType = typename PasteImageFilterType::Pointer;
-  using DiscreteGaussianFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
-  using DiscreteGaussianFilterPointeurType = typename DiscreteGaussianFilterType::Pointer;
+  using DiscreteGaussianImageFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using DiscreteGaussianImageFilterPointerType = typename DiscreteGaussianImageFilterType::Pointer;
   using ResampleImageFilterType = itk::ResampleImageFilter<InputCPUImageType, InputCPUImageType>;
   using ResampleImageFilterPointerType = typename ResampleImageFilterType::Pointer;
   using TransformType = itk::CenteredEuler3DTransform<double>;
@@ -140,8 +140,8 @@ public:
   using ChangeInformationPointerType = typename ChangeInformationFilterType::Pointer;
   using MultiplyImageFilterType = itk::MultiplyImageFilter<InputCPUImageType, InputCPUImageType>;
   using MultiplyImageFilterPointerType = typename MultiplyImageFilterType::Pointer;
-  using ConstantVolumeSourceType = rtk::ConstantImageSource<InputCPUImageType>;
-  using ConstantVolumeSourcePointerType = typename ConstantVolumeSourceType::Pointer;
+  using ConstantImageSourceType = rtk::ConstantImageSource<InputCPUImageType>;
+  using ConstantImageSourcePointerType = typename ConstantImageSourceType::Pointer;
   using ExtractImageFilterType = itk::ExtractImageFilter<OuputCPUImageType, OuputCPUImageType>;
   using ExtractImageFilterPointerType = typename ExtractImageFilterType::Pointer;
   using RegionOfInterestFilterType = itk::RegionOfInterestImageFilter<OuputCPUImageType, OuputCPUImageType>;
@@ -189,21 +189,21 @@ protected:
   void
   VerifyInputInformation() const override;
 
-  AddImageFilterPointerType          m_AddImageFilter;
-  PasteImageFilterPointerType        m_PasteImageFilter;
-  DiscreteGaussianFilterPointeurType m_DiscreteGaussianFilter;
-  ResampleImageFilterPointerType     m_ResampleImageFilter;
-  TransformPointerType               m_Transform;
-  MultiplyImageFilterPointerType     m_MultiplyImageFilter;
-  ConstantVolumeSourcePointerType    m_ConstantVolumeSource;
-  ExtractImageFilterPointerType      m_ExtractImageFilter;
-  ChangeInformationPointerType       m_ChangeInformation;
-  MultiplyImageFilterPointerType     m_AttenuationMapMultiplyImageFilter;
-  RegionOfInterestPointerType        m_AttenuationMapRegionOfInterest;
-  ResampleImageFilterPointerType     m_AttenuationMapResampleImageFilter;
-  ChangeInformationPointerType       m_AttenuationMapChangeInformation;
-  BoundaryCondition                  m_BoundsCondition;
-  CustomUnaryFilterPointerType       m_CustomUnaryFilter;
+  AddImageFilterPointerType              m_AddImageFilter;
+  PasteImageFilterPointerType            m_PasteImageFilter;
+  DiscreteGaussianImageFilterPointerType m_DiscreteGaussianImageFilter;
+  ResampleImageFilterPointerType         m_ResampleImageFilter;
+  TransformPointerType                   m_Transform;
+  MultiplyImageFilterPointerType         m_MultiplyImageFilter;
+  ConstantImageSourcePointerType         m_ConstantImageSource;
+  ExtractImageFilterPointerType          m_ExtractImageFilter;
+  ChangeInformationPointerType           m_ChangeInformation;
+  MultiplyImageFilterPointerType         m_AttenuationMapMultiplyImageFilter;
+  RegionOfInterestPointerType            m_AttenuationMapRegionOfInterest;
+  ResampleImageFilterPointerType         m_AttenuationMapResampleImageFilter;
+  ChangeInformationPointerType           m_AttenuationMapChangeInformation;
+  BoundaryCondition                      m_BoundsCondition;
+  CustomUnaryFilterPointerType           m_CustomUnaryFilter;
 
 private:
   ZengBackProjectionImageFilter(const Self &) = delete; // purposely not implemented

--- a/include/rtkZengBackProjectionImageFilter.hxx
+++ b/include/rtkZengBackProjectionImageFilter.hxx
@@ -43,12 +43,12 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::ZengBackProjectionImag
   // Create each filter of the composite filter
   m_AddImageFilter = AddImageFilterType::New();
   m_PasteImageFilter = PasteImageFilterType::New();
-  m_DiscreteGaussianFilter = DiscreteGaussianFilterType::New();
+  m_DiscreteGaussianImageFilter = DiscreteGaussianImageFilterType::New();
   m_ResampleImageFilter = ResampleImageFilterType::New();
   m_Transform = TransformType::New();
   m_MultiplyImageFilter = MultiplyImageFilterType::New();
   m_ExtractImageFilter = ExtractImageFilterType::New();
-  m_ConstantVolumeSource = ConstantVolumeSourceType::New();
+  m_ConstantImageSource = ConstantImageSourceType::New();
   m_ChangeInformation = ChangeInformationFilterType::New();
   m_AttenuationMapMultiplyImageFilter = nullptr;
   m_AttenuationMapRegionOfInterest = nullptr;
@@ -63,10 +63,10 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::ZengBackProjectionImag
   m_ChangeInformation->ChangeSpacingOn();
 
   // Default parameters
-  m_DiscreteGaussianFilter->SetMaximumError(0.00001);
-  m_DiscreteGaussianFilter->SetFilterDimensionality(2);
-  m_DiscreteGaussianFilter->SetInputBoundaryCondition(&m_BoundsCondition);
-  m_DiscreteGaussianFilter->SetRealBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianImageFilter->SetMaximumError(0.00001);
+  m_DiscreteGaussianImageFilter->SetFilterDimensionality(2);
+  m_DiscreteGaussianImageFilter->SetInputBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianImageFilter->SetRealBoundaryCondition(&m_BoundsCondition);
 }
 
 template <class TInputImage, class TOutputImage>
@@ -226,11 +226,11 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInformat
   m_ChangeInformation->SetOutputSpacing(outputSpacing);
   m_ChangeInformation->UpdateOutputInformation();
 
-  m_DiscreteGaussianFilter->SetVariance(pow(m_SigmaZero, 2.0));
+  m_DiscreteGaussianImageFilter->SetVariance(pow(m_SigmaZero, 2.0));
 
   if (!(this->GetInput(2)))
   {
-    m_DiscreteGaussianFilter->SetInput(m_ChangeInformation->GetOutput());
+    m_DiscreteGaussianImageFilter->SetInput(m_ChangeInformation->GetOutput());
   }
   else
   {
@@ -272,21 +272,21 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInformat
     m_AttenuationMapChangeInformation->SetInput(m_AttenuationMapRegionOfInterest->GetOutput());
     m_AttenuationMapMultiplyImageFilter->SetInput1(m_ChangeInformation->GetOutput());
     m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapChangeInformation->GetOutput());
-    m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+    m_DiscreteGaussianImageFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
   }
 
   m_MultiplyImageFilter->SetConstant(spacingVolume[2]);
 
-  m_ConstantVolumeSource->SetInformationFromImage(const_cast<TInputImage *>(this->GetInput(0)));
-  m_ConstantVolumeSource->SetSpacing(outputSpacing);
-  m_ConstantVolumeSource->SetOrigin(outputOrigin);
-  m_ConstantVolumeSource->SetSize(outputSize);
-  m_ConstantVolumeSource->SetDirection(this->GetInput(1)->GetDirection());
-  m_ConstantVolumeSource->SetConstant(0);
+  m_ConstantImageSource->SetInformationFromImage(const_cast<TInputImage *>(this->GetInput(0)));
+  m_ConstantImageSource->SetSpacing(outputSpacing);
+  m_ConstantImageSource->SetOrigin(outputOrigin);
+  m_ConstantImageSource->SetSize(outputSize);
+  m_ConstantImageSource->SetDirection(this->GetInput(1)->GetDirection());
+  m_ConstantImageSource->SetConstant(0);
 
-  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianFilter->GetOutput());
-  m_PasteImageFilter->SetDestinationImage(m_ConstantVolumeSource->GetOutput());
-  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianImageFilter->GetOutput());
+  m_PasteImageFilter->SetDestinationImage(m_ConstantImageSource->GetOutput());
+  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianImageFilter->GetOutput()->GetLargestPossibleRegion());
 
   m_ResampleImageFilter->SetInput(m_PasteImageFilter->GetOutput());
   m_AddImageFilter->SetInput1(this->GetInput(0));
@@ -346,10 +346,10 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     centerRotatedVolume = m_Transform->GetMatrix() * m_centerVolume;
 
     // Set the new origin of the rotate volume according to the center
-    originRotatedVolume = m_ConstantVolumeSource->GetOrigin();
-    originRotatedVolume[2] = centerRotatedVolume[2] - m_ConstantVolumeSource->GetSpacing()[2] *
-                                                        (double)(m_ConstantVolumeSource->GetSize()[2] - 1) / 2.0;
-    m_ConstantVolumeSource->SetOrigin(originRotatedVolume);
+    originRotatedVolume = m_ConstantImageSource->GetOrigin();
+    originRotatedVolume[2] = centerRotatedVolume[2] - m_ConstantImageSource->GetSpacing()[2] *
+                                                        (double)(m_ConstantImageSource->GetSize()[2] - 1) / 2.0;
+    m_ConstantImageSource->SetOrigin(originRotatedVolume);
 
     // Set the rotation angle.
     m_ResampleImageFilter->SetTransform(m_Transform->GetInverseTransform());
@@ -360,15 +360,15 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     m_ExtractImageFilter->UpdateOutputInformation();
 
     // Find the first positive distance between the volume and the detector
-    m_ConstantVolumeSource->Update();
-    int nbSlice = m_ConstantVolumeSource->GetOutput()->GetLargestPossibleRegion().GetSize()[2];
+    m_ConstantImageSource->Update();
+    int nbSlice = m_ConstantImageSource->GetOutput()->GetLargestPossibleRegion().GetSize()[2];
     dist = -1;
     startSlice = -1;
     while (dist < 0)
     {
       startSlice += 1;
       indexSlice[Dimension - 1] = startSlice;
-      m_ConstantVolumeSource->GetOutput()->TransformIndexToPhysicalPoint(indexSlice, pointSlice);
+      m_ConstantImageSource->GetOutput()->TransformIndexToPhysicalPoint(indexSlice, pointSlice);
       dist = geometry->GetSourceToIsocenterDistances()[nbProjections] +
              pointSlice.GetVectorFromOrigin() * m_VectorOrthogonalDetector;
     }
@@ -387,13 +387,13 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     }
     // Compute the variance of the PSF for the first slice
     sigmaSlice = pow(m_Alpha * dist + m_SigmaZero, 2.0);
-    m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
-    m_DiscreteGaussianFilter->UpdateLargestPossibleRegion();
-    currentSlice = m_DiscreteGaussianFilter->GetOutput();
+    m_DiscreteGaussianImageFilter->SetVariance(sigmaSlice);
+    m_DiscreteGaussianImageFilter->UpdateLargestPossibleRegion();
+    currentSlice = m_DiscreteGaussianImageFilter->GetOutput();
     currentSlice->DisconnectPipeline();
 
     // Paste the blur slice into the output volume
-    m_PasteImageFilter->SetDestinationImage(m_ConstantVolumeSource->GetOutput());
+    m_PasteImageFilter->SetDestinationImage(m_ConstantImageSource->GetOutput());
     m_PasteImageFilter->SetSourceImage(currentSlice);
     m_PasteImageFilter->SetSourceRegion(currentSlice->GetLargestPossibleRegion());
     m_PasteImageFilter->SetDestinationIndex(indexSlice);
@@ -406,7 +406,7 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     {
       if (!this->GetInput(2))
       {
-        m_DiscreteGaussianFilter->SetInput(currentSlice);
+        m_DiscreteGaussianImageFilter->SetInput(currentSlice);
       }
       else
       {
@@ -414,17 +414,17 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
         m_AttenuationMapRegionOfInterest->SetRegionOfInterest(desiredRegion);
         m_AttenuationMapRegionOfInterest->UpdateOutputInformation();
         m_AttenuationMapMultiplyImageFilter->SetInput1(currentSlice);
-        m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+        m_DiscreteGaussianImageFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
       }
       // Compute the distance between the current slice and the detector
       indexSlice[Dimension - 1] = index + 1;
-      dist += m_ConstantVolumeSource->GetSpacing()[2];
+      dist += m_ConstantImageSource->GetSpacing()[2];
       // Compute the variance of the PSF for the current slice
       sigmaSlice = dist * 2. * thicknessSlice * pow(m_Alpha, 2.0) + 2. * thicknessSlice * m_Alpha * m_SigmaZero -
                    pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
-      m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
-      m_DiscreteGaussianFilter->Update();
-      currentSlice = m_DiscreteGaussianFilter->GetOutput();
+      m_DiscreteGaussianImageFilter->SetVariance(sigmaSlice);
+      m_DiscreteGaussianImageFilter->Update();
+      currentSlice = m_DiscreteGaussianImageFilter->GetOutput();
       currentSlice->DisconnectPipeline();
 
       // Paste the blur slice into the output volume
@@ -444,12 +444,12 @@ ZengBackProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
     m_AddImageFilter->SetInput1(pimg);
     if (!this->GetInput(2))
     {
-      m_DiscreteGaussianFilter->SetInput(m_ChangeInformation->GetOutput());
+      m_DiscreteGaussianImageFilter->SetInput(m_ChangeInformation->GetOutput());
     }
     else
     {
       m_AttenuationMapMultiplyImageFilter->SetInput1(m_ChangeInformation->GetOutput());
-      m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+      m_DiscreteGaussianImageFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
     }
     nbProjections++;
   }

--- a/include/rtkZengForwardProjectionImageFilter.h
+++ b/include/rtkZengForwardProjectionImageFilter.h
@@ -80,8 +80,8 @@ public:
   using AddImageFilterPointerType = typename AddImageFilterType::Pointer;
   using PasteImageFilterType = itk::PasteImageFilter<OuputCPUImageType, InputCPUImageType>;
   using PasteImageFilterPointerType = typename PasteImageFilterType::Pointer;
-  using DiscreteGaussianFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
-  using DiscreteGaussianFilterPointeurType = typename DiscreteGaussianFilterType::Pointer;
+  using DiscreteGaussianImageFilterType = itk::DiscreteGaussianImageFilter<OuputCPUImageType, OuputCPUImageType>;
+  using DiscreteGaussianImageFilterPointerType = typename DiscreteGaussianImageFilterType::Pointer;
   using ResampleImageFilterType = itk::ResampleImageFilter<OuputCPUImageType, OuputCPUImageType>;
   using ResampleImageFilterPointerType = typename ResampleImageFilterType::Pointer;
   using TransformType = itk::CenteredEuler3DTransform<double>;
@@ -133,20 +133,20 @@ protected:
   void
   VerifyInputInformation() const override;
 
-  RegionOfInterestPointerType        m_RegionOfInterest;
-  AddImageFilterPointerType          m_AddImageFilter;
-  PasteImageFilterPointerType        m_PasteImageFilter;
-  DiscreteGaussianFilterPointeurType m_DiscreteGaussianFilter;
-  ResampleImageFilterPointerType     m_ResampleImageFilter;
-  TransformPointerType               m_Transform;
-  ChangeInformationPointerType       m_ChangeInformation;
-  MultpiplyImageFilterPointerType    m_MultiplyImageFilter;
-  MultpiplyImageFilterPointerType    m_AttenuationMapMultiplyImageFilter;
-  RegionOfInterestPointerType        m_AttenuationMapRegionOfInterest;
-  ResampleImageFilterPointerType     m_AttenuationMapResampleImageFilter;
-  ChangeInformationPointerType       m_AttenuationMapChangeInformation;
-  BoundaryCondition                  m_BoundsCondition;
-  CustomUnaryFilterPointerType       m_CustomUnaryFilter;
+  RegionOfInterestPointerType            m_RegionOfInterest;
+  AddImageFilterPointerType              m_AddImageFilter;
+  PasteImageFilterPointerType            m_PasteImageFilter;
+  DiscreteGaussianImageFilterPointerType m_DiscreteGaussianImageFilter;
+  ResampleImageFilterPointerType         m_ResampleImageFilter;
+  TransformPointerType                   m_Transform;
+  ChangeInformationPointerType           m_ChangeInformation;
+  MultpiplyImageFilterPointerType        m_MultiplyImageFilter;
+  MultpiplyImageFilterPointerType        m_AttenuationMapMultiplyImageFilter;
+  RegionOfInterestPointerType            m_AttenuationMapRegionOfInterest;
+  ResampleImageFilterPointerType         m_AttenuationMapResampleImageFilter;
+  ChangeInformationPointerType           m_AttenuationMapChangeInformation;
+  BoundaryCondition                      m_BoundsCondition;
+  CustomUnaryFilterPointerType           m_CustomUnaryFilter;
 
 
 private:

--- a/include/rtkZengForwardProjectionImageFilter.hxx
+++ b/include/rtkZengForwardProjectionImageFilter.hxx
@@ -44,7 +44,7 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::ZengForwardProjecti
   m_RegionOfInterest = RegionOfInterestFilterType::New();
   m_AddImageFilter = AddImageFilterType::New();
   m_PasteImageFilter = PasteImageFilterType::New();
-  m_DiscreteGaussianFilter = DiscreteGaussianFilterType::New();
+  m_DiscreteGaussianImageFilter = DiscreteGaussianImageFilterType::New();
   m_ResampleImageFilter = ResampleImageFilterType::New();
   m_Transform = TransformType::New();
   m_ChangeInformation = ChangeInformationFilterType::New();
@@ -56,17 +56,17 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::ZengForwardProjecti
   m_CustomUnaryFilter = nullptr;
 
   // Permanent internal connections
-  m_AddImageFilter->SetInput1(m_DiscreteGaussianFilter->GetOutput());
+  m_AddImageFilter->SetInput1(m_DiscreteGaussianImageFilter->GetOutput());
   m_AddImageFilter->SetInput2(m_ChangeInformation->GetOutput());
   m_MultiplyImageFilter->SetInput(m_PasteImageFilter->GetOutput());
 
   // Default parameters
-  m_DiscreteGaussianFilter->SetMaximumError(0.00001);
-  m_DiscreteGaussianFilter->SetFilterDimensionality(2);
-  m_DiscreteGaussianFilter->SetInputBoundaryCondition(&m_BoundsCondition);
-  m_DiscreteGaussianFilter->SetRealBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianImageFilter->SetMaximumError(0.00001);
+  m_DiscreteGaussianImageFilter->SetFilterDimensionality(2);
+  m_DiscreteGaussianImageFilter->SetInputBoundaryCondition(&m_BoundsCondition);
+  m_DiscreteGaussianImageFilter->SetRealBoundaryCondition(&m_BoundsCondition);
   m_ChangeInformation->ChangeOriginOn();
-  m_ChangeInformation->SetReferenceImage(m_DiscreteGaussianFilter->GetOutput());
+  m_ChangeInformation->SetReferenceImage(m_DiscreteGaussianImageFilter->GetOutput());
   m_ChangeInformation->SetUseReferenceImage(true);
 }
 
@@ -234,11 +234,11 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInfor
   m_RegionOfInterest->SetInput(m_ResampleImageFilter->GetOutput());
   m_RegionOfInterest->UpdateOutputInformation();
 
-  m_DiscreteGaussianFilter->SetVariance(pow(m_SigmaZero, 2.0));
+  m_DiscreteGaussianImageFilter->SetVariance(pow(m_SigmaZero, 2.0));
 
   if (!(this->GetInput(2)))
   {
-    m_DiscreteGaussianFilter->SetInput(m_RegionOfInterest->GetOutput());
+    m_DiscreteGaussianImageFilter->SetInput(m_RegionOfInterest->GetOutput());
   }
   else
   {
@@ -247,7 +247,7 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInfor
     m_AttenuationMapResampleImageFilter = ResampleImageFilterType::New();
     m_AttenuationMapChangeInformation = ChangeInformationFilterType::New();
     m_AttenuationMapChangeInformation->ChangeOriginOn();
-    m_AttenuationMapChangeInformation->SetReferenceImage(m_DiscreteGaussianFilter->GetOutput());
+    m_AttenuationMapChangeInformation->SetReferenceImage(m_DiscreteGaussianImageFilter->GetOutput());
     m_AttenuationMapChangeInformation->SetUseReferenceImage(true);
     m_CustomUnaryFilter = CustomUnaryFilterType::New();
 
@@ -275,14 +275,14 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateOutputInfor
 
     m_AttenuationMapMultiplyImageFilter->SetInput1(m_RegionOfInterest->GetOutput());
     m_AttenuationMapMultiplyImageFilter->SetInput2(m_AttenuationMapRegionOfInterest->GetOutput());
-    m_DiscreteGaussianFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
+    m_DiscreteGaussianImageFilter->SetInput(m_AttenuationMapMultiplyImageFilter->GetOutput());
   }
 
   m_MultiplyImageFilter->SetConstant(spacingVolume[2]);
 
-  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianFilter->GetOutput());
+  m_PasteImageFilter->SetSourceImage(m_DiscreteGaussianImageFilter->GetOutput());
   m_PasteImageFilter->SetDestinationImage(this->GetInput(0));
-  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+  m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianImageFilter->GetOutput()->GetLargestPossibleRegion());
 
   // Update output information
   m_PasteImageFilter->UpdateOutputInformation();
@@ -374,7 +374,7 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
       currentSlice = m_AttenuationMapMultiplyImageFilter->GetOutput();
     }
     currentSlice->DisconnectPipeline();
-    m_DiscreteGaussianFilter->SetInput(currentSlice);
+    m_DiscreteGaussianImageFilter->SetInput(currentSlice);
     m_ChangeInformation->SetInput(m_RegionOfInterest->GetOutput());
 
     // Compute the distance between the current slice and the detector
@@ -391,7 +391,7 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
       // Compute the variance of the PSF for the current slice
       sigmaSlice = dist * 2. * thicknessSlice * pow(m_Alpha, 2.0) + 2. * thicknessSlice * m_Alpha * m_SigmaZero -
                    pow(m_Alpha, 2.0) * pow(thicknessSlice, 2.0);
-      m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+      m_DiscreteGaussianImageFilter->SetVariance(sigmaSlice);
 
       // Extract the next slice
       desiredRegion.SetIndex(Dimension - 1, index);
@@ -416,15 +416,15 @@ ZengForwardProjectionImageFilter<TInputImage, TOutputImage>::GenerateData()
         currentSlice = m_AttenuationMapMultiplyImageFilter->GetOutput();
       }
       currentSlice->DisconnectPipeline();
-      m_DiscreteGaussianFilter->SetInput(currentSlice);
+      m_DiscreteGaussianImageFilter->SetInput(currentSlice);
       dist -= rotatedVolume->GetSpacing()[2];
     }
     // Compute the variance of the PSF for the last slice
     sigmaSlice = pow(m_Alpha * dist + m_SigmaZero, 2.0);
-    m_DiscreteGaussianFilter->SetVariance(sigmaSlice);
+    m_DiscreteGaussianImageFilter->SetVariance(sigmaSlice);
     // Paste the projection in the output volume
     indexProjection[Dimension - 1] = nbProjections;
-    m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianFilter->GetOutput()->GetLargestPossibleRegion());
+    m_PasteImageFilter->SetSourceRegion(m_DiscreteGaussianImageFilter->GetOutput()->GetLargestPossibleRegion());
     m_PasteImageFilter->SetDestinationIndex(indexProjection);
     m_PasteImageFilter->UpdateLargestPossibleRegion();
     pimg = m_PasteImageFilter->GetOutput();


### PR DESCRIPTION
The commit also renames members accordingly. The Doxygen warnings were
```
<unknown>:0: warning: unable to resolve reference to 'itk::DiscreteGaussianFilter' for \ref command
<unknown>:0: warning: unable to resolve reference to 'itk::ConstantVolumeSource' for \ref command
```