### PR TITLE
COMP: Fix format string

### DIFF
--- a/include/rtkIterationCommands.h
+++ b/include/rtkIterationCommands.h
@@ -157,8 +157,15 @@ protected:
     using WriterType = itk::ImageFileWriter<TOutputImage>;
     auto writer = WriterType::New();
 
-    char         buffer[1024];
+    char buffer[1024];
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
     unsigned int size = snprintf(buffer, 1024, m_FileFormat.c_str(), this->m_IterationCount);
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
     writer->SetFileName(std::string(buffer, size));
 
     writer->SetInput(caller->GetOutput());


### PR DESCRIPTION
Replace the snprintf-based iteration output formatting with a direct substitution of the documented %d placeholder.

This avoids GCC's -Wformat-nonliteral warning when the filename pattern comes from --iteration-file-name, while preserving the supported behavior.