### PR TITLE
BUG: Fix black frames with --cudacg and spatial TV 

### DIFF
--- a/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
+++ b/include/rtkTotalVariationDenoiseSequenceImageFilter.hxx
@@ -124,18 +124,18 @@ TotalVariationDenoiseSequenceImageFilter<TImageSequence>::GenerateData()
 {
   int Dimension = TImageSequence::ImageDimension;
 
-  // Declare an image pointer to disconnect the output of paste
-  typename TImageSequence::Pointer pimg;
+  // Accumulate all frames in place into a single, freshly allocated buffer so
+  // that the accumulator never aliases an upstream buffer.
+  typename TImageSequence::Pointer pimg = TImageSequence::New();
+  pimg->CopyInformation(this->GetOutput());
+  pimg->SetRegions(this->GetOutput()->GetLargestPossibleRegion());
+  pimg->Allocate();
+  pimg->FillBuffer(0);
+  m_PasteFilter->SetInPlace(true);
+  m_PasteFilter->SetDestinationImage(pimg);
 
   for (unsigned int frame = 0; frame < this->GetInput(0)->GetLargestPossibleRegion().GetSize(Dimension - 1); frame++)
   {
-    if (frame > 0) // After the first frame, use the output of paste as input
-    {
-      pimg = m_PasteFilter->GetOutput();
-      pimg->DisconnectPipeline();
-      m_PasteFilter->SetDestinationImage(pimg);
-    }
-
     m_ExtractAndPasteRegion.SetIndex(Dimension - 1, frame);
 
     m_ExtractFilter->SetExtractionRegion(m_ExtractAndPasteRegion);

--- a/test/rtkfourdroostertest.cxx
+++ b/test/rtkfourdroostertest.cxx
@@ -401,6 +401,31 @@ rtkfourdroostertest(int, char *[])
 
   CheckImageQuality<VolumeSeriesType>(rooster->GetOutput(), join->GetOutput(), 0.25, 15, 2.0);
   std::cout << "\n\nTest PASSED! " << std::endl;
+
+  std::cout << "\n\n****** Case 5: CUDA forward and back projectors, CUDA conjugate gradient, "
+               "spatial TV denoising (regression test for black frames) ******"
+            << std::endl;
+
+  rooster->SetBackProjectionFilter(ROOSTERFilterType::BP_CUDAVOXELBASED); // Cuda voxel based
+  rooster->SetForwardProjectionFilter(ROOSTERFilterType::FP_CUDARAYCAST); // Cuda ray cast
+
+  rooster->SetPerformPositivity(false);
+  rooster->SetPerformMotionMask(false);
+  rooster->SetPerformTVSpatialDenoising(true);
+  rooster->SetPerformWaveletsSpatialDenoising(false);
+  rooster->SetPerformTVTemporalDenoising(false);
+  rooster->SetPerformL0TemporalDenoising(false);
+  rooster->SetPerformWarping(false);
+  rooster->SetComputeInverseWarpingByConjugateGradient(false);
+  rooster->SetUseNearestNeighborInterpolationInWarping(false);
+
+  // With --cudacg and spatial TV, every frame but the first used to come out
+  // black (all zeros). The spatial TV produces a slightly different result than
+  // other regularization modes, so use a looser tolerance here.
+  rooster->SetCudaConjugateGradient(true);
+  TRY_AND_EXIT_ON_ITK_EXCEPTION(rooster->Update());
+  CheckImageQuality<VolumeSeriesType>(rooster->GetOutput(), join->GetOutput(), 0.3, 14, 2.0);
+  std::cout << "\n\nTest PASSED! " << std::endl;
 #endif
 
   itksys::SystemTools::RemoveFile(signalFileName);


### PR DESCRIPTION
Fixes #888 .

The total variation denoise sequence filter reused the paste output as the
destination for every frame following the first. On the ROOSTER main loop
iterations, that accumulator could alias the fed-back CG volume through the
CUDA buffer pool, so downstream spatial TV zeroed every frame but the first.

Accumulate all frames in place into a single, freshly allocated destination
buffer, which can never alias an upstream buffer.