### PR TITLE
ENH: Add GITHUB_TOKEN environment variable to pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,3 +18,5 @@ jobs:
 
     - name: Run pre-commit
       run: pre-commit run --all-files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This avoid the issue explained here https://github.com/cargo-bins/cargo-binstall/issues/2045