### PR TITLE
BUG: Avoid 32-bit index/offset overflow in CUDA filters for large images

### DIFF
--- a/.github/workflows/build-test-cxx-cuda.yml
+++ b/.github/workflows/build-test-cxx-cuda.yml
@@ -5,6 +5,9 @@ on: [push,pull_request]
 env:
   itk-git-tag: "v5.4.7"
   itk-module-deps: "CudaCommon@main"
+  warnings-to-ignore: |
+    "warning #1388-D"
+    "warning #1394-D"
 
 concurrency:
   group: '${{ github.workflow }}@${{ github.head_ref || github.run_id }}'

--- a/include/rtkCudaForwardProjectionImageFilter.hxx
+++ b/include/rtkCudaForwardProjectionImageFilter.hxx
@@ -34,6 +34,10 @@
 #  include <itkLinearInterpolateImageFunction.h>
 #  include <itkMacro.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
+
 namespace rtk
 {
 
@@ -49,11 +53,11 @@ CudaForwardProjectionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
 
   const typename Superclass::GeometryType * geometry = this->GetGeometry();
   const unsigned int                        Dimension = TInputImage::ImageDimension;
-  const unsigned int iFirstProj = this->GetInput(0)->GetRequestedRegion().GetIndex(Dimension - 1);
-  const unsigned int nProj = this->GetInput(0)->GetRequestedRegion().GetSize(Dimension - 1);
-  const unsigned int nPixelsPerProj = this->GetOutput()->GetBufferedRegion().GetSize(0) *
-                                      this->GetOutput()->GetBufferedRegion().GetSize(1) *
-                                      itk::NumericTraits<typename TInputImage::PixelType>::GetLength();
+  const unsigned int  iFirstProj = this->GetInput(0)->GetRequestedRegion().GetIndex(Dimension - 1);
+  const unsigned int  nProj = this->GetInput(0)->GetRequestedRegion().GetSize(Dimension - 1);
+  const SizeValueType nPixelsPerProj = this->GetOutput()->GetBufferedRegion().GetSize(0) *
+                                       this->GetOutput()->GetBufferedRegion().GetSize(1) *
+                                       itk::NumericTraits<typename TInputImage::PixelType>::GetLength();
 
   itk::Vector<double, 4> source_position;
 
@@ -166,7 +170,7 @@ CudaForwardProjectionImageFilter<TInputImage, TOutputImage>::GPUGenerateData()
       source_positions[(iProj - iFirstProj) * 3 + d] = source_position[d]; // Ignore the 4th component
   }
 
-  int                projectionOffset = 0;
+  OffsetValueType    projectionOffset = 0;
   const unsigned int vectorLength = itk::PixelTraits<typename TInputImage::PixelType>::Dimension;
 
   for (unsigned int i = 0; i < nProj; i += SLAB_SIZE)

--- a/src/rtkCudaAverageOutOfROIImageFilter.cu
+++ b/src/rtkCudaAverageOutOfROIImageFilter.cu
@@ -20,11 +20,14 @@
 #include "rtkCudaAverageOutOfROIImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
 #include <cuda_runtime.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 // TEXTURES AND CONSTANTS //
 
@@ -37,18 +40,18 @@ __constant__ int4 c_Size;
 
 
 __global__ void
-average_along_dim_4(float * in, float * out, float * roi, unsigned int strideInFloats)
+average_along_dim_4(float * in, float * out, float * roi, SizeValueType strideInFloats)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
   // Compute the index of the initial voxel
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
-  long int strided_id = id; // strided_id will run along the 4th dimension
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType strided_id = id; // strided_id will run along the 4th dimension
 
   // Compute the average along last dimension
   float avg = 0;
@@ -84,7 +87,7 @@ CUDA_average_out_of_ROI(int size[4], float * input, float * output, float * roi)
 
   // Compute the stride (in floats, not Bytes) to jump from one voxel
   // to the next one along 4th dimension
-  unsigned int strideInFloats = size[0] * size[1] * size[2];
+  SizeValueType strideInFloats = static_cast<SizeValueType>(size[0]) * size[1] * size[2];
 
   // Thread Block Dimensions
   dim3 dimBlock = dim3(8, 8, 8);

--- a/src/rtkCudaBackProjectionImageFilter.cu
+++ b/src/rtkCudaBackProjectionImageFilter.cu
@@ -39,6 +39,9 @@
  *****************/
 #include <cuda.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // Constant memory
 __constant__ float c_matrices[SLAB_SIZE * 12]; // Can process stacks of at most SLAB_SIZE projections
 __constant__ float c_volIndexToProjPP[SLAB_SIZE * 12];
@@ -55,9 +58,9 @@ template <unsigned int VVectorLength, bool VIsCylindrical>
 __global__ void
 kernel_backProject(float * dev_vol_in, float * dev_vol_out, float radius, cudaTextureObject_t * dev_tex_proj)
 {
-  itk::SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  itk::SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  itk::SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= c_volSize.x || j >= c_volSize.y || k >= c_volSize.z)
   {
@@ -65,7 +68,7 @@ kernel_backProject(float * dev_vol_in, float * dev_vol_out, float radius, cudaTe
   }
 
   // Index row major into the volume
-  itk::SizeValueType vol_idx = i + (j + k * c_volSize.y) * (c_volSize.x);
+  SizeValueType vol_idx = i + (j + k * c_volSize.y) * (c_volSize.x);
 
   float3 ip, pp;
   float  voxel_data[VVectorLength];

--- a/src/rtkCudaConjugateGradientImageFilter.cu
+++ b/src/rtkCudaConjugateGradientImageFilter.cu
@@ -50,7 +50,7 @@ CUDA_subtract(size_t numberOfElements, float * out, float * toBeSubtracted)
   cublasCreate(&handle);
 
   const float alpha = -1.0;
-#if CUDA_VERSION < 12000
+#if CUBLAS_VER_MAJOR < 12
   cublasSaxpy(handle, (int)numberOfElements, &alpha, toBeSubtracted, 1, out, 1);
 #else
   cublasSaxpy_64(handle, numberOfElements, &alpha, toBeSubtracted, 1, out, 1);
@@ -69,7 +69,11 @@ CUDA_subtract(size_t numberOfElements, double * out, double * toBeSubtracted)
   cublasCreate(&handle);
 
   const double alpha = -1.0;
+#if CUBLAS_VER_MAJOR < 12
   cublasDaxpy(handle, (int)numberOfElements, &alpha, toBeSubtracted, 1, out, 1);
+#else
+  cublasDaxpy_64(handle, numberOfElements, &alpha, toBeSubtracted, 1, out, 1);
+#endif
 
   // Destroy Cublas context
   cublasDestroy(handle);
@@ -87,24 +91,44 @@ CUDA_conjugate_gradient(size_t numberOfElements, float * Xk, float * Rk, float *
 
   // Compute Rk_square = sum(Rk(:).^2) by cublas
   float Rk_square = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasSdot(handle, (int)numberOfElements, Rk, 1, Rk, 1, &Rk_square);
+#else
+  cublasSdot_64(handle, numberOfElements, Rk, 1, Rk, 1, &Rk_square);
+#endif
 
   // Compute alpha_k = Rk_square / sum(Pk(:) .* APk(:))
   float Pk_APk = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasSdot(handle, (int)numberOfElements, Pk, 1, APk, 1, &Pk_APk);
+#else
+  cublasSdot_64(handle, numberOfElements, Pk, 1, APk, 1, &Pk_APk);
+#endif
 
   const float alpha_k = Rk_square / (Pk_APk + eps);
   const float minus_alpha_k = -alpha_k;
 
   // Compute Xk+1 = Xk + alpha_k * Pk
+#if CUBLAS_VER_MAJOR < 12
   cublasSaxpy(handle, (int)numberOfElements, &alpha_k, Pk, 1, Xk, 1);
+#else
+  cublasSaxpy_64(handle, numberOfElements, &alpha_k, Pk, 1, Xk, 1);
+#endif
 
   // Compute Rk+1 = Rk - alpha_k * APk
+#if CUBLAS_VER_MAJOR < 12
   cublasSaxpy(handle, (int)numberOfElements, &minus_alpha_k, APk, 1, Rk, 1);
+#else
+  cublasSaxpy_64(handle, numberOfElements, &minus_alpha_k, APk, 1, Rk, 1);
+#endif
 
   // Compute beta_k = sum(Rk+1(:).^2) / Rk_square
   float Rkplusone_square = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasSdot(handle, (int)numberOfElements, Rk, 1, Rk, 1, &Rkplusone_square);
+#else
+  cublasSdot_64(handle, numberOfElements, Rk, 1, Rk, 1, &Rkplusone_square);
+#endif
 
   float beta_k = Rkplusone_square / (Rk_square + eps);
   float one = 1.0;
@@ -112,8 +136,13 @@ CUDA_conjugate_gradient(size_t numberOfElements, float * Xk, float * Rk, float *
   // Compute Pk+1 = Rk+1 + beta_k * Pk
   // This requires two cublas functions,
   // since axpy would store the result in the wrong array
+#if CUBLAS_VER_MAJOR < 12
   cublasSscal(handle, (int)numberOfElements, &beta_k, Pk, 1);
   cublasSaxpy(handle, (int)numberOfElements, &one, Rk, 1, Pk, 1);
+#else
+  cublasSscal_64(handle, numberOfElements, &beta_k, Pk, 1);
+  cublasSaxpy_64(handle, numberOfElements, &one, Rk, 1, Pk, 1);
+#endif
 
   // Destroy Cublas context
   cublasDestroy(handle);
@@ -131,24 +160,44 @@ CUDA_conjugate_gradient(size_t numberOfElements, double * Xk, double * Rk, doubl
 
   // Compute Rk_square = sum(Rk(:).^2) by cublas
   double Rk_square = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasDdot(handle, (int)numberOfElements, Rk, 1, Rk, 1, &Rk_square);
+#else
+  cublasDdot_64(handle, numberOfElements, Rk, 1, Rk, 1, &Rk_square);
+#endif
 
   // Compute alpha_k = Rk_square / sum(Pk(:) .* APk(:))
   double Pk_APk = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasDdot(handle, (int)numberOfElements, Pk, 1, APk, 1, &Pk_APk);
+#else
+  cublasDdot_64(handle, numberOfElements, Pk, 1, APk, 1, &Pk_APk);
+#endif
 
   const double alpha_k = Rk_square / (Pk_APk + eps);
   const double minus_alpha_k = -alpha_k;
 
   // Compute Xk+1 = Xk + alpha_k * Pk
+#if CUBLAS_VER_MAJOR < 12
   cublasDaxpy(handle, (int)numberOfElements, &alpha_k, Pk, 1, Xk, 1);
+#else
+  cublasDaxpy_64(handle, numberOfElements, &alpha_k, Pk, 1, Xk, 1);
+#endif
 
   // Compute Rk+1 = Rk - alpha_k * APk
+#if CUBLAS_VER_MAJOR < 12
   cublasDaxpy(handle, (int)numberOfElements, &minus_alpha_k, APk, 1, Rk, 1);
+#else
+  cublasDaxpy_64(handle, numberOfElements, &minus_alpha_k, APk, 1, Rk, 1);
+#endif
 
   // Compute beta_k = sum(Rk+1(:).^2) / Rk_square
   double Rkplusone_square = 0;
+#if CUBLAS_VER_MAJOR < 12
   cublasDdot(handle, (int)numberOfElements, Rk, 1, Rk, 1, &Rkplusone_square);
+#else
+  cublasDdot_64(handle, numberOfElements, Rk, 1, Rk, 1, &Rkplusone_square);
+#endif
 
   double beta_k = Rkplusone_square / (Rk_square + eps);
   double one = 1.0;
@@ -156,8 +205,13 @@ CUDA_conjugate_gradient(size_t numberOfElements, double * Xk, double * Rk, doubl
   // Compute Pk+1 = Rk+1 + beta_k * Pk
   // This requires two cublas functions,
   // since axpy would store the result in the wrong array
+#if CUBLAS_VER_MAJOR < 12
   cublasDscal(handle, (int)numberOfElements, &beta_k, Pk, 1);
   cublasDaxpy(handle, (int)numberOfElements, &one, Rk, 1, Pk, 1);
+#else
+  cublasDscal_64(handle, numberOfElements, &beta_k, Pk, 1);
+  cublasDaxpy_64(handle, numberOfElements, &one, Rk, 1, Pk, 1);
+#endif
 
   // Destroy Cublas context
   cublasDestroy(handle);

--- a/src/rtkCudaConstantVolumeSeriesSource.cu
+++ b/src/rtkCudaConstantVolumeSeriesSource.cu
@@ -20,10 +20,13 @@
 #include "rtkCudaConstantVolumeSeriesSource.hcu"
 #include "rtkCudaUtilities.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 // TEXTURES AND CONSTANTS //
 
@@ -38,14 +41,14 @@ __constant__ int4 c_Size;
 __global__ void
 set_volume_series_to_constant(float * out, float value)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z * c_Size.w)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
 
   out[id] = value;
 }
@@ -74,7 +77,7 @@ CUDA_generate_constant_volume_series(int size[4], float * dev_out, float constan
   // run a kernel to replace the zeros with constantValue.
 
   // Reset output volume
-  size_t memorySizeOutput = size[0] * size[1] * size[2] * size[3] * sizeof(float);
+  size_t memorySizeOutput = static_cast<size_t>(size[0]) * size[1] * size[2] * size[3] * sizeof(float);
   cudaMemset((void *)dev_out, 0, memorySizeOutput);
 
   if (!(constantValue == 0))

--- a/src/rtkCudaConstantVolumeSource.cu
+++ b/src/rtkCudaConstantVolumeSource.cu
@@ -20,10 +20,13 @@
 #include "rtkCudaConstantVolumeSource.hcu"
 #include "rtkCudaUtilities.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 // TEXTURES AND CONSTANTS //
 
@@ -38,14 +41,14 @@ __constant__ int3 c_Size;
 __global__ void
 set_volume_to_constant(float * out, float value)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
 
   out[id] = value;
 }
@@ -74,7 +77,7 @@ CUDA_generate_constant_volume(int size[3], float * dev_out, float constantValue)
   // run a kernel to replace the zeros with constantValue.
 
   // Reset output volume
-  size_t memorySizeOutput = size[0] * size[1] * size[2] * sizeof(float);
+  size_t memorySizeOutput = static_cast<size_t>(size[0]) * size[1] * size[2] * sizeof(float);
   cudaMemset((void *)dev_out, 0, memorySizeOutput);
 
   if (!(constantValue == 0))

--- a/src/rtkCudaCropImageFilter.cu
+++ b/src/rtkCudaCropImageFilter.cu
@@ -25,6 +25,9 @@
 #include <cuda.h>
 #include <cufft.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 __global__ void
 crop_kernel(float *            input,
             float *            output,
@@ -33,17 +36,17 @@ crop_kernel(float *            input,
             const uint3        inputDim,
             const unsigned int Blocks_Y)
 {
-  unsigned int blockIdx_z = blockIdx.y / Blocks_Y;
-  unsigned int blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
+  unsigned int  blockIdx_z = blockIdx.y / Blocks_Y;
+  unsigned int  blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
 
   if (i >= cropDim.x || j >= cropDim.y || k >= cropDim.z)
     return;
 
-  unsigned long int out_idx = i + j * cropDim.x + k * cropDim.y * cropDim.x;
-  unsigned long int in_idx = (cropIdx.x + i) + (cropIdx.y + j) * inputDim.x + (cropIdx.z + k) * inputDim.y * inputDim.x;
+  SizeValueType out_idx = i + j * cropDim.x + k * cropDim.y * cropDim.x;
+  SizeValueType in_idx = cropIdx.x + i + (cropIdx.y + j) * inputDim.x + (cropIdx.z + k) * inputDim.y * inputDim.x;
 
   output[out_idx] = input[in_idx];
 }

--- a/src/rtkCudaCyclicDeformationImageFilter.cu
+++ b/src/rtkCudaCyclicDeformationImageFilter.cu
@@ -51,7 +51,7 @@ CUDA_linear_interpolate_along_fourth_dimension(unsigned int inputSize[4],
   float wInf = (float)weightInf;
   float wSup = (float)weightSup;
 
-  size_t numel = inputSize[0] * inputSize[1] * inputSize[2] * 3;
+  size_t numel = static_cast<size_t>(inputSize[0]) * inputSize[1] * inputSize[2] * 3;
 
   cudaMemset((void *)output, 0, numel * sizeof(float));
 

--- a/src/rtkCudaDisplacedDetectorImageFilter.cu
+++ b/src/rtkCudaDisplacedDetectorImageFilter.cu
@@ -18,9 +18,13 @@
 
 #include "rtkCudaDisplacedDetectorImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
+#include <itkIntTypes.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <math_constants.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 inline __device__ float
 TransformIndexToPhysicalPoint(int2 idx, float origin, float row, float column)
@@ -59,22 +63,22 @@ kernel_displaced_weight(int3                proj_idx_in,
                         cudaTextureObject_t tex_geom   // geometry texture object
 )
 {
-  // compute thread index
-  int3 tIdx;
-  tIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
-  tIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
-  tIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
-  long int tIdx_comp = tIdx.x + tIdx.y * proj_size_out.x + tIdx.z * proj_size_out_buf.x * proj_size_out_buf.y;
+  // compute thread index (64-bit to avoid 32-bit overflow of combined indices)
+  SizeValueType tIdx_x = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType tIdx_y = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType tIdx_z = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType tIdx_comp = tIdx_x + tIdx_y * proj_size_out.x + tIdx_z * proj_size_out_buf.x * proj_size_out_buf.y;
 
   // check if outside of projection grid
-  if (tIdx.x >= proj_size_out.x || tIdx.y >= proj_size_out.y || tIdx.z >= proj_size_out.z)
+  if (tIdx_x >= proj_size_out.x || tIdx_y >= proj_size_out.y || tIdx_z >= proj_size_out.z)
     return;
 
   // compute projection index from thread index
-  int3 pIdx = make_int3(tIdx.x + proj_idx_out.x, tIdx.y + proj_idx_out.y, tIdx.z + proj_idx_out.z);
-  // combined proj. index -> use thread index in z because accessing memory only with this index
-  long int pIdx_comp = (pIdx.x - proj_idx_in.x) + (pIdx.y - proj_idx_in.y) * proj_size_in_buf.x +
-                       (pIdx.z - proj_idx_in.z) * proj_size_in_buf.x * proj_size_in_buf.y;
+  int3 pIdx = make_int3(tIdx_x + proj_idx_out.x, tIdx_y + proj_idx_out.y, tIdx_z + proj_idx_out.z);
+  // combined proj. index -> arithmetic in 64-bit to avoid overflow of the products
+  SizeValueType pIdx_comp = (tIdx_x - proj_idx_in.x + proj_idx_out.x) +
+                            (tIdx_y - proj_idx_in.y + proj_idx_out.y) * proj_size_in_buf.x +
+                            (tIdx_z - proj_idx_in.z + proj_idx_out.z) * proj_size_in_buf.x * proj_size_in_buf.y;
 
   // check if outside overlapping region
   if (pIdx.x < proj_idx_in.x || pIdx.x >= (proj_idx_in.x + proj_size_in.x) || pIdx.y < proj_idx_in.y ||
@@ -89,10 +93,10 @@ kernel_displaced_weight(int3                proj_idx_in,
   {
     float pPoint = TransformIndexToPhysicalPoint(make_int2(pIdx.x, pIdx.y), proj_orig, proj_row, proj_col);
 
-    float sdd = tex1Dfetch<float>(tex_geom, tIdx.z * 4 + 0);
-    float sx = tex1Dfetch<float>(tex_geom, tIdx.z * 4 + 1);
-    float px = tex1Dfetch<float>(tex_geom, tIdx.z * 4 + 2);
-    float sid = tex1Dfetch<float>(tex_geom, tIdx.z * 4 + 3);
+    float sdd = tex1Dfetch<float>(tex_geom, tIdx_z * 4 + 0);
+    float sx = tex1Dfetch<float>(tex_geom, tIdx_z * 4 + 1);
+    float px = tex1Dfetch<float>(tex_geom, tIdx_z * 4 + 2);
+    float sid = tex1Dfetch<float>(tex_geom, tIdx_z * 4 + 3);
 
     float hyp = sqrtf(sid * sid + sx * sx); // to untilted situation
     float l = ToUntiltedCoordinateAtIsocenter(pPoint, sdd, sid, sx, px, hyp);

--- a/src/rtkCudaFDKBackProjectionImageFilter.cu
+++ b/src/rtkCudaFDKBackProjectionImageFilter.cu
@@ -39,6 +39,9 @@
  *****************/
 #include <cuda.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // Constant memory
 __constant__ float c_matrices[SLAB_SIZE * 12]; // Can process stacks of at most SLAB_SIZE projections
 __constant__ int3  c_projSize;
@@ -52,9 +55,9 @@ __constant__ int3  c_vol_size;
 __global__ void
 kernel_fdk_3Dgrid(float * dev_vol_in, float * dev_vol_out, cudaTextureObject_t tex_proj)
 {
-  itk::SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  itk::SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  itk::SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= c_vol_size.x || j >= c_vol_size.y || k >= c_vol_size.z)
   {
@@ -62,7 +65,7 @@ kernel_fdk_3Dgrid(float * dev_vol_in, float * dev_vol_out, cudaTextureObject_t t
   }
 
   // Index row major into the volume
-  itk::SizeValueType vol_idx = i + (j + k * c_vol_size.y) * (c_vol_size.x);
+  SizeValueType vol_idx = i + (j + k * c_vol_size.y) * (c_vol_size.x);
 
   float3 ip;
   float  voxel_data = 0;

--- a/src/rtkCudaFDKWeightProjectionFilter.cu
+++ b/src/rtkCudaFDKWeightProjectionFilter.cu
@@ -18,8 +18,12 @@
 
 #include "rtkCudaFDKWeightProjectionFilter.hcu"
 #include "rtkCudaUtilities.hcu"
+#include <itkIntTypes.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 inline __device__ float2
 TransformIndexToPhysicalPoint(int2 idx, float2 origin, float2 row, float2 column)
@@ -40,38 +44,37 @@ kernel_weight_projection(int2                proj_idx,
                          cudaTextureObject_t tex_geom   // geometry texture object
 )
 {
-  // compute projection index (== thread index)
-  int3 pIdx;
-  pIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
-  pIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
-  pIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
-  long int pIdx_comp_in = pIdx.x + (pIdx.y + pIdx.z * proj_size_buf_in.y) * (proj_size_buf_in.x);
-  long int pIdx_comp_out = pIdx.x + (pIdx.y + pIdx.z * proj_size_buf_out.y) * (proj_size_buf_out.x);
+  // compute projection index (== thread index), 64-bit to avoid 32-bit overflow of combined indices
+  SizeValueType pIdx_x = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType pIdx_y = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType pIdx_z = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType pIdx_comp_in = pIdx_x + (pIdx_y + pIdx_z * proj_size_buf_in.y) * proj_size_buf_in.x;
+  SizeValueType pIdx_comp_out = pIdx_x + (pIdx_y + pIdx_z * proj_size_buf_out.y) * proj_size_buf_out.x;
 
   // check if outside of projection grid
-  if (pIdx.x >= proj_size.x || pIdx.y >= proj_size.y || pIdx.z >= proj_size.z)
+  if (pIdx_x >= proj_size.x || pIdx_y >= proj_size.y || pIdx_z >= proj_size.z)
     return;
 
-  const float sdd = tex1Dfetch<float>(tex_geom, pIdx.z * 7);
-  const float sid = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 1);
-  const float wFac = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 5);
+  const float sdd = tex1Dfetch<float>(tex_geom, pIdx_z * 7);
+  const float sid = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 1);
+  const float wFac = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 5);
   if (sdd == 0) // parallel
   {
     dev_proj_out[pIdx_comp_out] = dev_proj_in[pIdx_comp_in] * wFac;
   }
   else // divergent
   {
-    const float pOffX = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 2);
-    const float pOffY = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 3);
-    const float sOffY = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 4);
-    const float tAngle = tex1Dfetch<float>(tex_geom, pIdx.z * 7 + 6);
+    const float pOffX = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 2);
+    const float pOffY = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 3);
+    const float sOffY = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 4);
+    const float tAngle = tex1Dfetch<float>(tex_geom, pIdx_z * 7 + 6);
     const float sina = sin(tAngle);
     const float cosa = cos(tAngle);
     const float tana = tan(tAngle);
 
     // compute projection point from index
     float2 pPoint =
-      TransformIndexToPhysicalPoint(make_int2(pIdx.x + proj_idx.x, pIdx.y + proj_idx.y), proj_orig, proj_row, proj_col);
+      TransformIndexToPhysicalPoint(make_int2(pIdx_x + proj_idx.x, pIdx_y + proj_idx.y), proj_orig, proj_row, proj_col);
     pPoint.x = pPoint.x + pOffX + tana * (sdd - sid);
     pPoint.y = pPoint.y + pOffY - sOffY;
 

--- a/src/rtkCudaFFTProjectionsConvolutionImageFilter.cu
+++ b/src/rtkCudaFFTProjectionsConvolutionImageFilter.cu
@@ -20,25 +20,28 @@
 #include "rtkCudaUtilities.hcu"
 #include "rtkCudaFFTProjectionsConvolutionImageFilter.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
 #include <cufft.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 __global__ void
 multiply_kernel(cufftComplex * projFFT, int3 fftDimension, cufftComplex * kernelFFT, unsigned int Blocks_Y)
 {
-  unsigned int blockIdx_z = blockIdx.y / Blocks_Y;
-  unsigned int blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
+  unsigned int  blockIdx_z = blockIdx.y / Blocks_Y;
+  unsigned int  blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
+  unsigned int  i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  unsigned int  j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
 
   if (i >= fftDimension.x || j >= fftDimension.y || k >= fftDimension.z)
     return;
 
-  long int proj_idx = i + (j + k * fftDimension.y) * fftDimension.x;
+  SizeValueType proj_idx = i + (j + k * fftDimension.y) * fftDimension.x;
 
   cufftComplex result;
   result.x = projFFT[proj_idx].x * kernelFFT[i].x - projFFT[proj_idx].y * kernelFFT[i].y;
@@ -49,17 +52,17 @@ multiply_kernel(cufftComplex * projFFT, int3 fftDimension, cufftComplex * kernel
 __global__ void
 multiply_kernel2D(cufftComplex * projFFT, int3 fftDimension, cufftComplex * kernelFFT, unsigned int Blocks_Y)
 {
-  unsigned int blockIdx_z = blockIdx.y / Blocks_Y;
-  unsigned int blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
+  unsigned int  blockIdx_z = blockIdx.y / Blocks_Y;
+  unsigned int  blockIdx_y = blockIdx.y - __umul24(blockIdx_z, Blocks_Y);
+  unsigned int  i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  unsigned int  j = __umul24(blockIdx_y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx_z, blockDim.z) + threadIdx.z;
 
   if (i >= fftDimension.x || j >= fftDimension.y || k >= fftDimension.z)
     return;
 
-  long int kernel_idx = i + j * fftDimension.x;
-  long int proj_idx = kernel_idx + k * fftDimension.y * fftDimension.x;
+  SizeValueType kernel_idx = i + j * fftDimension.x;
+  SizeValueType proj_idx = kernel_idx + k * fftDimension.y * fftDimension.x;
 
   cufftComplex result;
   result.x = projFFT[proj_idx].x * kernelFFT[kernel_idx].x - projFFT[proj_idx].y * kernelFFT[kernel_idx].y;
@@ -78,7 +81,8 @@ CUDA_fft_convolution(const int3 &   inputDimension,
   int3           fftDimension = inputDimension;
   fftDimension.x = inputDimension.x / 2 + 1;
 
-  size_t memorySizeProjectionFFT = sizeof(cufftComplex) * fftDimension.x * fftDimension.y * fftDimension.z;
+  size_t memorySizeProjectionFFT =
+    sizeof(cufftComplex) * static_cast<size_t>(fftDimension.x) * fftDimension.y * fftDimension.z;
   cudaMalloc((void **)&deviceProjectionFFT, memorySizeProjectionFFT);
   CUDA_CHECK_ERROR;
 
@@ -143,28 +147,33 @@ padding_kernel(float *            input,
   if (i >= paddingDim.x || j >= paddingDim.y || k >= paddingDim.z)
     return;
 
-  unsigned long int out_idx = i + (j + k * paddingDim.y) * paddingDim.x;
+  // 64-bit copies of the (here non-negative) grid coordinates avoid 32-bit overflow
+  SizeValueType gi = i, gj = j, gk = k;
+  SizeValueType out_idx = gi + (gj + gk * paddingDim.y) * paddingDim.x;
   i -= paddingIdx.x;
   j -= paddingIdx.y;
   k -= paddingIdx.z;
+  // 64-bit copies of the subtracted indices (only used where the int is non-negative)
+  SizeValueType ii = i, jj = j, kk = k;
 
   // out of input y/z dimensions
   if (j < 0 || j >= inputDim.y || k < 0 || k >= inputDim.z)
     output[out_idx] = 0.0f;
   // central part in CPU code
   else if (i >= 0 && i < inputDim.x)
-    output[out_idx] = input[i + (j + k * inputDim.y) * inputDim.x];
+    output[out_idx] = input[ii + (jj + kk * inputDim.y) * inputDim.x];
   // left mirroring (equation 3a in [Ohnesorge et al, Med Phys, 2000])
   else if (i < 0 && -i < sizeWeights)
   {
-    int begRow = (j + k * inputDim.y) * inputDim.x;
-    output[out_idx] = (2 * input[begRow + 1] - input[-i + begRow]) * truncationWeights[-i];
+    SizeValueType mirroredPixel = -i;
+    SizeValueType begRow = (jj + kk * inputDim.y) * inputDim.x;
+    output[out_idx] = (2 * input[begRow + 1] - input[mirroredPixel + begRow]) * truncationWeights[-i];
   }
   // right mirroring (equation 3b in [Ohnesorge et al, Med Phys, 2000])
   else if ((i >= inputDim.x) && (i - inputDim.x + 1) < sizeWeights)
   {
-    unsigned int borderDist = i - inputDim.x + 1;
-    int          endRow = inputDim.x - 1 + (j + k * inputDim.y) * inputDim.x;
+    SizeValueType borderDist = ii - inputDim.x + 1;
+    SizeValueType endRow = inputDim.x - 1 + (jj + kk * inputDim.y) * inputDim.x;
     output[out_idx] = (2 * input[endRow] - input[endRow - borderDist]) * truncationWeights[borderDist];
   }
   // zero padding

--- a/src/rtkCudaFirstOrderKernels.cu
+++ b/src/rtkCudaFirstOrderKernels.cu
@@ -17,21 +17,26 @@
  *=========================================================================*/
 
 #include "rtkCudaFirstOrderKernels.hcu"
+#include <itkIntTypes.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
 
 __global__ void
 divergence_kernel(float * grad_x, float * grad_y, float * grad_z, float * out, int3 c_Size, float3 c_Spacing)
 {
-  int i = blockIdx.x * blockDim.x + threadIdx.x;
-  int j = blockIdx.y * blockDim.y + threadIdx.y;
-  int k = blockIdx.z * blockDim.z + threadIdx.z;
+  OffsetValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  OffsetValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  OffsetValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
-  long int id_x = (k * c_Size.y + j) * c_Size.x + i - 1;
-  long int id_y = (k * c_Size.y + j - 1) * c_Size.x + i;
-  long int id_z = ((k - 1) * c_Size.y + j) * c_Size.x + i;
+  OffsetValueType id = (k * c_Size.y + j) * c_Size.x + i;
+  OffsetValueType id_x = (k * c_Size.y + j) * c_Size.x + i - 1;
+  OffsetValueType id_y = (k * c_Size.y + j - 1) * c_Size.x + i;
+  OffsetValueType id_z = ((k - 1) * c_Size.y + j) * c_Size.x + i;
 
   float3 A;
   float3 B;
@@ -69,17 +74,17 @@ divergence_kernel(float * grad_x, float * grad_y, float * grad_z, float * out, i
 __global__ void
 gradient_kernel(float * in, float * grad_x, float * grad_y, float * grad_z, int3 c_Size, float3 c_Spacing)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
-  long int id_x = (k * c_Size.y + j) * c_Size.x + i + 1;
-  long int id_y = (k * c_Size.y + j + 1) * c_Size.x + i;
-  long int id_z = ((k + 1) * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id_x = (k * c_Size.y + j) * c_Size.x + i + 1;
+  SizeValueType id_y = (k * c_Size.y + j + 1) * c_Size.x + i;
+  SizeValueType id_z = ((k + 1) * c_Size.y + j) * c_Size.x + i;
 
   if (i == (c_Size.x - 1))
     grad_x[id] = 0;

--- a/src/rtkCudaForwardProjectionImageFilter.cu
+++ b/src/rtkCudaForwardProjectionImageFilter.cu
@@ -96,7 +96,7 @@ kernel_forwardProject(float * dev_proj_in, float * dev_proj_out, cudaTextureObje
 
     ray.d = pixelPos - ray.o;
 
-    int projOffset = numThread + proj * c_projSize.x * c_projSize.y;
+    size_t projOffset = static_cast<size_t>(numThread) + static_cast<size_t>(proj) * c_projSize.x * c_projSize.y;
 
     // Detect intersection with box
     if (!intersectBox(ray, &tnear, &tfar, c_boxMin, c_boxMax) || tnear >= 1.0f || tfar <= 0.f || tfar == tnear)

--- a/src/rtkCudaForwardWarpImageFilter.cu
+++ b/src/rtkCudaForwardWarpImageFilter.cu
@@ -39,6 +39,10 @@
  *****************/
 #include <cuda.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
+
 // CONSTANTS //////////////////////////////////////////////////////////////
 __constant__ float c_IndexInputToPPInputMatrix[12];
 __constant__ float c_IndexInputToIndexDVFMatrix[12];
@@ -62,10 +66,11 @@ fillHoles_3Dgrid(float * dev_vol_out, float * dev_accumulate_weights, int3 out_d
     return;
   }
 
-  // Index row major into the volume
-  long int out_idx = i + (j + k * out_dim.y) * (out_dim.x);
-  long int current_idx;
-  int      radius = 3;
+  // Index row major into the volume (64-bit to avoid 32-bit overflow)
+  SizeValueType ii = i, jj = j, kk = k;
+  SizeValueType out_idx = ii + (jj + kk * out_dim.y) * out_dim.x;
+  SizeValueType current_idx;
+  int           radius = 3;
 
   float eps = 1e-6;
 
@@ -87,7 +92,8 @@ fillHoles_3Dgrid(float * dev_vol_out, float * dev_accumulate_weights, int3 out_d
           if ((i + delta_i >= 0) && (i + delta_i < out_dim.x) && (j + delta_j >= 0) && (j + delta_j < out_dim.y) &&
               (k + delta_k >= 0) && (k + delta_k < out_dim.z))
           {
-            current_idx = i + delta_i + (j + delta_j + (k + delta_k) * out_dim.y) * (out_dim.x);
+            SizeValueType ni = i + delta_i, nj = j + delta_j, nk = k + delta_k;
+            current_idx = ni + (nj + nk * out_dim.y) * out_dim.x;
             sum += dev_vol_out[current_idx] * dev_accumulate_weights[current_idx];
             sum_weights += dev_accumulate_weights[current_idx];
           }
@@ -104,9 +110,9 @@ fillHoles_3Dgrid(float * dev_vol_out, float * dev_accumulate_weights, int3 out_d
 __global__ void
 normalize_3Dgrid(float * dev_vol_out, float * dev_accumulate_weights, int3 out_dim)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= out_dim.x || j >= out_dim.y || k >= out_dim.z)
   {
@@ -114,7 +120,7 @@ normalize_3Dgrid(float * dev_vol_out, float * dev_accumulate_weights, int3 out_d
   }
 
   // Index row major into the volume
-  long int out_idx = i + (j + k * out_dim.y) * (out_dim.x);
+  SizeValueType out_idx = i + (j + k * out_dim.y) * (out_dim.x);
 
   float eps = 1e-6;
 
@@ -134,9 +140,9 @@ linearSplat_3Dgrid(float *             dev_vol_in,
                    cudaTextureObject_t tex_ydvf,
                    cudaTextureObject_t tex_zdvf)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= in_dim.x || j >= in_dim.y || k >= in_dim.z)
   {
@@ -144,8 +150,8 @@ linearSplat_3Dgrid(float *             dev_vol_in,
   }
 
   // Index row major into the volume
-  float3   idx = make_float3(i, j, k);
-  long int in_idx = i + (j + k * in_dim.y) * (in_dim.x);
+  float3        idx = make_float3(i, j, k);
+  SizeValueType in_idx = i + (j + k * in_dim.y) * (in_dim.x);
 
   // Matrix multiply to get the index in the DVF texture of the current point in the output volume
   float3 IndexInDVF = matrix_multiply(idx, c_IndexInputToIndexDVFMatrix);
@@ -188,23 +194,17 @@ linearSplat_3Dgrid(float *             dev_vol_in,
   float weight110 = Distance.x * Distance.y * (1 - Distance.z);
   float weight111 = Distance.x * Distance.y * Distance.z;
 
-  // Compute indices in the volume
-  long int out_idx000 = (BaseIndexInOutput.x + 0) + (BaseIndexInOutput.y + 0) * out_dim.x +
-                        (BaseIndexInOutput.z + 0) * out_dim.x * out_dim.y;
-  long int out_idx001 = (BaseIndexInOutput.x + 0) + (BaseIndexInOutput.y + 0) * out_dim.x +
-                        (BaseIndexInOutput.z + 1) * out_dim.x * out_dim.y;
-  long int out_idx010 = (BaseIndexInOutput.x + 0) + (BaseIndexInOutput.y + 1) * out_dim.x +
-                        (BaseIndexInOutput.z + 0) * out_dim.x * out_dim.y;
-  long int out_idx011 = (BaseIndexInOutput.x + 0) + (BaseIndexInOutput.y + 1) * out_dim.x +
-                        (BaseIndexInOutput.z + 1) * out_dim.x * out_dim.y;
-  long int out_idx100 = (BaseIndexInOutput.x + 1) + (BaseIndexInOutput.y + 0) * out_dim.x +
-                        (BaseIndexInOutput.z + 0) * out_dim.x * out_dim.y;
-  long int out_idx101 = (BaseIndexInOutput.x + 1) + (BaseIndexInOutput.y + 0) * out_dim.x +
-                        (BaseIndexInOutput.z + 1) * out_dim.x * out_dim.y;
-  long int out_idx110 = (BaseIndexInOutput.x + 1) + (BaseIndexInOutput.y + 1) * out_dim.x +
-                        (BaseIndexInOutput.z + 0) * out_dim.x * out_dim.y;
-  long int out_idx111 = (BaseIndexInOutput.x + 1) + (BaseIndexInOutput.y + 1) * out_dim.x +
-                        (BaseIndexInOutput.z + 1) * out_dim.x * out_dim.y;
+  // Compute indices in the volume (64-bit to avoid 32-bit overflow of the products)
+  OffsetValueType bx0 = BaseIndexInOutput.x, by0 = BaseIndexInOutput.y, bz0 = BaseIndexInOutput.z;
+  OffsetValueType bx1 = bx0 + 1, by1 = by0 + 1, bz1 = bz0 + 1;
+  OffsetValueType out_idx000 = bx0 + by0 * out_dim.x + bz0 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx001 = bx0 + by0 * out_dim.x + bz1 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx010 = bx0 + by1 * out_dim.x + bz0 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx011 = bx0 + by1 * out_dim.x + bz1 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx100 = bx1 + by0 * out_dim.x + bz0 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx101 = bx1 + by0 * out_dim.x + bz1 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx110 = bx1 + by1 * out_dim.x + bz0 * out_dim.x * out_dim.y;
+  OffsetValueType out_idx111 = bx1 + by1 * out_dim.x + bz1 * out_dim.x * out_dim.y;
 
   // Determine whether they are indeed in the volume
   bool isInVolume_out_idx000 = (BaseIndexInOutput.x + 0 >= 0) && (BaseIndexInOutput.x + 0 < out_dim.x) &&
@@ -386,7 +386,8 @@ CUDA_ForwardWarp(int     input_vol_dim[3],
 
   ///////////////////////////////////////
   /// Initialize the output
-  size_t memorySizeOutput = sizeof(float) * output_vol_dim[0] * output_vol_dim[1] * output_vol_dim[2];
+  size_t memorySizeOutput =
+    sizeof(float) * static_cast<size_t>(output_vol_dim[0]) * output_vol_dim[1] * output_vol_dim[2];
   cudaMemset((void *)dev_output_vol, 0, memorySizeOutput);
 
   //////////////////////////////////////

--- a/src/rtkCudaInterpolateImageFilter.cu
+++ b/src/rtkCudaInterpolateImageFilter.cu
@@ -34,7 +34,7 @@ CUDA_interpolation(const int4 & inputSize, float * input, float * output, int pr
   cublasCreate(&handle);
 
   // CUDA device pointers
-  size_t nVoxelsOutput = inputSize.x * inputSize.y * inputSize.z;
+  size_t nVoxelsOutput = static_cast<size_t>(inputSize.x) * inputSize.y * inputSize.z;
   size_t memorySizeOutput = nVoxelsOutput * sizeof(float);
 
   // Reset output volume

--- a/src/rtkCudaLagCorrectionImageFilter.cu
+++ b/src/rtkCudaLagCorrectionImageFilter.cu
@@ -18,9 +18,13 @@
 
 #include "rtkCudaLagCorrectionImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
+#include <itkIntTypes.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <math_constants.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 __constant__ float cst_coef[9];
 
@@ -37,25 +41,23 @@ kernel_lag_correction(int3             proj_idx_in,
 {
   constexpr int modelOrder = 4;
 
-  // compute thread index
-  int3 tIdx;
-  tIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
-  tIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
-  tIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
-  long int tIdx_comp = tIdx.x + tIdx.y * proj_size_out.x + tIdx.z * proj_size_out_buf.x * proj_size_out_buf.y;
+  // compute thread index (64-bit to avoid 32-bit overflow of combined indices)
+  SizeValueType tIdx_x = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType tIdx_y = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType tIdx_z = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType tIdx_comp = tIdx_x + tIdx_y * proj_size_out.x + tIdx_z * proj_size_out_buf.x * proj_size_out_buf.y;
 
   // check if outside of projection grid
-  if (tIdx.x >= proj_size_out.x || tIdx.y >= proj_size_out.y || tIdx.z >= proj_size_out.z)
+  if (tIdx_x >= proj_size_out.x || tIdx_y >= proj_size_out.y || tIdx_z >= proj_size_out.z)
     return;
 
-  // compute projection index from thread index
-  int3 pIdx = make_int3(tIdx.x + proj_idx_out.x, tIdx.y + proj_idx_out.y, tIdx.z + proj_idx_out.z);
-  // combined proj. index -> use thread index in z because accessing memory only with this index
-  long int pIdx_comp = (pIdx.x - proj_idx_in.x) + (pIdx.y - proj_idx_in.y) * proj_size_in_buf.x +
-                       (pIdx.z - proj_idx_in.z) * proj_size_in_buf.x * proj_size_in_buf.y;
+  // combined projection index (arithmetic in 64-bit to avoid overflow of the products)
+  SizeValueType pIdx_comp = (tIdx_x - proj_idx_in.x + proj_idx_out.x) +
+                            (tIdx_y - proj_idx_in.y + proj_idx_out.y) * proj_size_in_buf.x +
+                            (tIdx_z - proj_idx_in.z + proj_idx_out.z) * proj_size_in_buf.x * proj_size_in_buf.y;
 
-  long int sIdx_comp = tIdx.x + tIdx.y * proj_size_out.x;
-  unsigned idx_s = sIdx_comp * modelOrder;
+  SizeValueType sIdx_comp = tIdx_x + tIdx_y * proj_size_out.x;
+  SizeValueType idx_s = sIdx_comp * modelOrder;
 
   float yk = static_cast<float>(dev_proj_in[pIdx_comp]);
   float xk = yk;

--- a/src/rtkCudaLaplacianImageFilter.cu
+++ b/src/rtkCudaLaplacianImageFilter.cu
@@ -33,7 +33,7 @@ CUDA_laplacian(int size[3], float spacing[3], float * dev_in, float * dev_out)
   float3 dev_Spacing = make_float3(spacing[0], spacing[1], spacing[2]);
 
   // Reset output volume
-  size_t memorySizeOutput = sizeof(float) * size[0] * size[1] * size[2];
+  size_t memorySizeOutput = sizeof(float) * static_cast<size_t>(size[0]) * size[1] * size[2];
   cudaMemset((void *)dev_out, 0, memorySizeOutput);
 
   // Initialize volumes to store the gradient components

--- a/src/rtkCudaLastDimensionTVDenoisingImageFilter.cu
+++ b/src/rtkCudaLastDimensionTVDenoisingImageFilter.cu
@@ -20,10 +20,13 @@
 #include "rtkCudaLastDimensionTVDenoisingImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 // TEXTURES AND CONSTANTS //
 
@@ -45,8 +48,9 @@ denoise_oneD_TV_kernel(float * in, float * out, float beta, float gamma, int nit
   float *                 gradient = &shared[3 * c_Size.w];
 
   // Each thread reads one element into the shared buffer
-  long int gindex = ((threadIdx.x * c_Size.z + blockIdx.z) * c_Size.y + blockIdx.y) * c_Size.x + blockIdx.x;
-  int      lindex = threadIdx.x;
+  SizeValueType tx = threadIdx.x;
+  SizeValueType gindex = ((tx * c_Size.z + blockIdx.z) * c_Size.y + blockIdx.y) * c_Size.x + blockIdx.x;
+  int           lindex = threadIdx.x;
   input[lindex] = in[gindex];
   __syncthreads();
 

--- a/src/rtkCudaParkerShortScanImageFilter.cu
+++ b/src/rtkCudaParkerShortScanImageFilter.cu
@@ -18,9 +18,13 @@
 
 #include "rtkCudaParkerShortScanImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
+#include <itkIntTypes.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <math_constants.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 inline __device__ float
 TransformIndexToPhysicalPoint(int2 idx, float origin, float row, float column)
@@ -57,26 +61,25 @@ kernel_parker_weight(int2                proj_idx,
                      cudaTextureObject_t tex_geom   // geometry texture object
 )
 {
-  // compute projection index (== thread index)
-  int3 pIdx;
-  pIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
-  pIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
-  pIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
-  long int pIdx_comp_in = pIdx.x + (pIdx.y + pIdx.z * proj_size_buf_in.y) * (proj_size_buf_in.x);
-  long int pIdx_comp_out = pIdx.x + (pIdx.y + pIdx.z * proj_size_buf_out.y) * (proj_size_buf_out.x);
+  // compute projection index (== thread index), 64-bit to avoid 32-bit overflow of combined indices
+  SizeValueType pIdx_x = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType pIdx_y = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType pIdx_z = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType pIdx_comp_in = pIdx_x + (pIdx_y + pIdx_z * proj_size_buf_in.y) * proj_size_buf_in.x;
+  SizeValueType pIdx_comp_out = pIdx_x + (pIdx_y + pIdx_z * proj_size_buf_out.y) * proj_size_buf_out.x;
 
   // check if outside of projection grid
-  if (pIdx.x >= proj_size.x || pIdx.y >= proj_size.y || pIdx.z >= proj_size.z)
+  if (pIdx_x >= proj_size.x || pIdx_y >= proj_size.y || pIdx_z >= proj_size.z)
     return;
 
-  float sdd = tex1Dfetch<float>(tex_geom, pIdx.z * 5 + 0);
-  float sx = tex1Dfetch<float>(tex_geom, pIdx.z * 5 + 1);
-  float px = tex1Dfetch<float>(tex_geom, pIdx.z * 5 + 2);
-  float sid = tex1Dfetch<float>(tex_geom, pIdx.z * 5 + 3);
+  float sdd = tex1Dfetch<float>(tex_geom, pIdx_z * 5 + 0);
+  float sx = tex1Dfetch<float>(tex_geom, pIdx_z * 5 + 1);
+  float px = tex1Dfetch<float>(tex_geom, pIdx_z * 5 + 2);
+  float sid = tex1Dfetch<float>(tex_geom, pIdx_z * 5 + 3);
 
   // convert actual index to point
   float pPoint =
-    TransformIndexToPhysicalPoint(make_int2(pIdx.x + proj_idx.x, pIdx.y + proj_idx.y), proj_orig, proj_row, proj_col);
+    TransformIndexToPhysicalPoint(make_int2(pIdx_x + proj_idx.x, pIdx_y + proj_idx.y), proj_orig, proj_row, proj_col);
 
   // alpha projection angle
   float hyp = sqrtf(sid * sid + sx * sx); // to untilted situation
@@ -85,7 +88,7 @@ kernel_parker_weight(int2                proj_idx,
   float alpha = atan(-1 * l * invsid);
 
   // beta projection angle: Parker's article assumes that the scan starts at 0
-  float beta = tex1Dfetch<float>(tex_geom, pIdx.z * 5 + 4);
+  float beta = tex1Dfetch<float>(tex_geom, pIdx_z * 5 + 4);
   beta -= firstAngle;
   if (beta < 0)
     beta += (2.f * CUDART_PI_F);

--- a/src/rtkCudaPolynomialGainCorrectionImageFilter.cu
+++ b/src/rtkCudaPolynomialGainCorrectionImageFilter.cu
@@ -18,9 +18,13 @@
 
 #include "rtkCudaPolynomialGainCorrectionImageFilter.hcu"
 #include "rtkCudaUtilities.hcu"
+#include <itkIntTypes.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <math_constants.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 __constant__ float cst_coef[2];
 
@@ -37,39 +41,37 @@ kernel_gain_correction(int3             proj_idx_in,
                        float *          dev_gain_in,
                        float *          powerlut)
 {
-  // compute thread index
-  int3 tIdx;
-  tIdx.x = blockIdx.x * blockDim.x + threadIdx.x;
-  tIdx.y = blockIdx.y * blockDim.y + threadIdx.y;
-  tIdx.z = blockIdx.z * blockDim.z + threadIdx.z;
-  long int tIdx_comp = tIdx.x + tIdx.y * proj_size_out.x + tIdx.z * proj_size_out_buf.x * proj_size_out_buf.y;
+  // compute thread index (64-bit to avoid 32-bit overflow of combined indices)
+  SizeValueType tIdx_x = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType tIdx_y = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType tIdx_z = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType tIdx_comp = tIdx_x + tIdx_y * proj_size_out.x + tIdx_z * proj_size_out_buf.x * proj_size_out_buf.y;
 
   // check if outside of projection grid
-  if (tIdx.x >= proj_size_out.x || tIdx.y >= proj_size_out.y || tIdx.z >= proj_size_out.z)
+  if (tIdx_x >= proj_size_out.x || tIdx_y >= proj_size_out.y || tIdx_z >= proj_size_out.z)
     return;
 
-  // compute projection index from thread index
-  int3 pIdx = make_int3(tIdx.x + proj_idx_out.x, tIdx.y + proj_idx_out.y, tIdx.z + proj_idx_out.z);
-  // combined proj. index -> use thread index in z because accessing memory only with this index
-  long int pIdx_comp = (pIdx.x - proj_idx_in.x) + (pIdx.y - proj_idx_in.y) * proj_size_in_buf.x +
-                       (pIdx.z - proj_idx_in.z) * proj_size_in_buf.x * proj_size_in_buf.y;
+  // combined projection index (arithmetic in 64-bit to avoid overflow of the products)
+  SizeValueType pIdx_comp = (tIdx_x - proj_idx_in.x + proj_idx_out.x) +
+                            (tIdx_y - proj_idx_in.y + proj_idx_out.y) * proj_size_in_buf.x +
+                            (tIdx_z - proj_idx_in.z + proj_idx_out.z) * proj_size_in_buf.x * proj_size_in_buf.y;
 
   int modelOrder = static_cast<float>(cst_coef[0]);
 
-  long int sIdx_comp = tIdx.x + tIdx.y * proj_size_out.x; // in-slice index
+  SizeValueType sIdx_comp = tIdx_x + tIdx_y * proj_size_out.x; // in-slice index
 
   // Correct for dark field
   unsigned short xk = 0;
   if (dev_proj_in[pIdx_comp] > dev_dark_in[sIdx_comp])
     xk = dev_proj_in[pIdx_comp] - dev_dark_in[sIdx_comp];
 
-  float yk = 0.f;
-  int   lutidx = xk * modelOrder; // index to powerlut
-  int   projsize = proj_size_in.x * proj_size_in.y;
+  float         yk = 0.f;
+  SizeValueType lutidx = static_cast<SizeValueType>(xk) * modelOrder; // index to powerlut
+  SizeValueType projsize = static_cast<SizeValueType>(proj_size_in.x) * proj_size_in.y;
   for (int n = 0; n < modelOrder; n++)
   {
-    int   gainidx = n * projsize + sIdx_comp;
-    float gainM = dev_gain_in[gainidx];
+    SizeValueType gainidx = n * projsize + sIdx_comp;
+    float         gainM = dev_gain_in[gainidx];
     yk += gainM * powerlut[lutidx + n];
   }
 

--- a/src/rtkCudaRayCastBackProjectionImageFilter.cu
+++ b/src/rtkCudaRayCastBackProjectionImageFilter.cu
@@ -37,6 +37,9 @@
  *****************/
 #include <cuda.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // TEXTURES AND CONSTANTS //
 
 __constant__ int3   c_projSize;
@@ -55,10 +58,10 @@ __constant__ float c_sourcePos[SLAB_SIZE * 3];         // Can process stacks of 
 __global__ void
 kernel_ray_cast_back_project(float * dev_vol_out, float * dev_proj)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int numThread = j * c_projSize.x + i;
-  unsigned int proj = blockIdx.z * blockDim.z + threadIdx.z;
+  unsigned int  i = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int  j = blockIdx.y * blockDim.y + threadIdx.y;
+  unsigned int  numThread = j * c_projSize.x + i;
+  SizeValueType proj = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_projSize.x || j >= c_projSize.y || proj >= c_projSize.z)
     return;
@@ -100,10 +103,10 @@ kernel_ray_cast_back_project(float * dev_vol_out, float * dev_proj)
     float  mmStep = vStep * dirLengthInMM;
 
     // Skip rays intersecting less half a step
-    float    toSplat;
-    long int indices[8];
-    float    weights[8];
-    int3     floor_pos;
+    float         toSplat;
+    SizeValueType indices[8];
+    float         weights[8];
+    int3          floor_pos;
 
     // First position in the box
     float halfVStep = 0.5f * vStep;
@@ -144,18 +147,27 @@ kernel_ray_cast_back_project(float * dev_vol_out, float * dev_proj)
       pos_high.y = min(floor_pos.y + 1, c_volSize.y - 1);
       pos_high.z = min(floor_pos.z + 1, c_volSize.z - 1);
 
-      // Compute indices in the volume
-      indices[0] = pos_low.x + pos_low.y * c_volSize.x + pos_low.z * c_volSize.x * c_volSize.y;    // index000
-      indices[1] = pos_low.x + pos_low.y * c_volSize.x + pos_high.z * c_volSize.x * c_volSize.y;   // index001
-      indices[2] = pos_low.x + pos_high.y * c_volSize.x + pos_low.z * c_volSize.x * c_volSize.y;   // index010
-      indices[3] = pos_low.x + pos_high.y * c_volSize.x + pos_high.z * c_volSize.x * c_volSize.y;  // index011
-      indices[4] = pos_high.x + pos_low.y * c_volSize.x + pos_low.z * c_volSize.x * c_volSize.y;   // index100
-      indices[5] = pos_high.x + pos_low.y * c_volSize.x + pos_high.z * c_volSize.x * c_volSize.y;  // index101
-      indices[6] = pos_high.x + pos_high.y * c_volSize.x + pos_low.z * c_volSize.x * c_volSize.y;  // index110
-      indices[7] = pos_high.x + pos_high.y * c_volSize.x + pos_high.z * c_volSize.x * c_volSize.y; // index111
+      // Compute indices in the volume (using 64-bit arithmetic to avoid overflow on large volumes)
+      const SizeValueType volSize_X = c_volSize.x;
+      const SizeValueType volSize_XY = volSize_X * c_volSize.y;
+      const SizeValueType pxl = pos_low.x;
+      const SizeValueType pxh = pos_high.x;
+      const SizeValueType pyl = pos_low.y;
+      const SizeValueType pyh = pos_high.y;
+      const SizeValueType pzl = pos_low.z;
+      const SizeValueType pzh = pos_high.z;
+      indices[0] = pxl + pyl * volSize_X + pzl * volSize_XY; // index000
+      indices[1] = pxl + pyl * volSize_X + pzh * volSize_XY; // index001
+      indices[2] = pxl + pyh * volSize_X + pzl * volSize_XY; // index010
+      indices[3] = pxl + pyh * volSize_X + pzh * volSize_XY; // index011
+      indices[4] = pxh + pyl * volSize_X + pzl * volSize_XY; // index100
+      indices[5] = pxh + pyl * volSize_X + pzh * volSize_XY; // index101
+      indices[6] = pxh + pyh * volSize_X + pzl * volSize_XY; // index110
+      indices[7] = pxh + pyh * volSize_X + pzh * volSize_XY; // index111
 
       // Compute the value to be splatted
-      toSplat = dev_proj[numThread + proj * c_projSize.x * c_projSize.y] * mmStep;
+      SizeValueType projOffset = numThread + proj * c_projSize.x * c_projSize.y;
+      toSplat = dev_proj[projOffset] * mmStep;
       atomicAdd(&dev_vol_out[indices[0]], toSplat * weights[0]);
       atomicAdd(&dev_vol_out[indices[1]], toSplat * weights[1]);
       atomicAdd(&dev_vol_out[indices[2]], toSplat * weights[2]);
@@ -170,7 +182,8 @@ kernel_ray_cast_back_project(float * dev_vol_out, float * dev_proj)
     }
 
     // Last position
-    toSplat = dev_proj[numThread + proj * c_projSize.x * c_projSize.y] * (tfar - t + halfVStep) * dirLengthInMM;
+    SizeValueType projOffsetLast = numThread + proj * c_projSize.x * c_projSize.y;
+    toSplat = dev_proj[projOffsetLast] * (tfar - t + halfVStep) * dirLengthInMM;
     atomicAdd(&dev_vol_out[indices[0]], toSplat * weights[0]);
     atomicAdd(&dev_vol_out[indices[1]], toSplat * weights[1]);
     atomicAdd(&dev_vol_out[indices[2]], toSplat * weights[2]);

--- a/src/rtkCudaRayCastBackProjectionImageFilter.cxx
+++ b/src/rtkCudaRayCastBackProjectionImageFilter.cxx
@@ -25,6 +25,10 @@
 #include <itkLinearInterpolateImageFunction.h>
 #include <itkMacro.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
+
 namespace rtk
 {
 
@@ -45,7 +49,7 @@ CudaRayCastBackProjectionImageFilter ::GPUGenerateData()
   constexpr unsigned int Dimension = 3;
   const unsigned int     iFirstProj = this->GetInput(1)->GetRequestedRegion().GetIndex(Dimension - 1);
   const unsigned int     nProj = this->GetInput(1)->GetRequestedRegion().GetSize(Dimension - 1);
-  const unsigned int     nPixelsPerProj =
+  const SizeValueType    nPixelsPerProj =
     this->GetInput(1)->GetBufferedRegion().GetSize(0) * this->GetInput(1)->GetBufferedRegion().GetSize(1);
 
   itk::Vector<double, 4> source_position;
@@ -155,7 +159,7 @@ CudaRayCastBackProjectionImageFilter ::GPUGenerateData()
       source_positions[(iProj - iFirstProj) * 3 + d] = source_position[d]; // Ignore the 4th component
   }
 
-  int projectionOffset = 0;
+  OffsetValueType projectionOffset = 0;
   for (unsigned int i = 0; i < nProj; i += SLAB_SIZE)
   {
     // If nProj is not a multiple of SLAB_SIZE, the last slab will contain less than SLAB_SIZE projections

--- a/src/rtkCudaSplatImageFilter.cu
+++ b/src/rtkCudaSplatImageFilter.cu
@@ -33,7 +33,7 @@ CUDA_splat(const int4 & outputSize, float * input, float * output, int projectio
   cublasHandle_t handle;
   cublasCreate(&handle);
 
-  size_t numel = outputSize.x * outputSize.y * outputSize.z;
+  size_t numel = static_cast<size_t>(outputSize.x) * outputSize.y * outputSize.z;
 
   for (int phase = 0; phase < outputSize.w; phase++)
   {

--- a/src/rtkCudaTotalVariationDenoisingBPDQImageFilter.cu
+++ b/src/rtkCudaTotalVariationDenoisingBPDQImageFilter.cu
@@ -21,10 +21,13 @@
 #include "rtkCudaFirstOrderKernels.hcu"
 #include "rtkCudaUtilities.hcu"
 
-#include <itkMacro.h>
+#include <itkIntTypes.h>
 
 // cuda includes
 #include <cuda.h>
+
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
 
 // TEXTURES AND CONSTANTS //
 
@@ -38,14 +41,14 @@ __constant__ float3 c_Spacing;
 __global__ void
 magnitude_threshold_kernel(float * grad_x, float * grad_y, float * grad_z, float gamma)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
 
   float norm = sqrt(grad_x[id] * grad_x[id] + grad_y[id] * grad_y[id] + grad_z[id] * grad_z[id]);
   if (norm > gamma)
@@ -60,17 +63,17 @@ magnitude_threshold_kernel(float * grad_x, float * grad_y, float * grad_z, float
 __global__ void
 gradient_and_subtract_kernel(float * in, float * grad_x, float * grad_y, float * grad_z)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
-  long int id_x = (k * c_Size.y + j) * c_Size.x + i + 1;
-  long int id_y = (k * c_Size.y + j + 1) * c_Size.x + i;
-  long int id_z = ((k + 1) * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id_x = (k * c_Size.y + j) * c_Size.x + i + 1;
+  SizeValueType id_y = (k * c_Size.y + j + 1) * c_Size.x + i;
+  SizeValueType id_z = ((k + 1) * c_Size.y + j) * c_Size.x + i;
 
   if (i != (c_Size.x - 1))
     grad_x[id] -= ((in[id_x] - in[id]) / c_Spacing.x);
@@ -83,14 +86,14 @@ gradient_and_subtract_kernel(float * in, float * grad_x, float * grad_y, float *
 __global__ void
 multiply_by_beta_kernel(float * input, float * output, float beta)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
 
   output[id] = input[id] * beta;
 }
@@ -98,14 +101,14 @@ multiply_by_beta_kernel(float * input, float * output, float beta)
 __global__ void
 subtract_kernel(float * in1, float * in2, float * out)
 {
-  unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int k = blockIdx.z * blockDim.z + threadIdx.z;
+  SizeValueType i = blockIdx.x * blockDim.x + threadIdx.x;
+  SizeValueType j = blockIdx.y * blockDim.y + threadIdx.y;
+  SizeValueType k = blockIdx.z * blockDim.z + threadIdx.z;
 
   if (i >= c_Size.x || j >= c_Size.y || k >= c_Size.z)
     return;
 
-  long int id = (k * c_Size.y + j) * c_Size.x + i;
+  SizeValueType id = (k * c_Size.y + j) * c_Size.x + i;
 
   out[id] = in1[id] - in2[id];
 }
@@ -138,7 +141,7 @@ CUDA_total_variation(int     size[3],
     minSpacing = spacing[2];
 
   // Reset output volume
-  size_t memorySizeOutput = sizeof(float) * size[0] * size[1] * size[2];
+  size_t memorySizeOutput = sizeof(float) * static_cast<size_t>(size[0]) * size[1] * size[2];
   cudaMemset((void *)dev_out, 0, memorySizeOutput);
 
   // Initialize volume to store intermediate images

--- a/src/rtkCudaUtilities.cu
+++ b/src/rtkCudaUtilities.cu
@@ -166,7 +166,7 @@ prepareVectorTextureObject(int                                size[3],
 
   // Allocate an intermediate memory space to extract the components of the input volume
   float * singleComponent;
-  size_t  numel = size[0] * size[1] * size[2];
+  size_t  numel = static_cast<size_t>(size[0]) * size[1] * size[2];
   if (nComponents > 1)
   {
     cudaMalloc(&singleComponent, numel * sizeof(float));

--- a/src/rtkCudaWarpBackProjectionImageFilter.cu
+++ b/src/rtkCudaWarpBackProjectionImageFilter.cu
@@ -40,6 +40,9 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // CONSTANTS //////////////////////////////////////////////////////////////
 __constant__ float c_matrices[SLAB_SIZE * 12]; // Can process stacks of at most SLAB_SIZE projections
 __constant__ float c_volIndexToProjPP[SLAB_SIZE * 12];
@@ -64,9 +67,9 @@ kernel_warp_back_project_3Dgrid(float *             dev_vol_in,
                                 cudaTextureObject_t tex_zdvf,
                                 cudaTextureObject_t tex_proj)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= c_volSize.x || j >= c_volSize.y || k >= c_volSize.z)
   {
@@ -74,7 +77,7 @@ kernel_warp_back_project_3Dgrid(float *             dev_vol_in,
   }
 
   // Index row major into the volume
-  long int vol_idx = i + (j + k * c_volSize.y) * (c_volSize.x);
+  SizeValueType vol_idx = i + (j + k * c_volSize.y) * c_volSize.x;
 
   float3 IndexInDVF, Displacement, PP, IndexInInput, ip;
   float  voxel_data = 0;
@@ -120,9 +123,9 @@ kernel_warp_back_project_3Dgrid_cylindrical_detector(float *             dev_vol
                                                      cudaTextureObject_t tex_zdvf,
                                                      cudaTextureObject_t tex_proj)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= c_volSize.x || j >= c_volSize.y || k >= c_volSize.z)
   {
@@ -130,7 +133,7 @@ kernel_warp_back_project_3Dgrid_cylindrical_detector(float *             dev_vol
   }
 
   // Index row major into the volume
-  long int vol_idx = i + (j + k * c_volSize.y) * (c_volSize.x);
+  SizeValueType vol_idx = i + (j + k * c_volSize.y) * c_volSize.x;
 
   float3 IndexInDVF, Displacement, PP, IndexInInput, ip, pp;
   float  voxel_data = 0;

--- a/src/rtkCudaWarpForwardProjectionImageFilter.cu
+++ b/src/rtkCudaWarpForwardProjectionImageFilter.cu
@@ -38,6 +38,9 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // CONSTANTS
 __constant__ int3   c_projSize;
 __constant__ float3 c_boxMin;
@@ -78,7 +81,7 @@ kernel_warped_forwardProject(float *             dev_proj_in,
   float3 pixelPos;
   float  tnear, tfar;
 
-  for (unsigned int proj = 0; proj < c_projSize.z; proj++)
+  for (SizeValueType proj = 0; proj < c_projSize.z; proj++)
   {
     // Setting ray origin
     ray.o = make_float3(c_sourcePos[3 * proj], c_sourcePos[3 * proj + 1], c_sourcePos[3 * proj + 2]);
@@ -91,8 +94,8 @@ kernel_warped_forwardProject(float *             dev_proj_in,
     // Detect intersection with box
     if (!intersectBox(ray, &tnear, &tfar, c_boxMin, c_boxMax) || tfar < 0.f)
     {
-      dev_proj_out[numThread + proj * c_projSize.x * c_projSize.y] =
-        dev_proj_in[numThread + proj * c_projSize.x * c_projSize.y];
+      SizeValueType projOffset = numThread + proj * c_projSize.x * c_projSize.y;
+      dev_proj_out[projOffset] = dev_proj_in[projOffset];
     }
     else
     {
@@ -139,9 +142,8 @@ kernel_warped_forwardProject(float *             dev_proj_in,
         sum += sample;
         pos += step;
       }
-      dev_proj_out[numThread + proj * c_projSize.x * c_projSize.y] =
-        dev_proj_in[numThread + proj * c_projSize.x * c_projSize.y] +
-        (sum + (tfar - t + halfVStep) / vStep * sample) * c_tStep;
+      SizeValueType projOffset = numThread + proj * c_projSize.x * c_projSize.y;
+      dev_proj_out[projOffset] = dev_proj_in[projOffset] + (sum + (tfar - t + halfVStep) / vStep * sample) * c_tStep;
     }
   }
 }

--- a/src/rtkCudaWarpForwardProjectionImageFilter.cxx
+++ b/src/rtkCudaWarpForwardProjectionImageFilter.cxx
@@ -30,6 +30,10 @@
 #include <itkLinearInterpolateImageFunction.h>
 #include <itkMacro.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
+
 namespace rtk
 {
 
@@ -145,9 +149,9 @@ CudaWarpForwardProjectionImageFilter ::GPUGenerateData()
 
   const Superclass::GeometryType * geometry = this->GetGeometry();
   const unsigned int               Dimension = InputImageType::ImageDimension;
-  const unsigned int iFirstProj = this->GetInputProjectionStack()->GetRequestedRegion().GetIndex(Dimension - 1);
-  const unsigned int nProj = this->GetInputProjectionStack()->GetRequestedRegion().GetSize(Dimension - 1);
-  const unsigned int nPixelsPerProj =
+  const unsigned int  iFirstProj = this->GetInputProjectionStack()->GetRequestedRegion().GetIndex(Dimension - 1);
+  const unsigned int  nProj = this->GetInputProjectionStack()->GetRequestedRegion().GetSize(Dimension - 1);
+  const SizeValueType nPixelsPerProj =
     this->GetOutput()->GetBufferedRegion().GetSize(0) * this->GetOutput()->GetBufferedRegion().GetSize(1);
 
   itk::Vector<double, 4> source_position;
@@ -254,7 +258,7 @@ CudaWarpForwardProjectionImageFilter ::GPUGenerateData()
       source_positions[(iProj - iFirstProj) * 3 + d] = source_position[d]; // Ignore the 4th component
   }
 
-  int projectionOffset = 0;
+  OffsetValueType projectionOffset = 0;
   for (unsigned int i = 0; i < nProj; i += SLAB_SIZE)
   {
     // If nProj is not a multiple of SLAB_SIZE, the last slab will contain less than SLAB_SIZE projections

--- a/src/rtkCudaWarpImageFilter.cu
+++ b/src/rtkCudaWarpImageFilter.cu
@@ -39,6 +39,9 @@
  *****************/
 #include <cuda.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+
 // CONSTANTS //////////////////////////////////////////////////////////////
 __constant__ float c_IndexOutputToPPOutputMatrix[12];
 __constant__ float c_IndexOutputToIndexDVFMatrix[12];
@@ -58,9 +61,9 @@ kernel_3Dgrid(float *             dev_vol_out,
               cudaTextureObject_t tex_zdvf,
               cudaTextureObject_t tex_input_vol)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= vol_dim.x || j >= vol_dim.y || k >= vol_dim.z)
   {
@@ -68,7 +71,7 @@ kernel_3Dgrid(float *             dev_vol_out,
   }
 
   // Index row major into the volume
-  long int vol_idx = i + (j + k * vol_dim.y) * (vol_dim.x);
+  SizeValueType vol_idx = i + (j + k * vol_dim.y) * vol_dim.x;
 
   // Matrix multiply to get the index in the DVF texture of the current point in the output volume
   float3 IndexInDVF = matrix_multiply(make_float3(i, j, k), c_IndexOutputToIndexDVFMatrix);

--- a/src/rtkCudaWeidingerForwardModelImageFilter.cu
+++ b/src/rtkCudaWeidingerForwardModelImageFilter.cu
@@ -40,6 +40,10 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
+// System-adaptive buffer index types (ITK)
+using SizeValueType = itk::SizeValueType;
+using OffsetValueType = itk::OffsetValueType;
+
 #define IDX2D(r, c, cols) ((r) * (cols) + (c))
 
 // CONSTANTS //////////////////////////////////////////////////////////////
@@ -64,9 +68,9 @@ kernel_forward_model(float *      pMatProj,
                      unsigned int nProjSpectrum,
                      int          nIdxProj)
 {
-  unsigned int i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
-  unsigned int j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
-  unsigned int k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
+  SizeValueType i = __umul24(blockIdx.x, blockDim.x) + threadIdx.x;
+  SizeValueType j = __umul24(blockIdx.y, blockDim.y) + threadIdx.y;
+  SizeValueType k = __umul24(blockIdx.z, blockDim.z) + threadIdx.z;
 
   if (i >= c_projSize.x || j >= c_projSize.y || k >= c_projSize.z)
   {
@@ -74,9 +78,9 @@ kernel_forward_model(float *      pMatProj,
   }
 
   // Index row major in the projection
-  long int first_proj_idx =
-    i + (j + (nIdxProj + k) % nProjSpectrum * c_projSize.y) * c_projSize.x; // To determine the efficient spectrum
-  long int proj_idx = i + (j + k * c_projSize.y) * (c_projSize.x);          // For all the rest
+  OffsetValueType first_proj_idx =
+    i + (j + ((nIdxProj + k) % nProjSpectrum) * c_projSize.y) * c_projSize.x; // To determine the efficient spectrum
+  SizeValueType proj_idx = i + (j + k * c_projSize.y) * c_projSize.x;         // For all the rest
 
   // Compute the efficient spectrum at the current pixel
   float efficientSpectrum[VBins * VEnergies];


### PR DESCRIPTION
Use 64-bit types for pointer offsets and element counts in the CUDA filters so that reconstructions on large projection stacks or volumes do not overflowing signed 32-bit arithmetic (which caused illegal memory access / segmentation faults).