### PR TITLE
BUG: Use ptrdiff_t instead of int for pointer offsets in CPU projectors

### DIFF
--- a/include/rtkJosephBackAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephBackAttenuatedProjectionImageFilter.h
@@ -55,7 +55,7 @@ public:
   }
 
   TOutput
-  operator()(const double stepLengthInVoxel, const TCoordinateType weight, const TInput * p, const int i)
+  operator()(const double stepLengthInVoxel, const TCoordinateType weight, const TInput * p, const ptrdiff_t i)
   {
     const double w = weight * stepLengthInVoxel;
 

--- a/include/rtkJosephBackProjectionImageFilter.h
+++ b/include/rtkJosephBackProjectionImageFilter.h
@@ -58,7 +58,7 @@ public:
   operator()(const double          itkNotUsed(stepLengthInVoxel),
              const TCoordinateType itkNotUsed(weight),
              const TInput *        itkNotUsed(p),
-             const int             itkNotUsed(i)) const
+             const ptrdiff_t       itkNotUsed(i)) const
   {
     return {};
   }
@@ -279,8 +279,8 @@ protected:
                 OutputPixelType *      pxsys,
                 double                 x,
                 double                 y,
-                int                    ox,
-                int                    oy);
+                ptrdiff_t              ox,
+                ptrdiff_t              oy);
 
   inline void
   BilinearSplatOnBorders(const InputPixelType & rayValue,
@@ -292,8 +292,8 @@ protected:
                          OutputPixelType *      pxsys,
                          double                 x,
                          double                 y,
-                         int                    ox,
-                         int                    oy,
+                         ptrdiff_t              ox,
+                         ptrdiff_t              oy,
                          CoordinateType         minx,
                          CoordinateType         miny,
                          CoordinateType         maxx,
@@ -307,8 +307,8 @@ protected:
                         const InputPixelType * pxsys,
                         double                 x,
                         double                 y,
-                        int                    ox,
-                        int                    oy);
+                        ptrdiff_t              ox,
+                        ptrdiff_t              oy);
 
   inline OutputPixelType
   BilinearInterpolationOnBorders(double                 stepLengthInVoxel,
@@ -318,8 +318,8 @@ protected:
                                  const InputPixelType * pxsys,
                                  double                 x,
                                  double                 y,
-                                 int                    ox,
-                                 int                    oy,
+                                 ptrdiff_t              ox,
+                                 ptrdiff_t              oy,
                                  double                 minx,
                                  double                 miny,
                                  double                 maxx,

--- a/include/rtkJosephBackProjectionImageFilter.hxx
+++ b/include/rtkJosephBackProjectionImageFilter.hxx
@@ -61,7 +61,7 @@ JosephBackProjectionImageFilter<TInputImage,
 
   const unsigned int               Dimension = TInputImage::ImageDimension;
   typename TInputImage::RegionType buffReg = this->GetInput(1)->GetBufferedRegion();
-  int                              offsets[3];
+  ptrdiff_t                        offsets[3];
   offsets[0] = 1;
   offsets[1] = this->GetInput(0)->GetBufferedRegion().GetSize()[0];
   offsets[2] =
@@ -129,7 +129,7 @@ JosephBackProjectionImageFilter<TInputImage,
   // Go over each pixel of the projection
   typename BoxShape::VectorType stepMM;
   typename BoxShape::PointType  np, fp;
-  for (unsigned int pix = 0; pix < buffReg.GetNumberOfPixels(); pix++, itIn->Next())
+  for (size_t pix = 0; pix < buffReg.GetNumberOfPixels(); pix++, itIn->Next())
   {
     typename InputRegionIterator::PointType  pixelPosition = itIn->GetPixelPosition();
     typename InputRegionIterator::VectorType dirVox = -itIn->GetSourceToPixel();
@@ -174,9 +174,9 @@ JosephBackProjectionImageFilter<TInputImage,
       const CoordinateType maxy = box->GetBoxMax()[notMainDirSup];
 
       // Init data pointers to first pixel of slice ns (i)nferior and (s)uperior (x|y) corner
-      const int offsetx = offsets[notMainDirInf];
-      const int offsety = offsets[notMainDirSup];
-      int       offsetz = offsets[mainDir];
+      const ptrdiff_t offsetx = offsets[notMainDirInf];
+      const ptrdiff_t offsety = offsets[notMainDirSup];
+      ptrdiff_t       offsetz = offsets[mainDir];
 
       OutputPixelType * pxiyi = beginBuffer + ns * offsetz;
       OutputPixelType * pxsyi = pxiyi + offsetx;
@@ -341,12 +341,12 @@ JosephBackProjectionImageFilter<TInputImage,
                                                              OutputPixelType *      pxsys,
                                                              const double           x,
                                                              const double           y,
-                                                             const int              ox,
-                                                             const int              oy)
+                                                             const ptrdiff_t        ox,
+                                                             const ptrdiff_t        oy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
@@ -377,25 +377,25 @@ JosephBackProjectionImageFilter<TInputImage,
                                                                       OutputPixelType *      pxsys,
                                                                       const double           x,
                                                                       const double           y,
-                                                                      const int              ox,
-                                                                      const int              oy,
+                                                                      const ptrdiff_t        ox,
+                                                                      const ptrdiff_t        oy,
                                                                       const CoordinateType   minx,
                                                                       const CoordinateType   miny,
                                                                       const CoordinateType   maxx,
                                                                       const CoordinateType   maxy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
   CoordinateType lyc = 1. - ly;
 
-  int offset_xi = 0;
-  int offset_yi = 0;
-  int offset_xs = 0;
-  int offset_ys = 0;
+  ptrdiff_t offset_xi = 0;
+  ptrdiff_t offset_yi = 0;
+  ptrdiff_t offset_xs = 0;
+  ptrdiff_t offset_ys = 0;
 
   if (ix < minx)
     offset_xi = ox;
@@ -433,12 +433,12 @@ JosephBackProjectionImageFilter<TInputImage,
                                                                      const InputPixelType * pxsys,
                                                                      const CoordinateType   x,
                                                                      const CoordinateType   y,
-                                                                     const int              ox,
-                                                                     const int              oy)
+                                                                     const ptrdiff_t        ox,
+                                                                     const ptrdiff_t        oy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
@@ -470,25 +470,25 @@ JosephBackProjectionImageFilter<TInputImage,
                                                                               const InputPixelType * pxsys,
                                                                               const CoordinateType   x,
                                                                               const CoordinateType   y,
-                                                                              const int              ox,
-                                                                              const int              oy,
+                                                                              const ptrdiff_t        ox,
+                                                                              const ptrdiff_t        oy,
                                                                               const CoordinateType   minx,
                                                                               const CoordinateType   miny,
                                                                               const CoordinateType   maxx,
                                                                               const CoordinateType   maxy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
   CoordinateType lyc = 1. - ly;
 
-  int offset_xi = 0;
-  int offset_yi = 0;
-  int offset_xs = 0;
-  int offset_ys = 0;
+  ptrdiff_t offset_xi = 0;
+  ptrdiff_t offset_yi = 0;
+  ptrdiff_t offset_xs = 0;
+  ptrdiff_t offset_ys = 0;
 
   OutputPixelType result = itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue();
   if (ix < minx)

--- a/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
+++ b/include/rtkJosephForwardAttenuatedProjectionImageFilter.h
@@ -71,7 +71,7 @@ public:
              const double          stepLengthInVoxel,
              const TCoordinateType weight,
              const TInput *        p,
-             const int             i)
+             const ptrdiff_t       i)
   {
     const double w = weight * stepLengthInVoxel;
 

--- a/include/rtkJosephForwardProjectionImageFilter.h
+++ b/include/rtkJosephForwardProjectionImageFilter.h
@@ -61,7 +61,7 @@ public:
              const double          itkNotUsed(stepLengthInVoxel),
              const TCoordinateType weight,
              const TInput *        p,
-             const int             i) const
+             const ptrdiff_t       i) const
   {
     return weight * p[i];
   }
@@ -323,8 +323,8 @@ protected:
                         const InputPixelType * pxsys,
                         double                 x,
                         double                 y,
-                        int                    ox,
-                        int                    oy);
+                        ptrdiff_t              ox,
+                        ptrdiff_t              oy);
 
   inline OutputPixelType
   BilinearInterpolationOnBorders(ThreadIdType           threadId,
@@ -335,8 +335,8 @@ protected:
                                  const InputPixelType * pxsys,
                                  double                 x,
                                  double                 y,
-                                 int                    ox,
-                                 int                    oy,
+                                 ptrdiff_t              ox,
+                                 ptrdiff_t              oy,
                                  double                 minx,
                                  double                 miny,
                                  double                 maxx,

--- a/include/rtkJosephForwardProjectionImageFilter.hxx
+++ b/include/rtkJosephForwardProjectionImageFilter.hxx
@@ -184,7 +184,7 @@ JosephForwardProjectionImageFilter<TInputImage,
                                                                        ThreadIdType threadId)
 {
   const unsigned int Dimension = TInputImage::ImageDimension;
-  int                offsets[3];
+  ptrdiff_t          offsets[3];
   offsets[0] = 1;
   offsets[1] = this->GetInput(1)->GetBufferedRegion().GetSize()[0];
   offsets[2] =
@@ -239,7 +239,7 @@ JosephForwardProjectionImageFilter<TInputImage,
   double superiorClip = 1. - m_InferiorClip;
 
   // Go over each pixel of the projection
-  for (unsigned int pix = 0; pix < outputRegionForThread.GetNumberOfPixels(); pix++, itIn->Next(), ++itOut)
+  for (size_t pix = 0; pix < outputRegionForThread.GetNumberOfPixels(); pix++, itIn->Next(), ++itOut)
   {
     typename InputRegionIterator::PointType  pixelPosition = itIn->GetPixelPosition();
     typename InputRegionIterator::VectorType dirVox = -itIn->GetSourceToPixel();
@@ -298,9 +298,9 @@ JosephForwardProjectionImageFilter<TInputImage,
       const CoordinateType maxy = box->GetBoxMax()[notMainDirSup];
 
       // Init data pointers to first pixel of slice ns (i)nferior and (s)uperior (x|y) corner
-      const int offsetx = offsets[notMainDirInf];
-      const int offsety = offsets[notMainDirSup];
-      int       offsetz = offsets[mainDir];
+      const ptrdiff_t offsetx = offsets[notMainDirInf];
+      const ptrdiff_t offsety = offsets[notMainDirSup];
+      ptrdiff_t       offsetz = offsets[mainDir];
 
       const typename TInputImage::PixelType * pxiyi = beginBuffer + ns * offsetz;
       const typename TInputImage::PixelType * pxsyi = pxiyi + offsetx;
@@ -448,12 +448,12 @@ JosephForwardProjectionImageFilter<TInputImage,
                                                                         const InputPixelType * pxsys,
                                                                         const CoordinateType   x,
                                                                         const CoordinateType   y,
-                                                                        const int              ox,
-                                                                        const int              oy)
+                                                                        const ptrdiff_t        ox,
+                                                                        const ptrdiff_t        oy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
@@ -498,25 +498,25 @@ JosephForwardProjectionImageFilter<TInputImage,
                                                                                  const InputPixelType * pxsys,
                                                                                  const CoordinateType   x,
                                                                                  const CoordinateType   y,
-                                                                                 const int              ox,
-                                                                                 const int              oy,
+                                                                                 const ptrdiff_t        ox,
+                                                                                 const ptrdiff_t        oy,
                                                                                  const CoordinateType   minx,
                                                                                  const CoordinateType   miny,
                                                                                  const CoordinateType   maxx,
                                                                                  const CoordinateType   maxy)
 {
-  int            ix = itk::Math::floor(x);
-  int            iy = itk::Math::floor(y);
-  int            idx = ix * ox + iy * oy;
+  ptrdiff_t      ix = itk::Math::floor(x);
+  ptrdiff_t      iy = itk::Math::floor(y);
+  ptrdiff_t      idx = ix * ox + iy * oy;
   CoordinateType lx = x - ix;
   CoordinateType ly = y - iy;
   CoordinateType lxc = 1. - lx;
   CoordinateType lyc = 1. - ly;
 
-  int offset_xi = 0;
-  int offset_yi = 0;
-  int offset_xs = 0;
-  int offset_ys = 0;
+  ptrdiff_t offset_xi = 0;
+  ptrdiff_t offset_yi = 0;
+  ptrdiff_t offset_xs = 0;
+  ptrdiff_t offset_ys = 0;
 
   OutputPixelType result = itk::NumericTraits<typename TOutputImage::PixelType>::ZeroValue();
   if (ix < minx)


### PR DESCRIPTION
Fixes #979, i.e., segmentation faults when projecting large volumes causing int overflow.