### PR TITLE
DOC: Make SVG diagrams visible in dark mode

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,14 @@
+/* Invert SVG diagrams with transparent backgrounds in dark mode,
+   so black lines become visible on the dark page background. */
+
+/* When user explicitly selects dark mode in the Furo theme toggle */
+body[data-theme="dark"] img[src$=".svg"] {
+  filter: invert(1);
+}
+
+/* When Furo auto mode follows OS dark preference */
+@media (prefers-color-scheme: dark) {
+  body[data-theme="auto"] img[src$=".svg"] {
+    filter: invert(1);
+  }
+}

--- a/conf.py
+++ b/conf.py
@@ -74,7 +74,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets or icons)
 # here, relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_logo = "https://www.openrtk.org/opensourcelogos/rtk75.png"
 html_title = f"{project}'s documentation"
 html_favicon = "https://www.openrtk.org/RTK/img/rtk_favicon.ico"

--- a/documentation/docs/copy_and_fetch_sphinx_doc_files.cmake
+++ b/documentation/docs/copy_and_fetch_sphinx_doc_files.cmake
@@ -15,6 +15,7 @@ set(
   "examples"
   "applications"
   "documentation"
+  "_static"
 )
 
 # List of files to grab from CudaCommon


### PR DESCRIPTION
Add custom CSS that inverts SVG images when the Furo theme's dark mode is active (both explicit toggle and OS auto preference), so the black-on- transparent geometry diagrams remain visible on a dark background.

Register the new _static directory in conf.py and include it in the list of copied sources so it is not cleaned up during the Sphinx doc build.

Fix #909 
 
The PR https://gitlab.in2p3.fr/simon.rit/rtk-website/-/merge_requests/3 must be merged to avoid conflict before merging this one 