### PR TITLE
STYLE: Remove unused displaced detector filter from rtkadmmwavelets

### DIFF
--- a/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
+++ b/applications/rtkadmmwavelets/rtkadmmwavelets.cxx
@@ -25,7 +25,6 @@
 
 #include "rtkADMMWaveletsConeBeamReconstructionFilter.h"
 #include "rtkConstantImageSource.h"
-#include "rtkDisplacedDetectorImageFilter.h"
 #include "rtkProjectionsReader.h"
 #include "rtkThreeDCircularProjectionGeometryXMLFile.h"
 
@@ -57,11 +56,6 @@ main(int argc, char * argv[])
     std::cout << "Reading geometry information from " << args_info.geometry_arg << "..." << std::endl;
   rtk::ThreeDCircularProjectionGeometry::Pointer geometry;
   TRY_AND_EXIT_ON_ITK_EXCEPTION(geometry = rtk::ReadGeometry(args_info.geometry_arg));
-
-  // Displaced detector weighting
-  auto ddf = rtk::DisplacedDetectorImageFilter<OutputImageType>::New();
-  ddf->SetInput(projectionsReader->GetOutput());
-  ddf->SetGeometry(geometry);
 
   // Create input: either an existing volume read from a file or a blank image
   itk::ImageSource<OutputImageType>::Pointer inputFilter;


### PR DESCRIPTION
## Summary

- Remove the unused `DisplacedDetectorImageFilter` instance from the C++ `rtkadmmwavelets` application.
- Remove the corresponding unused header include.

The filter instance was created but never connected to the processing pipeline. Displaced detector handling remains managed internally by `ADMMWaveletsConeBeamReconstructionFilter`.

## Testing

- `git diff --check` passes.
- Not built locally because an ITK C++ build tree is not available.
- Existing C++ build and ADMM wavelets tests will run in CI.

Closes #751