### PR TITLE
ENH: Support install-tree use of RTK when built externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,26 +210,7 @@ endif()
 "
 )
 
-set(
-  RTK_EXPORT_CODE_INSTALL
-  "
-# The RTK version number
-set(RTK_VERSION_MAJOR ${RTK_VERSION_MAJOR})
-set(RTK_VERSION_MINOR ${RTK_VERSION_MINOR})
-set(RTK_VERSION_PATCH ${RTK_VERSION_PATCH})
-
-# Whether the compiled version of RTK uses CUDA
-set(RTK_USE_CUDA ${RTK_USE_CUDA})
-
-# Whether RTK applications were built
-set(RTK_BUILD_APPLICATIONS ${RTK_BUILD_APPLICATIONS})
-
-if(RTK_USE_CUDA)
-  find_package(CUDAToolkit)
-  set(RTK_CUDA_PROJECTIONS_SLAB_SIZE \"16\" CACHE STRING \"Number of projections processed simultaneously in CUDA forward and back projections\")
-endif()
-"
-)
+set(RTK_EXPORT_CODE_INSTALL "${RTK_EXPORT_CODE_BUILD}")
 
 #=========================================================
 # Configure and build ITK external module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,13 +318,6 @@ install(
     ${RTK_SOURCE_DIR}/cmake/FindGengetopt.cmake
   DESTINATION ${ITK_INSTALL_PACKAGE_DIR}
 )
-if(NOT ITK_SOURCE_DIR)
-  install(
-    CODE
-      "MESSAGE(FATAL_ERROR \"Cannot install, RTK is compiled separately from ITK. Installation is only functional if RTK is compiled within ITK.\")"
-  )
-endif()
-
 #=========================================================
 # Build applications
 #=========================================================
@@ -387,4 +380,12 @@ if(
   if(_result AND NOT "${_output}" MATCHES "Error copying file")
     message("${_output}")
   endif()
+endif()
+
+if(NOT ITK_SOURCE_DIR)
+  install(
+    EXPORT ${${itk-module}-targets}
+    DESTINATION "${ITK_INSTALL_PACKAGE_DIR}/Modules/Targets"
+    COMPONENT Development
+  )
 endif()

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,8 +20,6 @@ For RTK developpers, it may be useful to compile RTK independently from ITK. Thi
 * Manually download RTK's source repository from [GitHub](https://github.com/RTKConsortium/RTK) with `git` (recommended) or as a [zip package](https://codeload.github.com/RTKConsortium/RTK/zip/main).
 * Configure the project with CMake pointing to RTK's source directory and setting the CMake option `ITK_DIR` to ITK's compilation directory. All CMake options above can be set except `Module_RTK`.
 
-Installation is currently not supported for independent RTK compilations.
-
 ## Python pre-compiled binaries
 We only provide pre-compiled binaries for the Python package which depends on ITK. Use the following commands to install the RTK module with `pip`.
 ```


### PR DESCRIPTION
After some tests, it seems  possible to install standalone modules, so I removed the error message.

Close #957 