### PR TITLE
DOC: Fix doc for bounding box in Cuda forward and back projectors

### DIFF
--- a/include/rtkCudaForwardProjectionImageFilter.hxx
+++ b/include/rtkCudaForwardProjectionImageFilter.hxx
@@ -59,8 +59,8 @@ CudaForwardProjectionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
   // Setting BoxMin and BoxMax
   // SR: we are using cuda textures where the pixel definition is not center but corner.
-  // Therefore, we set the box limits from index to index+size instead of, for ITK,
-  // index-0.5 to index+size-0.5.
+  // Therefore, we set the box limits from index+0.5 to index+size-0.5 instead of, for ITK,
+  // index to index+size-1 (from the first pixel center to the last pixel center).
   float boxMin[3];
   float boxMax[3];
   for (unsigned int i = 0; i < 3; i++)

--- a/src/rtkCudaRayCastBackProjectionImageFilter.cxx
+++ b/src/rtkCudaRayCastBackProjectionImageFilter.cxx
@@ -52,8 +52,8 @@ CudaRayCastBackProjectionImageFilter ::GPUGenerateData()
 
   // Setting BoxMin and BoxMax
   // SR: we are using cuda textures where the pixel definition is not center but corner.
-  // Therefore, we set the box limits from index to index+size instead of, for ITK,
-  // index-0.5 to index+size-0.5.
+  // Therefore, we set the box limits from index+0.5 to index+size-0.5 instead of, for ITK,
+  // index to index+size-1 (from the first pixel center to the last pixel center).
   float boxMin[3];
   float boxMax[3];
   for (unsigned int i = 0; i < 3; i++)


### PR DESCRIPTION
The comment originally written in 1bf17054703e99450de08210a938b9a666b3b27c had not been updated after making it consistent with Joseph's CPU projector in 2db3d5391a57711ddf3f03853cf62eac7ed52afe.