### PR TITLE
ENH: Update GitHub Actions to fix Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/build-test-cxx-cuda.yml
+++ b/.github/workflows/build-test-cxx-cuda.yml
@@ -28,7 +28,7 @@ jobs:
             cmake-build-type: "Release"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/build-test-package-python-cuda.yml
+++ b/.github/workflows/build-test-package-python-cuda.yml
@@ -28,7 +28,7 @@ jobs:
             cuda-version: "130"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: 'Fetch build script'
       run: |
@@ -106,7 +106,7 @@ jobs:
         python -m twine check ${WHEEL_PATTERN}
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: LinuxWheel3${{ matrix.python3-minor-version }}${{ matrix.manylinux-platform }}-cuda${{ matrix.cuda-version }}
         path: dist/*.whl
@@ -120,7 +120,7 @@ jobs:
         cuda-version: ${{ github.event_name == 'pull_request' && fromJSON('["128"]') || fromJSON('["128","130"]') }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         path: "im"
 
@@ -197,7 +197,7 @@ jobs:
         python -m twine check ${WHEEL_PATTERN}
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: WindowsWheel3${{ matrix.python3-minor-version }}-cuda${{ matrix.cuda-version }}
         path: dist/*.whl
@@ -210,7 +210,7 @@ jobs:
 
     steps:
     - name: Download Python Packages
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
 
     - name: Prepare packages for upload
       run: |
@@ -245,15 +245,15 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download all wheel artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         path: wheels
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -33,15 +33,15 @@ jobs:
             wheel-pattern: "*cp311*macosx_*.whl"
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Download all wheel artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         path: wheels
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,10 +6,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 


### PR DESCRIPTION
The Node.js 20 actions are deprecated and will be forced to run on Node.js 24 by default. Update the actions to versions that target Node.js 24, following the ITK fix (InsightSoftwareConsortium/ITK@74ae5e0):
- actions/checkout@v4 -> v5
- actions/setup-python@v4 -> v6
- actions/upload-artifact@v4 -> v6
- actions/download-artifact@v4 -> v6

Fix #988 