### PR TITLE
COMP: Fix ill-formed std::abs<double> in ConditionalMedianImageFilter

### DIFF
--- a/include/rtkConditionalMedianImageFilter.hxx
+++ b/include/rtkConditionalMedianImageFilter.hxx
@@ -95,7 +95,8 @@ ConditionalMedianImageFilter<TInputImage>::DynamicThreadedGenerateData(
     std::nth_element(pixels.begin(), pixels.begin() + pixels.size() / 2, pixels.end());
 
     // If the pixel value is too far from the median, replace it by the median
-    if (std::abs<double>(pixels[pixels.size() / 2] - nIt.GetCenterPixel()) > (m_ThresholdMultiplier * stdev))
+    if (std::abs(static_cast<double>(pixels[pixels.size() / 2] - nIt.GetCenterPixel())) >
+        (m_ThresholdMultiplier * stdev))
       outIt.Set(pixels[pixels.size() / 2]);
     else // Otherwise, leave it as is
       outIt.Set(nIt.GetCenterPixel());


### PR DESCRIPTION
`std::abs` has no function-template overload that accepts an explicit template argument, so `std::abs<double>(x)` is ill-formed. Conforming compilers (e.g. Apple clang) reject it as an ambiguous call, breaking any consumer that instantiates `ConditionalMedianImageFilter`. This computes the difference in `double` and calls the unambiguous `std::abs(double)` overload.

<details>
<summary>Context</summary>

Introduced by commit `3936486` ("COMP: Drop use of itk::Math::Absolute to fix compilation warnings"), which replaced `itk::Math::Absolute(...)` with `std::abs<double>(...)`. The surrounding arithmetic (`sum`, `mean`, `stdev`) is already computed in `double`, so casting the pixel-difference to `double` and calling `std::abs(double)` matches the intended semantics and remains warning-free.

Discovered while building RTK as an ITK remote module with Apple clang, where every translation unit including `rtkConditionalMedianImageFilter.hxx` failed with `call to 'abs' is ambiguous`. Verified locally: rebuilt RTK application/test targets with this change; the errors are cleared.
</details>
