### PR TITLE
COMP: Restore namespace itk in IO factory files

### DIFF
--- a/src/rtkDCMImagXImageIOFactory.cxx
+++ b/src/rtkDCMImagXImageIOFactory.cxx
@@ -31,8 +31,13 @@ DCMImagXImageIOFactory::DCMImagXImageIOFactory()
                          itk::CreateObjectFunction<DCMImagXImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool DCMImagXImageIOFactoryHasBeenRegistered;
 
@@ -46,4 +51,4 @@ DCMImagXImageIOFactoryRegister__Private()
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkHisImageIOFactory.cxx
+++ b/src/rtkHisImageIOFactory.cxx
@@ -29,8 +29,13 @@ HisImageIOFactory::HisImageIOFactory()
     "itkImageIOBase", "HisImageIO", "His Image IO", true, itk::CreateObjectFunction<HisImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool HisImageIOFactoryHasBeenRegistered;
 
@@ -40,8 +45,8 @@ HisImageIOFactoryRegister__Private()
   if (!HisImageIOFactoryHasBeenRegistered)
   {
     HisImageIOFactoryHasBeenRegistered = true;
-    HisImageIOFactory::RegisterOneFactory();
+    rtk::HisImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkHncImageIOFactory.cxx
+++ b/src/rtkHncImageIOFactory.cxx
@@ -30,8 +30,13 @@ HncImageIOFactory::HncImageIOFactory()
     "itkImageIOBase", "HncImageIO", "Hnc Image IO", true, itk::CreateObjectFunction<HncImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool HncImageIOFactoryHasBeenRegistered;
 
@@ -41,8 +46,8 @@ HncImageIOFactoryRegister__Private()
   if (!HncImageIOFactoryHasBeenRegistered)
   {
     HncImageIOFactoryHasBeenRegistered = true;
-    HncImageIOFactory::RegisterOneFactory();
+    rtk::HncImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkHndImageIOFactory.cxx
+++ b/src/rtkHndImageIOFactory.cxx
@@ -30,8 +30,13 @@ HndImageIOFactory::HndImageIOFactory()
     "itkImageIOBase", "HndImageIO", "Hnd Image IO", true, itk::CreateObjectFunction<HndImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool HndImageIOFactoryHasBeenRegistered;
 
@@ -41,8 +46,8 @@ HndImageIOFactoryRegister__Private()
   if (!HndImageIOFactoryHasBeenRegistered)
   {
     HndImageIOFactoryHasBeenRegistered = true;
-    HndImageIOFactory::RegisterOneFactory();
+    rtk::HndImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkImagXImageIOFactory.cxx
+++ b/src/rtkImagXImageIOFactory.cxx
@@ -28,8 +28,13 @@ ImagXImageIOFactory::ImagXImageIOFactory()
     "itkImageIOBase", "ImagXImageIO", "ImagX Image IO", true, itk::CreateObjectFunction<ImagXImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool ImagXImageIOFactoryHasBeenRegistered;
 
@@ -39,8 +44,8 @@ ImagXImageIOFactoryRegister__Private()
   if (!ImagXImageIOFactoryHasBeenRegistered)
   {
     ImagXImageIOFactoryHasBeenRegistered = true;
-    ImagXImageIOFactory::RegisterOneFactory();
+    rtk::ImagXImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkOraImageIOFactory.cxx
+++ b/src/rtkOraImageIOFactory.cxx
@@ -30,8 +30,13 @@ OraImageIOFactory::OraImageIOFactory()
     "itkImageIOBase", "OraImageIO", "Ora Image IO", true, itk::CreateObjectFunction<OraImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool OraImageIOFactoryHasBeenRegistered;
 
@@ -41,8 +46,8 @@ OraImageIOFactoryRegister__Private()
   if (!OraImageIOFactoryHasBeenRegistered)
   {
     OraImageIOFactoryHasBeenRegistered = true;
-    OraImageIOFactory::RegisterOneFactory();
+    rtk::OraImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkXRadImageIOFactory.cxx
+++ b/src/rtkXRadImageIOFactory.cxx
@@ -28,8 +28,13 @@ XRadImageIOFactory::XRadImageIOFactory()
     "itkImageIOBase", "XRadImageIO", "XRad Image IO", true, itk::CreateObjectFunction<XRadImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool XRadImageIOFactoryHasBeenRegistered;
 
@@ -39,8 +44,8 @@ XRadImageIOFactoryRegister__Private()
   if (!XRadImageIOFactoryHasBeenRegistered)
   {
     XRadImageIOFactoryHasBeenRegistered = true;
-    XRadImageIOFactory::RegisterOneFactory();
+    rtk::XRadImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk

--- a/src/rtkXimImageIOFactory.cxx
+++ b/src/rtkXimImageIOFactory.cxx
@@ -30,8 +30,13 @@ XimImageIOFactory::XimImageIOFactory()
     "itkImageIOBase", "XimImageIO", "Xim Image IO", true, itk::CreateObjectFunction<XimImageIO>::New());
 }
 
+} // namespace rtk
+
 // Undocumented API used to register during static initialization.
 // DO NOT CALL DIRECTLY.
+
+namespace itk
+{
 
 static bool XimImageIOFactoryHasBeenRegistered;
 
@@ -41,8 +46,8 @@ XimImageIOFactoryRegister__Private()
   if (!XimImageIOFactoryHasBeenRegistered)
   {
     XimImageIOFactoryHasBeenRegistered = true;
-    XimImageIOFactory::RegisterOneFactory();
+    rtk::XimImageIOFactory::RegisterOneFactory();
   }
 }
 
-} // namespace rtk
+} // namespace itk


### PR DESCRIPTION
This is a modification of commit a40080a3b that removed the itk namespace in IO factories, Fix compilation error like "undefined reference to `itk::DCMImagXImageIOFactoryRegister__Private()"

Fix #970 